### PR TITLE
Ensure OGRShapeReader internal data source is closed

### DIFF
--- a/mapproxy/util/ogr.py
+++ b/mapproxy/util/ogr.py
@@ -78,11 +78,10 @@ class OGRShapeReaderError(Exception):
 class CtypesOGRShapeReader(object):
     def __init__(self, datasource):
         self.datasource = datasource
-        self.opened = False
         self._ds = None
 
     def open(self):
-        if self.opened: return
+        if self._ds: return
         self._ds = libgdal.OGROpen(self.datasource, False, None)
         if self._ds is None:
             msg = None
@@ -93,7 +92,7 @@ class CtypesOGRShapeReader(object):
             raise OGRShapeReaderError(msg)
 
     def wkts(self, where=None):
-        if not self.opened: self.open()
+        if not self._ds: self.open()
 
         if where:
             if not where.lower().startswith('select'):
@@ -126,9 +125,9 @@ class CtypesOGRShapeReader(object):
             libgdal.OGR_DS_ReleaseResultSet(self._ds, layer)
 
     def close(self):
-        if self.opened:
+        if self._ds:
             libgdal.OGR_DS_Destroy(self._ds)
-            self.opened = False
+            self._ds = None
 
     def __del__(self):
         self.close()
@@ -137,11 +136,10 @@ class CtypesOGRShapeReader(object):
 class OSGeoOGRShapeReader(object):
     def __init__(self, datasource):
         self.datasource = datasource
-        self.opened = False
         self._ds = None
 
     def open(self):
-        if self.opened: return
+        if self._ds: return
         self._ds = ogr.Open(self.datasource, False)
         if self._ds is None:
             msg = gdal.GetLastErrorMsg()
@@ -150,7 +148,7 @@ class OSGeoOGRShapeReader(object):
             raise OGRShapeReaderError(msg)
 
     def wkts(self, where=None):
-        if not self.opened: self.open()
+        if not self._ds: self.open()
 
         if where:
             if not where.lower().startswith('select'):
@@ -173,9 +171,8 @@ class OSGeoOGRShapeReader(object):
             yield geom.ExportToWkt()
 
     def close(self):
-        if self.opened:
+        if self._ds:
             self._ds = None
-            self.opened = False
 
 
 ogr = gdal = None


### PR DESCRIPTION
@olt I've been experimenting with using `mapproxy.util.geom.load_datasource` to load features for use in an authorization filter. I found that when load testing I was running into the following error:

```
OGRShapeReaderError: PQconnectdb failed.
FATAL:  sorry, too many clients already
```

When I looked into it I found that the internal OGR data source was not getting closed in `OGRShapeReader`. This pull attempts to ensure that the data source is closed when the `close` method is called and uses a context manager when creating an instance to ensure `close` is called when the reader is no longer required.

I've tested manually using `CtypesOGRShapeReader` on Linux and Windows and `OSGeoOGRShapeReader` on Windows.
