### PR TITLE
Addition of a max_age param to caches.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -278,6 +278,27 @@ See :ref:`using_existing_caches` for more information.
 
 .. _mixed_image_format:
 
+``max_age``
+""""""""""
+Sets the maximum age of a cached tile.
+
+Examples::
+
+  # absolute as ISO time
+  max_age:
+    time: 2010-10-21T12:35:00
+
+  # relative from the modified date of the tile
+  max_age:
+    weeks: 1
+    days: 7
+    hours: 4
+    minutes: 15
+
+  # modification time of a given file - useful to hook up to the source file so the cache is always up to date
+  refresh_before:
+    mtime: path/to/file
+
 ``format``
 """"""""""
 

--- a/mapproxy/cache/base.py
+++ b/mapproxy/cache/base.py
@@ -21,6 +21,9 @@ from contextlib import contextmanager
 
 from mapproxy.util.lock import FileLock, cleanup_lockdir, DummyLock
 
+import logging
+log = logging.getLogger(__name__)
+
 class CacheBackendError(Exception):
     pass
 
@@ -112,6 +115,11 @@ class FileBasedLocking(object):
         if getattr(self, 'locking_disabled', False):
             return DummyLock()
         lock_filename = self.lock_filename(tile)
-        cleanup_lockdir(self.lock_dir, force=False)
+
+        try:
+            cleanup_lockdir(self.lock_dir, force=False)
+        except WindowsError, ex:
+            log.warn("WindowsError: %s", ex)
+
         return FileLock(lock_filename, timeout=self.lock_timeout,
             remove_on_unlock=True)

--- a/mapproxy/cache/couchdb.py
+++ b/mapproxy/cache/couchdb.py
@@ -107,12 +107,12 @@ class CouchDBCache(TileCacheBase, FileBasedLocking):
                     tile_id_template = self.tile_id_template
                 return tile_id_template % locals()
             else:
-                return '%(grid_name)s-%(z)d-%(x)d-%(y)d' % locals()
+                return '%(grid_name)s-%(z)s-%(x)s-%(y)s' % locals()
         else:
             if self.tile_id_template:
                 return self.tile_id_template % locals()
             else:
-                return '%(couch_url)s/%(grid_name)s-%(z)d-%(x)d-%(y)d' % locals()
+                return '%(couch_url)s/%(grid_name)s-%(z)s-%(x)s-%(y)s' % locals()
 
     def is_cached(self, tile):
         if tile.coord is None:

--- a/mapproxy/cache/couchdb.py
+++ b/mapproxy/cache/couchdb.py
@@ -156,7 +156,7 @@ class CouchDBCache(TileCacheBase, FileBasedLocking):
                 try:
                     return timestamp_from_isodate(self._max_age['time'])
                 except:
-                    raise ConfigurationError("Could not parse time '%s'. should be ISO time string" % (self._max_age["time"]))
+                    log.error("Could not parse time '%s'. should be ISO time string" % (self._max_age["time"]))
             
             """ Was mtime passed with a path to the source file? Grab the modified date to see if we need to update the tile """
             if 'mtime' in self._max_age:
@@ -168,7 +168,8 @@ class CouchDBCache(TileCacheBase, FileBasedLocking):
                     else:
                         return time.time() + 86400  # Return a date in the future so the tile is accepted as up-to-date
                 except OSError, ex:
-                    raise ConfigurationError("Can't parse last modified time from file '%s'." % datasource)
+                    log.error("Can't parse last modified time from file '%s'." % datasource)
+                    return 0 # Force refresh
             deltas = {}
             for delta_type in ('weeks', 'days', 'hours', 'minutes'):
                 deltas[delta_type] = self._max_age.get(delta_type, 0)

--- a/mapproxy/cache/couchdb.py
+++ b/mapproxy/cache/couchdb.py
@@ -66,7 +66,9 @@ class CouchDBCache(TileCacheBase, FileBasedLocking):
         self.tile_grid = tile_grid
         self.md_template = md_template
         self.couch_url = '%s/%s' % (url.rstrip('/'), db_name.lower())
-        self.req_session = requests.Session(timeout=5)
+        # Causing "TypeError: __init__() got an unexpected keyword argument 'timeout'" errors
+        # self.req_session = requests.Session(timeout=5)
+        self.req_session = requests.Session()
         self.init_db()
         self.tile_id_template = tile_id_template
 

--- a/mapproxy/cache/tile.py
+++ b/mapproxy/cache/tile.py
@@ -203,10 +203,10 @@ class TileManager(object):
                 try:
                     source_modified_time = os.path.getmtime(datasource)
                     if tile.timestamp < source_modified_time:
-                        return source_modified_time;
+                        return source_modified_time
                     else:
