### PR TITLE
Add support for ArcGIS data sources.

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -6,6 +6,7 @@ Sources
 MapProxy supports the following sources:
 
 - :ref:`wms_label`
+- :ref:`arcgis_label`
 - :ref:`tiles_label`
 - :ref:`mapserver_label`
 - :ref:`mapnik_label`
@@ -250,6 +251,87 @@ Full example::
       url: http://localhost:8080/service?mycustomparam=foo
       layers: roads
       another_param: bar
+      transparent: true
+
+
+.. _arcgis_label:
+
+ArcGIS REST API
+"""
+
+Use the type ``arcgis`` to for ArcGIS servers.
+
+``req``
+^^^^^^^
+
+This describes the ArcGIS source. The only required option is ``url``. You need to set
+``transparent`` to ``true`` if you want to use this source as an overlay.
+::
+
+  req:
+    url: http://example.org/ArcGIS/rest/services/Imagery/MapService
+    layers: show: 0,1
+    transparent: true
+
+``coverage``
+^^^^^^^^^^^^
+
+Define the covered area of the source. The source will only be requested if there is an intersection between the requested data and the coverage. See :doc:`coverages <coverages>` for more information about the configuration. The intersection is calculated for meta-tiles and not the actual client request, so you should expect more visible data at the coverage boundaries.
+
+.. _supported_srs:
+
+``supported_srs``
+^^^^^^^^^^^^^^^^^
+
+A list with SRSs that should be requested from the ArcGIS server. MapProxy will only query the source in these SRSs. It will reproject data if it needs to get data from this layer in any other SRS.
+
+In most cases you should not need to configure this because ArcGIS servers should be able to dynamically reproject to any SRS.
+
+If MapProxy needs to reproject and the source has multiple ``supported_srs``, then it will use the fist projected SRS for requests in projected SRS, or the fist geographic SRS for requests in geographic SRS. E.g when `supported_srs` is ``['EPSG:4326', 'EPSG:31467']`` caches with EPSG:900913 will use EPSG:32467.
+
+  ..  .. note:: For the configuration of SRS for MapProxy see `srs_configuration`_.
+
+
+``http``
+^^^^^^^^
+
+You can configure the following HTTP related options for this source:
+
+- ``headers``
+- ``client_timeout``
+- ``ssl_ca_certs``
+- ``ssl_no_cert_checks`` (see below)
+
+See :ref:`HTTP Options <http_ssl>` for detailed documentation.
+
+.. _arcgis_source-ssl_no_cert_checks:
+
+``ssl_no_cert_checks``
+
+  MapProxy checks the SSL server certificates for any ``req.url`` that use HTTPS. You need to supply a file (see) that includes that certificate, otherwise MapProxy will fail to establish the connection. You can set the ``http.ssl_no_cert_checks`` options to ``true`` to disable this verification.
+
+.. _tagged_source_names:
+
+Example configuration
+^^^^^^^^^^^^^^^^^^^^^
+
+Minimal example::
+
+  my_minimal_arcgissource:
+    type: arcgis
+    req:
+      url: http://example.org/ArcGIS/rest/services/Imagery/MapService
+
+Full example::
+
+  my_arcgissource:
+    type: arcgis
+    coverage:
+       polygons: GM.txt
+       polygons_srs: EPSG:900913
+    req:
+      url: http://example.org/ArcGIS/rest/services/Imagery/MapService
+      layers: show:0,1
       transparent: true
 
 

--- a/mapproxy/client/arcgis.py
+++ b/mapproxy/client/arcgis.py
@@ -1,0 +1,35 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2010 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ArcGISClient(object):
+    def __init__(self, request_template, http_client=None):
+        self.request_template = request_template
+        self.http_client = http_client
+
+    def retrieve(self, query, format):
+        url  = self._query_url(query, format)
+        resp = self.http_client.open(url)
+        return resp
+
+    def _query_url(self, query, format):
+        req = self.request_template.copy()
+        req.params.format = format
+        req.params.bbox = query.bbox
+        req.params.size = query.size
+        req.params.bboxSR = query.srs
+        req.params.imageSR = query.srs
+        req.params.transparent = "True"
+
+        return req.complete_url

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -36,6 +36,7 @@ from mapproxy.util.yaml import load_yaml_file, YAMLError
 from mapproxy.compat.modules import urlparse
 from mapproxy.compat import string_type, iteritems
 
+
 class ConfigurationError(Exception):
     pass
 
@@ -594,6 +595,40 @@ def resolution_range(conf):
                                 max_scale=conf.get('max_scale'))
 
 
+class ArcGISSourceConfiguration(SourceConfiguration):
+    source_type = ('arcgis',)
+    def __init__(self, conf, context):
+        SourceConfiguration.__init__(self, conf, context)
+
+    def source(self, params=None):
+        from mapproxy.client.arcgis import ArcGISClient
+        from mapproxy.source.arcgis import ArcGISSource
+        from mapproxy.srs import SRS
+        from mapproxy.request.arcgis import create_request
+
+        # Get the supported SRS codes and formats from the configuration.
+        supported_srs = [SRS(code) for code in self.conf.get("supported_srs", [])]
+        supported_formats = [file_ext(f) for f in self.conf.get("supported_formats", [])]
+
+        # Construct the parameters
+        if params is None:
+            params = {}
+
+        request_format = self.conf['req'].get('format')
+        if request_format:
+            params['format'] = request_format
+
+        request = create_request(self.conf["req"], params)
+        http_client, request.url = self.http_client(request.url)
+        coverage = self.coverage()
+
+        client = ArcGISClient(request, http_client)
+        image_opts = self.image_opts(format=params.get('format'))
+        return ArcGISSource(client, image_opts=image_opts, coverage=coverage,
+                            supported_srs=supported_srs,
+                            supported_formats=supported_formats or None)
+
+
 class WMSSourceConfiguration(SourceConfiguration):
     source_type = ('wms',)
 
@@ -895,6 +930,7 @@ class DebugSourceConfiguration(SourceConfiguration):
 
 source_configuration_types = {
     'wms': WMSSourceConfiguration,
+    'arcgis': ArcGISSourceConfiguration,
     'tile': TileSourceConfiguration,
     'debug': DebugSourceConfiguration,
     'mapserver': MapServerSourceConfiguration,

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -391,6 +391,17 @@ mapproxy_yaml_spec = {
                 'use_mapnik2': bool(),
                 'scale_factor': number(),
             }),
+            'arcgis': combined(source_commons, {
+               required('req'): {
+                    required('url'): str(),
+                    'dpi': int(),
+                    'layers': str(),
+                    'transparent': bool(),
+                    'time': str()
+                },
+                'supported_srs': [str()],
+                'http': http_opts
+            }),
             'debug': {
             },
         })

--- a/mapproxy/request/arcgis.py
+++ b/mapproxy/request/arcgis.py
@@ -1,0 +1,125 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2010 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial as fp
+from mapproxy.request.base import RequestParams, BaseRequest, split_mime_type
+from mapproxy.compat import string_type
+
+
+class ArcGISExportRequestParams(RequestParams):
+    """
+    Supported params f, bbox(required), size, dpi, imageSR, bboxSR, format, layerDefs,
+    layers, transparent, time, layerTimeOptions.
+
+    @param layers: Determines which layers appear on the exported map. There are
+                   four ways to specify layers: show, hide, include, exclude.
+                   (ex show:1,2)
+    """
+    def _get_format(self):
+        """
+        The requested format as string (w/o any 'image/', 'text/', etc prefixes)
+        """
+        return self["format"]
+    def _set_format(self, format):
+        self["format"] = format.rsplit("/")[-1]
+    format = property(_get_format, _set_format)
+    del _get_format
+    del _set_format
+
+    def _get_bbox(self):
+        """
+        ``bbox`` as a tuple (minx, miny, maxx, maxy).
+        """
+        if 'bbox' not in self.params or self.params['bbox'] is None:
+            return None
+        points = [float(val) for val in self.params['bbox'].split(',')]
+        return tuple(points[:4])
+    def _set_bbox(self, value):
+        if value is not None and not isinstance(value, string_type):
+            value = ','.join(str(x) for x in value)
+        self['bbox'] = value
+    bbox = property(_get_bbox, _set_bbox)
+    del _get_bbox
+    del _set_bbox
+
+    def _get_size(self):
+        """
+        Size of the request in pixel as a tuple (width, height),
+        or None if one is missing.
+        """
+        if 'size' not in self.params or self.params['size'] is None:
+            return None
+        dim = [float(val) for val in self.params['size'].split(',')]
+        return tuple(dim[:2])
+    def _set_size(self, value):
+        if value is not None and not isinstance(value, string_type):
+            value = ','.join(str(x) for x in value)
+        self['size'] = value
+    size = property(_get_size, _set_size)
+    del _get_size
+    del _set_size
+
+    def _get_srs(self, key):
+        return self.params.get(key, None)
+    def _set_srs(self, srs, key):
+        if hasattr(srs, 'srs_code'):
+            code = srs.srs_code
+        else:
+            code = srs
+        self.params[key] = code.rsplit(":", 1)[-1]
+
+    bboxSR = property(fp(_get_srs, key="bboxSR"), fp(_set_srs, key="bboxSR"))
+    imageSR = property(fp(_get_srs, key="imageSR"), fp(_set_srs, key="imageSR"))
+    del _get_srs
+    del _set_srs
+
+
+class ArcGISRequest(BaseRequest):
+    request_params = ArcGISExportRequestParams
+    fixed_params = {"f": "image"}
+
+    def __init__(self, param=None, url='', validate=False, http=None):
+        BaseRequest.__init__(self, param, url, validate, http)
+
+        self.url = self.url.rstrip("/")
+        if not self.url.endswith("export"):
+            self.url += "/export"
+
+    def copy(self):
+        return self.__class__(param=self.params.copy(), url=self.url)
+
+    @property
+    def query_string(self):
+        params = self.params.copy()
+        for key, value in self.fixed_params.iteritems():
+            params[key] = value
+        return params.query_string
+
+
+def create_request(req_data, param):
+    req_data = req_data.copy()
+
+    # Pop the URL off the request data.
+    url = req_data['url']
+    del req_data['url']
+
+    if 'format' in param:
+        req_data['format'] = param['format']
+
+    if 'transparent' in req_data:
+        # Convert boolean to a string.
+        req_data['transparent'] = str(req_data['transparent'])
+
+    return ArcGISRequest(url=url, param=req_data)

--- a/mapproxy/source/arcgis.py
+++ b/mapproxy/source/arcgis.py
@@ -1,0 +1,26 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2010 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mapproxy.source.wms import WMSSource
+
+import logging
+log = logging.getLogger('mapproxy.source.arcgis')
+
+
+class ArcGISSource(WMSSource):
+    def __init__(self, client, image_opts=None, coverage=None,
+                 supported_srs=None, supported_formats=None):
+        WMSSource.__init__(self, client, image_opts=image_opts, coverage=coverage,
+                           supported_srs=supported_srs, supported_formats=supported_formats)

--- a/mapproxy/test/unit/test_request.py
+++ b/mapproxy/test/unit/test_request.py
@@ -22,6 +22,7 @@ from mapproxy.request.tile import TMSRequest, tile_request, TileRequest
 from mapproxy.request.wms import (wms_request, WMSMapRequest, WMSMapRequestParams,
                               WMS111MapRequest, WMS100MapRequest, WMS130MapRequest,
                               WMS111FeatureInfoRequest)
+from mapproxy.request.arcgis import ArcGISRequest
 from mapproxy.exception import RequestError
 from mapproxy.request.wms.exception import (WMS111ExceptionHandler, WMSImageExceptionHandler,
                                      WMSBlankExceptionHandler)
@@ -212,6 +213,23 @@ class TestWMS111FeatureInfoRequest(TestWMSMapRequest):
     def test_pos_coords(self):
         req = wms_request(DummyRequest(self.base_req))
         eq_(req.params.pos_coords, (7.25, 50.5))
+
+class TestArcGISRequest(object):
+    def test_base_request(self):
+        req = ArcGISRequest(url="http://something.com/ArcGIS/rest/MapServer/")
+        eq_("http://something.com/ArcGIS/rest/MapServer/export", req.url)
+        req.params.bbox = [-180.0, -90.0, 180.0, 90.0]
+        eq_((-180.0, -90.0, 180.0, 90.0), req.params.bbox)
+        eq_("-180.0,-90.0,180.0,90.0", req.params["bbox"])
+        req.params.size = [256, 256]
+        eq_((256, 256), req.params.size)
+        eq_("256,256", req.params["size"])
+        req.params.imageSR = "EPSG:4326"
+        eq_("4326", req.params.imageSR)
+        eq_("4326", req.params["imageSR"])
+        req.params.bboxSR = SRS("EPSG:4326")
+        eq_("4326", req.params.bboxSR)
+        eq_("4326", req.params["bboxSR"])
 
 
 class TestRequest(object):


### PR DESCRIPTION
Adds support for connecting to ArcGIS REST servers directly. There could definitely be some improvements made, but wanted to get some initial feedback and determine interest level.

Example Configuration:
```
services:
  demo: null
  wms:
    md:
      title: MapProxy WMS Proxy

layers:
  - name: world_arcgis
    title: World Imagery
    sources: [arcgis_cache]

caches:
  arcgis_cache:
    grids: [GLOBAL_MERCATOR]
    sources: [arcgissource]

sources:
  arcgissource:
    type: arcgis
    req:
      url: http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer
      layers: show:0
      transparent: true
```