### PR TITLE
Handle case that we have zero layers

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -159,7 +159,9 @@ class ProxyConfiguration(object):
         if layers_conf is None: return
 
         if isinstance(layers_conf, list):
-            if isinstance(layers_conf[0], dict) and len(layers_conf[0].keys()) == 1:
+            if 0 == len(layers_conf):
+                layers_conf = dict(title=None, layers=[])
+            elif isinstance(layers_conf[0], dict) and len(layers_conf[0].keys()) == 1:
                 # looks like ordered legacy config
                 layers_conf = self._legacy_layers_conf_dict()
             elif len(layers_conf) == 1 and 'layers' in layers_conf[0]:
@@ -1260,10 +1262,7 @@ class WMSLayerConfiguration(ConfigurationBase):
         if 'sources' in self.conf or 'legendurl' in self.conf:
             this_layer = LayerConfiguration(self.conf, self.context).wms_layer()
 
-        if not layers and not this_layer:
-            raise ValueError('wms layer requires sources and/or layers')
-
-        if not layers:
+        if not layers and this_layer:
             layer = this_layer
         else:
             layer = WMSGroupLayer(name=self.conf.get('name'), title=self.conf.get('title'),


### PR DESCRIPTION
While a configuration with zero layers is not that useful, if you are dynamically changing the configuration and remove all layers their would be an error. This handles the case that there are zero layers.