### PR TITLE
example comment typo fixed

### DIFF
--- a/doc/seed.rst
+++ b/doc/seed.rst
@@ -174,7 +174,7 @@ Examples::
   levels:
     to: 10
 
-  # seed from level 3 to 6 (including level 10)
+  # seed from level 3 to 6 (including level 3 and 6)
   levels:
     from: 3
     to: 6
@@ -267,7 +267,7 @@ Examples::
   levels:
     to: 10
 
-  # cleanup from level 3 to 6 (including level 10)
+  # cleanup from level 3 to 6 (including level 3 and 6)
   levels:
     from: 3
     to: 6


### PR DESCRIPTION
Hi Oliver,

bedeutungsloser kann ein Pullrequest wohl nicht sein... Es gibt jetzt einen Typo weniger in der Doku, in einem Kommentar zu einem Beispielcode... 
