### PR TITLE
Documentation for mapnik source: transparent=true

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -460,6 +460,12 @@ A list of layer names you want to render. MapProxy disables each layer that is n
 
 Use Mapnik 2 if set to ``true``.
 
+``transparent``
+^^^^^^^^^^^
+
+Set to ``true`` to render from mapnik sources with background-color="transparent", ``false`` (default) will force a black background color.
+
+
 
 Other options
 ^^^^^^^^^^^^^


### PR DESCRIPTION
After spending a whole morning trying for a mapnik stylesheet to render properly, @vehrka asked me if it was possible to update the documentation in order to not repeat the same mistake