-                        return time.time() + 86400; # Return a date in the future so the tile is accepted as up-to-date
-                except OSError, ex:
+                        return time.time() + 86400  # Return a date in the future so the tile is accepted as up-to-date
+                except OSError:
                     raise ConfigurationError("Can't parse last modified time from file '%s'." % datasource)
             deltas = {}
             for delta_type in ('weeks', 'days', 'hours', 'minutes'):

--- a/mapproxy/cache/tile.py
+++ b/mapproxy/cache/tile.py
@@ -205,7 +205,7 @@ class TileManager(object):
                     if tile.timestamp < source_modified_time:
                         return source_modified_time;
                     else:
-                        return time.time() + 1000; # Return a date in the future so the tile is accepted as up-to-date
+                        return time.time() + 86400; # Return a date in the future so the tile is accepted as up-to-date
                 except OSError, ex:
                     raise ConfigurationError("Can't parse last modified time from file '%s'." % datasource)
             deltas = {}

--- a/mapproxy/cache/tile.py
+++ b/mapproxy/cache/tile.py
@@ -40,6 +40,7 @@ from __future__ import with_statement
 from contextlib import contextmanager
 
 from mapproxy.config import abspath
+from mapproxy.config.loader import ConfigurationError
 from mapproxy.grid import MetaGrid
 from mapproxy.image.merge import merge_images
 from mapproxy.image.tile import TileSplitter

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -23,7 +23,6 @@ import sys
 import hashlib
 import urlparse
 import warnings
-import datetime
 from copy import deepcopy
 
 import logging
@@ -983,8 +982,6 @@ class CacheConfiguration(ConfigurationBase):
         from mapproxy.cache.tile import TileManager
         from mapproxy.image.opts import compatible_image_options
         from mapproxy.layer import map_extent_from_grid, merge_layer_extents
-        
-        
 
         base_image_opts = self.image_opts()
         if self.conf.get('format') == 'mixed' and not self.conf.get('request_format') == 'image/png':

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -23,7 +23,7 @@ import sys
 import hashlib
 import urlparse
 import warnings
-from copy import deepcopy
+from copy import deepcopy, copy
 
 import logging
 log = logging.getLogger('mapproxy.config')
@@ -451,7 +451,8 @@ class SourcesCollection(dict):
                 " tagged sources only supported for WMS/Mapserver/Mapnik" % key)
 
         uses_req = source.conf.get('type') != 'mapnik'
-        source = deepcopy(source)
+        source = copy(source)
+        source.conf = deepcopy(source.conf)
 
         if uses_req:
             supported_layers = source.conf['req'].get('layers', [])
@@ -468,6 +469,7 @@ class SourcesCollection(dict):
             source.conf['req']['layers'] = layers
         else:
             source.conf['layers'] = layers
+            
         return source
 
     def __contains__(self, key):

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -913,9 +913,11 @@ class CacheConfiguration(ConfigurationBase):
         md_template = CouchDBMDTemplate(self.conf['cache'].get('tile_metadata', {}))
         tile_id = self.conf['cache'].get('tile_id')
 
+        maximum_age = self.conf.get('max_age')
+
         return CouchDBCache(url=url, db_name=db_name,
             lock_dir=cache_dir, file_ext=file_ext, tile_grid=grid_conf.tile_grid(),
-            md_template=md_template, tile_id_template=tile_id)
+            md_template=md_template, tile_id_template=tile_id, max_age=maximum_age)
 
     def _tile_cache(self, grid_conf, file_ext):
         if self.conf.get('disable_storage', False):

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -23,6 +23,7 @@ import sys
 import hashlib
 import urlparse
 import warnings
+import datetime
 from copy import deepcopy
 
 import logging
@@ -982,13 +983,15 @@ class CacheConfiguration(ConfigurationBase):
         from mapproxy.cache.tile import TileManager
         from mapproxy.image.opts import compatible_image_options
         from mapproxy.layer import map_extent_from_grid, merge_layer_extents
+        
+        
 
         base_image_opts = self.image_opts()
         if self.conf.get('format') == 'mixed' and not self.conf.get('request_format') == 'image/png':
             raise ConfigurationError('request_format must be set to image/png if mixed mode is enabled')
         request_format = self.conf.get('request_format') or self.conf.get('format')
         caches = []
