### PR TITLE
Fix to tile retrieval for WMTS via couchdb

### DIFF
--- a/mapproxy/cache/couchdb.py
+++ b/mapproxy/cache/couchdb.py
@@ -92,12 +92,12 @@ class CouchDBCache(TileCacheBase, FileBasedLocking):
                     tile_id_template = self.tile_id_template
                 return tile_id_template % locals()
             else:
-                return '%(grid_name)s-%(z)d-%(x)d-%(y)d' % locals()
+                return '%(grid_name)s-%(z)s-%(x)s-%(y)s' % locals()
         else:
             if self.tile_id_template:
                 return self.tile_id_template % locals()
             else:
-                return '%(couch_url)s/%(grid_name)s-%(z)d-%(x)d-%(y)d' % locals()
+                return '%(couch_url)s/%(grid_name)s-%(z)s-%(x)s-%(y)s' % locals()
 
     def is_cached(self, tile):
         if tile.coord is None or tile.source:


### PR DESCRIPTION
x, y, z coords are strings, so we had some type errors being thrown when WMTS was used
