### PR TITLE
Avoid concurrent requests to uninitialised services triggering more than one initialisation

### DIFF
--- a/mapproxy/multiapp.py
+++ b/mapproxy/multiapp.py
@@ -67,11 +67,8 @@ class MultiMapProxy(object):
         self.apps = LRU(app_cache_size)
 
     def __call__(self, environ, start_response):
-        try:
-            req = Request(environ)
-            return self.handle(req)(environ, start_response)
-        except TypeError, ex:
-            return self.handle(req)(environ, start_response)
+        req = Request(environ)
+        return self.handle(req)(environ, start_response)
 
     def handle(self, req):
         app_name = req.pop_path()
@@ -121,7 +118,7 @@ class MultiMapProxy(object):
                     proj_app, m_time = self.create_app(proj_name)
                     self.apps[proj_name] = proj_app, m_time
                 else:
-                    proj_app = self.apps[proj_name]
+                    proj_app, timestamp = self.apps[proj_name]
 
         return proj_app
 


### PR DESCRIPTION
When an uninitialised services received multiple concurrent requests it would initialise once for every request. Merely retrieving the timestamp from the app before checking if we need to reload fixed it.

However...this did seem to cause this

```
[Mon May 27 13:21:38 2013] [error] [client 202.1.16.73] mod_wsgi (pid=11004): Exception occurred processing WSGI script 'C:/web_projects/mapproxy/mapproxy-srss/config.py'.
[Mon May 27 13:21:38 2013] [error] [client 202.1.16.73] Traceback (most recent call last):
[Mon May 27 13:21:38 2013] [error] [client 202.1.16.73]   File "c:\\pythonenv\\mapproxy-srss\\Lib\\site-packages\\mapproxy-1.5.0a_20130527-py2.7.egg\\mapproxy\\multiapp.py", line 71, in __call__
[Mon May 27 13:21:38 2013] [error] [client 202.1.16.73]     return self.handle(req)(environ, start_response)
[Mon May 27 13:21:38 2013] [error] [client 202.1.16.73] TypeError: 'tuple' object is not callable
```

So we worked around it by just catching the exception and repeating the call. It's a bit of a hack =/

Happy to accept suggestions for a better way of handling the "do I really need to reinitialise this service" change :)
