### PR TITLE
adding quadkey as file cache option

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -31,10 +31,10 @@ The following backend types are available.
 This is the default cache type and it uses a single file for each tile. Available options are:
 
 ``directory_layout``:
-  The directory layout MapProxy uses to store tiles on disk. Defaults to ``tc`` which uses a TileCache compatible directory layout (``zz/xxx/xxx/xxx/yyy/yyy/yyy.format``). ``tms`` uses TMS compatible directories (``zz/xxxx/yyyy.format``).
+  The directory layout MapProxy uses to store tiles on disk. Defaults to ``tc`` which uses a TileCache compatible directory layout (``zz/xxx/xxx/xxx/yyy/yyy/yyy.format``). ``tms`` uses TMS compatible directories (``zz/xxxx/yyyy.format``). ``quadkey`` uses Microsoft Virtual Earth or quadkey compatible directories (see http://msdn.microsoft.com/en-us/library/bb259689.aspx);
 
   .. note::
-    ``tms`` layout is not suited for large caches, since it will create directories with thousands of files, which most file systems do not handle well.
+    ``tms`` and ``quadkey`` layout are not suited for large caches, since it will create directories with thousands of files, which most file systems do not handle well.
 
 ``use_grid_names``:
   When ``true`` MapProxy will use the actual grid name in the path instead of the SRS code. E.g. tiles will be stored in ``./cache_data/mylayer/mygrid/`` instead of ``./cache_data/mylayer/EPSG1234/``.

--- a/doc/configuration_examples.rst
+++ b/doc/configuration_examples.rst
@@ -759,3 +759,26 @@ You can reuse parts of the MapProxy configuration with the `base` option. You ca
 
 
 .. [#f1] This does not apply to `srs.proj_data_dir`, because it affects the proj4 library directly.
+
+.. _quadkey_cache:
+
+Generate static quadkey / virtual earth cache for use on Multitouch table
+=========================================================================
+
+Some software running on Microsoft multitouch tables need a static quadkey generated cache. Mapproxy understands quadkey both as a client and as a cache option.
+
+Example part of ``mapproxy.yaml`` to generate a quadkey cache::
+
+  caches:
+    osm_cache:
+      grids: [osm_grid]
+      sources: [osm_wms]
+      cache:
+        type: file
+        directory_layout: quadkey
+
+  grids:
+    osm_grid:
+      base: GLOBAL_MERCATOR
+      origin: nw
+

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -49,6 +49,8 @@ class FileCache(TileCacheBase, FileBasedLocking):
             self.tile_location = self._tile_location_tc
         elif directory_layout == 'tms':
             self.tile_location = self._tile_location_tms
+        elif directory_layout == 'quadkey':
+            self.tile_location = self._tile_location_quadkey
         else:
             raise ValueError('unknown directory_layout "%s"' % directory_layout)
         
@@ -116,7 +118,41 @@ class FileCache(TileCacheBase, FileBasedLocking):
         if create_dir:
             ensure_directory(tile.location)
         return tile.location
-    
+
+    def _tile_location_quadkey(self, tile, create_dir=False):
+        """
+        Return the location of the `tile`. Caches the result as ``location``
+        property of the `tile`.
+
+        :param tile: the tile object
+        :param create_dir: if True, create all necessary directories
+        :return: the full filename of the tile
+
+        >>> from mapproxy.cache.tile import Tile
+        >>> from mapproxy.cache.file import FileCache
+        >>> c = FileCache(cache_dir='/tmp/cache/', file_ext='png', directory_layout='quadkey')
+        >>> c.tile_location(Tile((3, 4, 2))).replace('\\\\', '/')
+        '/tmp/cache/11.png'
+        """
+        if tile.location is None:
+            x, y, z = tile.coord
+            quadKey = ""
+            for i in range(z,0,-1):
+                digit = 0
+                mask = 1 << (i-1)
+                if (x & mask) != 0:
+                    digit += 1
+                if (y & mask) != 0:
+                    digit += 2
+                quadKey += str(digit)
+            tile.location = os.path.join( 
+                self.cache_dir, quadKey + '.' + self.file_ext
+            )
+        if create_dir:
+            ensure_directory(tile.location)
+        return tile.location
+
+
     def _single_color_tile_location(self, color, create_dir=False):
         """
         >>> c = FileCache(cache_dir='/tmp/cache/', file_ext='png')

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -249,3 +249,14 @@ class TestMBTileCache(TileCacheTestBase):
         TileCacheTestBase.setup(self)
         self.cache = MBTilesCache(os.path.join(self.cache_dir, 'tmp.mbtiles'))
 
+
+class TestQuadkeyFileTileCache(TileCacheTestBase):
+    def setup(self):
+        TileCacheTestBase.setup(self)
+        self.cache = FileCache(self.cache_dir, 'png', directory_layout='quadkey')
+
+    def test_store_tile(self):
+        tile = self.create_tile((3, 4, 2))
+        self.cache.store_tile(tile)
+        tile_location = os.path.join(self.cache_dir, '11.png' )
+        assert os.path.exists(tile_location), tile_location


### PR DESCRIPTION
This pull request gives you the possibility to use MapProxy as a way to generate a static quadkey cache. These static cache are needed for certain software packages on microsoft based surface tables.

One discussion point (both for client and cache) for me is how MapProxy handles the (0,0,0) xyz tile.
Here: https://github.com/mapproxy/mapproxy/issues/49 somebody notes issues with a client requesting this (0,0,0) tile.
But if I understand correct from: http://msdn.microsoft.com/en-us/library/bb259689.aspx there is actually not 0,0,0 tile in quadkey. The first 'level' there is is level 1.

So maybe we should throw some exception when requesting 0,0,0 ?

By the way: current implementation is working correct if requested as wms etc.
