### PR TITLE
Allow unicode for str values

### DIFF
--- a/mapproxy/util/ext/dictspec/validator.py
+++ b/mapproxy/util/ext/dictspec/validator.py
@@ -185,5 +185,9 @@ def type_matches(spec, data):
         spec_type = spec
     else:
         spec_type = type(spec)
+
+    if spec_type is str:
+        spec_type = basestring
+
     return isinstance(data, spec_type)
 


### PR DESCRIPTION
This change makes it possible to have Unicode values for various parts of the MapProxy configuration. This is a simple workaround that allows Unicode without changing all of the existing spec code.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mapproxy/mapproxy/133)
<!-- Reviewable:end -->
