### PR TITLE
fix tmp progress-file rename on windows

### DIFF
--- a/mapproxy/seed/util.py
+++ b/mapproxy/seed/util.py
@@ -173,6 +173,7 @@ class ProgressLog(object):
         if self.progress_store and self.current_task_id:
             self.progress_store.add(self.current_task_id,
                 progress.current_progress_identifier())
+            self.progress_store.remove()
             self.progress_store.write()
 
         if self.silent:


### PR DESCRIPTION
On windows os.rename can't overwrite an existing file.
We must delete the progress_store file before rename the progress_store.tmp file.