### PR TITLE
Image.FASTOCTREE fails on certains images

### DIFF
--- a/mapproxy/image/__init__.py
+++ b/mapproxy/image/__init__.py
@@ -318,7 +318,10 @@ def quantize(img, colors=256, alpha=False, defaults=None, quantizer=None):
     if hasattr(Image, 'FASTOCTREE') and quantizer in (None, 'fastoctree'):
         if not alpha:
             img = img.convert('RGB')
-        img = img.quantize(colors, Image.FASTOCTREE)
+        try:
+            img = img.quantize(colors, Image.FASTOCTREE)
+        except ValueError:
+            pass
     else:
         if alpha and img.mode == 'RGBA':
             img.load() # split might fail if image is not loaded

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -90,6 +90,21 @@ class TestImageSource(object):
         assert is_tiff(ir.as_buffer(TIFF_FORMAT))
         assert is_tiff(ir.as_buffer())
 
+
+    def test_output_formats_greyscale_png(self):
+        img = Image.new('L', (100, 100))
+        ir = ImageSource(img, image_opts=PNG_FORMAT)
+        img = Image.open(ir.as_buffer(ImageOptions(colors=256, transparent=True, format='image/png')))
+        assert img.mode == 'P'
+        assert img.getpixel((0, 0)) == 255
+
+    def test_output_formats_greyscale_alpha_png(self):
+        img = Image.new('LA', (100, 100))
+        ir = ImageSource(img, image_opts=PNG_FORMAT)
+        img = Image.open(ir.as_buffer(ImageOptions(colors=256, transparent=True, format='image/png')))
+        assert img.mode == 'LA'
+        assert img.getpixel((0, 0)) == (0, 0)
+
     def test_output_formats_png8(self):
         img = Image.new('RGBA', (100, 100))
         ir = ImageSource(img, image_opts=PNG_FORMAT)


### PR DESCRIPTION
Transparent greyscale ('LA') cannot be quantized, so do nothing.