### PR TITLE
Parse tilematrix as integer from kvp request

### DIFF
--- a/mapproxy/request/wmts.py
+++ b/mapproxy/request/wmts.py
@@ -60,7 +60,7 @@ class WMTSTileRequestParams(RequestParams):
     def _get_coord(self):
         x = int(self['tilecol'])
         y = int(self['tilerow'])
-        z = self['tilematrix']
+        z = int(self['tilematrix'])
         return x, y, z
     def _set_coord(self, value):
         x, y, z = value


### PR DESCRIPTION
WMTS REST and KVP parsers behave diffenerent when reading tilematrix, causing an TileOutOfRange exception (KVP) in some situations while REST is still working. As tilematrix is parsed as int in `WMTS100RestTileRequest`, it should be done similar in `WMTSTileRequestParams`.