### PR TITLE
Use relative symlinks for single color tiles

### DIFF
--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -256,7 +256,13 @@ class FileCache(TileCacheBase, FileBasedLocking):
         if os.path.exists(tile_loc) or os.path.islink(tile_loc):
             os.unlink(tile_loc)
 
-        os.symlink(os.path.relpath(real_tile_loc, os.path.dirname(tile_loc)), tile_loc)
+        # Use relative path for the symlink if os.path.relpath is available
+        # (only supported with >= Python 2.6)
+        if hasattr(os.path, 'relpath'):
+            real_tile_loc = os.path.relpath(real_tile_loc,
+                                            os.path.dirname(tile_loc))
+
+        os.symlink(real_tile_loc, tile_loc)
         return
 
     def __repr__(self):


### PR DESCRIPTION
@olt this is a tiny change to use a relative path when creating symlinks to single color tiles. The current tests for single color tiles pass, I couldn't see any additional tests that where required.
