### PR TITLE
Improvements to initialisation time for large services with couchdb caches

### DIFF
--- a/mapproxy/cache/couchdb.py
+++ b/mapproxy/cache/couchdb.py
@@ -71,13 +71,10 @@ class CouchDBCache(TileCacheBase, FileBasedLocking):
         self.req_session = requests.Session()
         self.req_session.timeout = 5
         self.db_initialised = False
-        self.app_init_db_lock = None
+        self.app_init_db_lock = Lock()
         self.tile_id_template = tile_id_template
 
     def init_db(self):
-        if not self.app_init_db_lock:
-            self.app_init_db_lock = Lock()
-
         with self.app_init_db_lock:
             if self.db_initialised:
                 return


### PR DESCRIPTION
With init_db called during init our large services (600+ layers) were taking a very long time to init and saturating the available connectons back to couchdb.

1) Only initialise the DB when a connection is required, not once for every cache at service initialisation.

2) Lock to prevent initialising more connections than required (e.g. when multi simultaneous connections are received).
