### PR TITLE
Fix "CacheBackendError: cannot query SQLite for more than 333 tiles"

### DIFF
--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -198,29 +198,35 @@ class MBTilesCache(TileCacheBase):
             # all tiles loaded or coords are None
             return True
 
-        if len(coords) > 1000:
-            # SQLite is limited to 1000 args
-            raise CacheBackendError('cannot query SQLite for more than 333 tiles')
-
         if self.supports_timestamp:
-            stmt = "SELECT tile_column, tile_row, tile_data, last_modified FROM tiles WHERE "
+            stmt_base = "SELECT tile_column, tile_row, tile_data, last_modified FROM tiles WHERE "
         else:
-            stmt = "SELECT tile_column, tile_row, tile_data FROM tiles WHERE "
-        stmt += ' OR '.join(['(tile_column = ? AND tile_row = ? AND zoom_level = ?)'] * (len(coords)//3))
-
-        cursor = self.db.cursor()
-        cursor.execute(stmt, coords)
+            stmt_base = "SELECT tile_column, tile_row, tile_data FROM tiles WHERE "
 
         loaded_tiles = 0
-        for row in cursor:
-            loaded_tiles += 1
-            tile = tile_dict[(row[0], row[1])]
-            data = row[2]
-            tile.size = len(data)
-            tile.source = ImageSource(BytesIO(data))
-            if self.supports_timestamp:
-                tile.timestamp = sqlite_datetime_to_timestamp(row[3])
-        cursor.close()
+
+        # SQLite is limited to 1000 args -> split into multiple requests if more arguments are needed
+        while len(coords) > 0:
+            cur_coords = coords[:999] if len(coords) > 999 else coords
+
+            stmt = stmt_base + ' OR '.join(
+                ['(tile_column = ? AND tile_row = ? AND zoom_level = ?)'] * (len(cur_coords) // 3))
+
+            cursor = self.db.cursor()
+            cursor.execute(stmt, cur_coords)
+
+            for row in cursor:
+                loaded_tiles += 1
+                tile = tile_dict[(row[0], row[1])]
+                data = row[2]
+                tile.size = len(data)
+                tile.source = ImageSource(BytesIO(data))
+                if self.supports_timestamp:
+                    tile.timestamp = sqlite_datetime_to_timestamp(row[3])
+            cursor.close()
+
+            coords = coords[999:] if len(coords) > 999 else []
+
         return loaded_tiles == len(tile_dict)
 
     def remove_tile(self, tile):
@@ -343,4 +349,3 @@ class MBTilesLevelCache(TileCacheBase):
             return True
         else:
             return level_cache.remove_level_tiles_before(level, timestamp)
-

--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -206,8 +206,8 @@ class MBTilesCache(TileCacheBase):
         loaded_tiles = 0
 
         # SQLite is limited to 1000 args -> split into multiple requests if more arguments are needed
-        while len(coords) > 0:
-            cur_coords = coords[:999] if len(coords) > 999 else coords
+        while coords:
+            cur_coords = coords[:999]
 
             stmt = stmt_base + ' OR '.join(
                 ['(tile_column = ? AND tile_row = ? AND zoom_level = ?)'] * (len(cur_coords) // 3))
@@ -225,7 +225,7 @@ class MBTilesCache(TileCacheBase):
                     tile.timestamp = sqlite_datetime_to_timestamp(row[3])
             cursor.close()
 
-            coords = coords[999:] if len(coords) > 999 else []
+            coords = coords[999:]
 
         return loaded_tiles == len(tile_dict)
 

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -258,8 +258,9 @@ class TestMBTileCache(TileCacheTestBase):
         assert self.cache.load_tiles([Tile(None)]) == True
         assert self.cache.load_tiles([Tile(None), Tile(None), Tile(None)]) == True
 
-    def test_load_1001_tiles(self):
-        assert_raises(CacheBackendError, self.cache.load_tiles, [Tile((19, 1, 1))] * 1001)
+    # TODO: is this test still necessary?
+    # def test_load_1001_tiles(self):
+    #     assert self.cache.load_tiles([Tile((19, 1, 1))] * 1001) == True
 
     def test_timeouts(self):
         self.cache._db_conn_cache.db = sqlite3.connect(self.cache.mbtile_file, timeout=0.05)

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -254,13 +254,22 @@ class TestMBTileCache(TileCacheTestBase):
         TileCacheTestBase.setup(self)
         self.cache = MBTilesCache(os.path.join(self.cache_dir, 'tmp.mbtiles'))
 
+    def teardown(self):
+        if self.cache:
+            self.cache.cleanup()
+        TileCacheTestBase.teardown(self)
+
     def test_load_empty_tileset(self):
         assert self.cache.load_tiles([Tile(None)]) == True
         assert self.cache.load_tiles([Tile(None), Tile(None), Tile(None)]) == True
 
-    # TODO: is this test still necessary?
-    # def test_load_1001_tiles(self):
-    #     assert self.cache.load_tiles([Tile((19, 1, 1))] * 1001) == True
+    def test_load_more_than_2000_tiles(self):
+        # prepare data
+        for i in range(0, 2010):
+            assert self.cache.store_tile(Tile((i, 0, 10),  ImageSource(BytesIO(b'foo'))))
+
+        tiles = [Tile((i, 0, 10)) for i in range(0, 2010)]
+        assert self.cache.load_tiles(tiles)
 
     def test_timeouts(self):
         self.cache._db_conn_cache.db = sqlite3.connect(self.cache.mbtile_file, timeout=0.05)


### PR DESCRIPTION
When using MapProxy with MBTiles/SQLite based caches, large WMS requests can issue a CacheBackendError. The proposed fix will issue multiple SQLite-queries when more than 333 tiles are requested.