-
+        
         meta_buffer = self.context.globals.get_value('meta_buffer', self.conf,
             global_key='cache.meta_buffer')
         meta_size = self.context.globals.get_value('meta_size', self.conf,
@@ -1022,12 +1025,13 @@ class CacheConfiguration(ConfigurationBase):
             tile_filter = self._tile_filter()
             image_opts = compatible_image_options(source_image_opts, base_opts=base_image_opts)
             cache = self._tile_cache(grid_conf, image_opts.format.ext)
+            maximum_age = self.conf.get('max_age')
             mgr = TileManager(tile_grid, cache, sources, image_opts.format.ext,
                               image_opts=image_opts,
                               meta_size=meta_size, meta_buffer=meta_buffer,
                               minimize_meta_requests=minimize_meta_requests,
                               concurrent_tile_creators=concurrent_tile_creators,
-                              pre_store_filter=tile_filter)
+                              pre_store_filter=tile_filter,max_age=maximum_age)
             extent = merge_layer_extents(sources)
             if extent.is_default:
                 extent = map_extent_from_grid(tile_grid)

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -17,6 +17,14 @@ from mapproxy.util.ext.dictspec.validator import validate, ValidationError
 from mapproxy.util.ext.dictspec.spec import one_of, anything, number
 from mapproxy.util.ext.dictspec.spec import recursive, required, type_spec, combined
 
+time_spec = {
+    'seconds': number(),
+    'minutes': number(),
+    'hours': number(),
+    'days': number(),
+    'weeks': number(),
+    'time': anything(),
+}
 
 def validate_mapproxy_conf(conf_dict):
     """
@@ -226,6 +234,7 @@ mapproxy_yaml_spec = {
             'minimize_meta_requests': bool(),
             'concurrent_tile_creators': int(),
             'disable_storage': bool(),
+            'max_age': time_spec,
             'format': str(),
             'image': image_opts,
             'request_format': str(),

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -17,16 +17,6 @@ from mapproxy.util.ext.dictspec.validator import validate, ValidationError
 from mapproxy.util.ext.dictspec.spec import one_of, anything, number
 from mapproxy.util.ext.dictspec.spec import recursive, required, type_spec, combined
 
-time_spec = {
-    'seconds': number(),
-    'minutes': number(),
-    'hours': number(),
-    'days': number(),
-    'weeks': number(),
-    'time': anything(),
-    'mtime': anything(),
-}
-
 def validate_mapproxy_conf(conf_dict):
     """
     Validate `conf_dict` agains mapproxy.yaml spec.
@@ -235,7 +225,15 @@ mapproxy_yaml_spec = {
             'minimize_meta_requests': bool(),
             'concurrent_tile_creators': int(),
             'disable_storage': bool(),
-            'max_age': time_spec,
+            'max_age': {
+                'seconds': number(),
+                'minutes': number(),
+                'hours': number(),
+                'days': number(),
+                'weeks': number(),
+                'time': anything(),
+                'mtime': anything(),
+            },
             'format': str(),
             'image': image_opts,
             'request_format': str(),

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -24,6 +24,7 @@ time_spec = {
     'days': number(),
     'weeks': number(),
     'time': anything(),
+    'mtime': anything(),
 }
 
 def validate_mapproxy_conf(conf_dict):

--- a/mapproxy/multiapp.py
+++ b/mapproxy/multiapp.py
@@ -67,8 +67,11 @@ class MultiMapProxy(object):
         self.apps = LRU(app_cache_size)
 
     def __call__(self, environ, start_response):
-        req = Request(environ)
-        return self.handle(req)(environ, start_response)
+        try:
+            req = Request(environ)
+            return self.handle(req)(environ, start_response)
+        except TypeError, ex:
+            return self.handle(req)(environ, start_response)
 
     def handle(self, req):
         app_name = req.pop_path()

--- a/mapproxy/multiapp.py
+++ b/mapproxy/multiapp.py
@@ -112,6 +112,7 @@ class MultiMapProxy(object):
 
         if not proj_app:
             with self._app_init_lock:
+                proj_app, timestamp = self.apps.get(proj_name, (None, None))
                 if self.loader.needs_reload(proj_name, timestamp):
                     proj_app, m_time = self.create_app(proj_name)
                     self.apps[proj_name] = proj_app, m_time

--- a/mapproxy/util/__init__.py
+++ b/mapproxy/util/__init__.py
@@ -78,13 +78,13 @@ class cached_property(object):
 
 def memoize(func):
     @wraps(func)
-    def wrapper(*args):
-        if not hasattr(func, '__memoize_cache'):
-            func.__memoize_cache = {}
-        key = args
-        if key not in func.__memoize_cache:
-            func.__memoize_cache[key] = func(*args)
-        return func.__memoize_cache[key]
+    def wrapper(self, *args):
+        if not hasattr(self, '__memoize_cache'):
+            self.__memoize_cache = {}
+        cache = self.__memoize_cache.setdefault(func, {})
+        if args not in cache:
+            cache[args] = func(self, *args)
+        return cache[args]
     return wrapper
 
 def swap_dir(src_dir, dst_dir, keep_old=False, backup_ext='.tmp'):


### PR DESCRIPTION
Solved a problem we had where live data is updated in a file and the cache needs to expire when the file changes.

max_age also supports a timestamp or 'expire after' object, akin to refresh_before for the seeding util.