### PR TITLE
An slightly improvements in dimensions support in mapProxy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 *.patch
+*~
 build/
 dist/
 doc/_build

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1410,7 +1410,7 @@ class LayerConfiguration(ConfigurationBase):
                         continue
                     conf_sources.append(self.context.sources[source_name].source())
 
-                pass
+                continue
             else:
                 conf_sources.append(self.context.caches[source_name].map_layer())
             sources.append(source_name)

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1369,18 +1369,25 @@ class LayerConfiguration(ConfigurationBase):
         res_range = resolution_range(self.conf)
 
         layer = WMSLayer(self.conf.get('name'), self.conf.get('title'),
-                         sources, fi_sources, lg_sources, res_range=res_range, md=self.conf.get('md'))
+                         sources, fi_sources, lg_sources, res_range=res_range, md=self.conf.get('md'),dimensions=self.dimensions(sources))
         return layer
 
-    @memoize
-    def dimensions(self):
+#    @memoize
+    def dimensions(self,sources=None):
         from mapproxy.layer import Dimension
         dimensions = {}
 
         for dimension, conf in iteritems(self.conf.get('dimensions', {})):
             values = [str(val) for val in  conf.get('values', ['default'])]
             default = conf.get('default', values[-1])
-            dimensions[dimension.lower()] = Dimension(dimension, values, default=default)
+            units = conf.get('units',None)
+            multipleValues = conf.get('multipleValues',False)
+            current = conf.get('current',False)
+            refresh = conf.get('refresh',None)
+            dimensions[dimension.lower()] = Dimension(dimension, values, default=default,
+                                                        units=units,unitSymbol=None,
+                                                        multipleValues=multipleValues,current=current,
+                                                        sources=sources,refresh=refresh)
         return dimensions
 
     @memoize
@@ -1389,6 +1396,7 @@ class LayerConfiguration(ConfigurationBase):
         from mapproxy.cache.dummy import DummyCache
 
         sources = []
+        conf_sources=[]
         for source_name in self.conf.get('sources', []):
             # we only support caches for tiled access...
             if not source_name in self.context.caches:
@@ -1400,14 +1408,17 @@ class LayerConfiguration(ConfigurationBase):
                     # and WMS layers with map: False (i.e. FeatureInfo only sources)
                     if src_conf['type'] == 'wms' and src_conf.get('wms_opts', {}).get('map', True) == False:
                         continue
+                    conf_sources.append(self.context.sources[source_name].source())
 
-                return []
+                pass
+            else:
+                conf_sources.append(self.context.caches[source_name].map_layer())
             sources.append(source_name)
 
         if len(sources) > 1:
             return []
 
-        dimensions = self.dimensions()
+        dimensions = self.dimensions(conf_sources)
 
         tile_layers = []
         for cache_name in sources:

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -489,6 +489,10 @@ mapproxy_yaml_spec = {
                 anything(): {
                     required('values'): [one_of(string_type, float, int)],
                     'default': one_of(string_type, float, int),
+                    'unit':string_type,
+                    'multiplyValues':bool(),
+                    'current':bool(),
+                    'refresh':int,
                 }
             }
         })])

--- a/mapproxy/service/templates/wms110capabilities.xml
+++ b/mapproxy/service/templates/wms110capabilities.xml
@@ -115,6 +115,29 @@
     {{for srs_code, bbox in layer_srs_bbox(layer)}}
     <BoundingBox SRS="{{srs_code}}" minx="{{ bbox[0] }}" miny="{{ bbox[1] }}" maxx="{{ bbox[2] }}" maxy="{{ bbox[3] }}" />
     {{endfor}}
+	{{if len(layer.dimensions)>0}}
+	    {{for dmn in layer.dimensions}}
+	        {{py:dimension=bunch(default='',**layer.dimensions)[dmn]}}
+	        {{if len(dimension)>0 and dimension.units}}
+	            <Dimension 
+	                name="{{dimension.identifier}}"
+	                units="{{dimension.units}}"
+	                {{if dimension.unitSymbol}}
+        	            unitSymbol="{{dimension.unitSymbol}}"
+                    {{endif}}
+                />
+                <Extent
+	                name="{{dimension.identifier}}"
+	                default="{{dimension.default}}"
+	                {{if dimension.multipleValues}}
+	                multipleValues="1"
+	                {{endif}}
+                >
+                    {{",".join(dimension)}}
+                </Extent>
+	        {{endif}}
+	    {{endfor}}
+	{{endif}}
     {{if layer.is_active and layer.has_legend and layer.legend_url}}
     <Style>
         <Name>default</Name>

--- a/mapproxy/service/templates/wms111capabilities.xml
+++ b/mapproxy/service/templates/wms111capabilities.xml
@@ -132,6 +132,29 @@
     {{for srs_code, bbox in layer_srs_bbox(layer)}}
     <BoundingBox SRS="{{srs_code}}" minx="{{ bbox[0] }}" miny="{{ bbox[1] }}" maxx="{{ bbox[2] }}" maxy="{{ bbox[3] }}" />
     {{endfor}}
+	{{if len(layer.dimensions)>0}}
+	    {{for dmn in layer.dimensions}}
+	        {{py:dimension=bunch(default='',**layer.dimensions)[dmn]}}
+	        {{if len(dimension)>0 and dimension.units}}
+	            <Dimension 
+	                name="{{dimension.identifier}}"
+	                units="{{dimension.units}}"
+	                {{if dimension.unitSymbol}}
+        	            unitSymbol="{{dimension.unitSymbol}}"
+                    {{endif}}
+                />
+                <Extent
+	                name="{{dimension.identifier}}"
+	                default="{{dimension.default}}"
+	                {{if dimension.multipleValues}}
+	                multipleValues="1"
+	                {{endif}}
+                >
+                {{",".join(dimension)}}
+                </Extent>
+	        {{endif}}
+	    {{endfor}}
+	{{endif}}
     {{py: md = bunch(default='', **layer.md)}}
     {{if md.metadata}}
       {{for data in md.metadata}}

--- a/mapproxy/service/templates/wms130capabilities.xml
+++ b/mapproxy/service/templates/wms130capabilities.xml
@@ -233,6 +233,29 @@
     {{for srs_code, bbox in layer_srs_bbox(layer, epsg_axis_order=True)}}
     <BoundingBox CRS="{{srs_code}}" minx="{{ bbox[0] }}" miny="{{ bbox[1] }}" maxx="{{ bbox[2] }}" maxy="{{ bbox[3] }}" />
     {{endfor}}
+	{{if len(layer.dimensions)>0}}
+	{{for dmn in layer.dimensions}}
+	    {{py:dimension=bunch(default='',**layer.dimensions)[dmn]}}
+	    {{if len(dimension)>0 and dimension.units}}
+	        <Dimension 
+	            name="{{dimension.identifier}}"
+                units="{{dimension.units}}"
+                {{if dimension.unitSymbol}}
+    	            unitSymbol="{{dimension.unitSymbol}}"
+                {{endif}}
+	            default="{{dimension.default}}"
+	            {{if dimension.multipleValues}}
+	            multipleValues="1"
+	            {{endif}}
+	            {{if dimension.current}}
+	            current="1"
+	            {{endif}}
+            >
+            {{",".join(dimension)}}
+            </Dimension>
+	    {{endif}}
+	{{endfor}}
+	{{endif}}
     {{if md.attribution}}
     {{py: attribution = bunch(default='', **md.attribution)}}
     <Attribution>

--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -78,7 +78,7 @@
       <Format>image/{{layer.format}}</Format>
       {{for dimension in layer.dimensions}}
       <Dimension>
-        <ows:Identifier>{{ dimension_keys[dimension] }}</ows:Identifier>
+        <ows:Identifier>{{ dimension_keys[dimension].identifier }}</ows:Identifier>
         <Default>{{ layer.dimensions[dimension].default }}</Default>
         {{for value in layer.dimensions[dimension]}}
         <Value>{{ value }}</Value>

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -632,6 +632,8 @@ class WMSLayerBase(object):
     res_range = None
     "MapExtend of the layer"
     extent = None
+    "Dimensions of the layer"
+    dimensions=[]
 
     def is_opaque(self):
         return not self.transparent
@@ -653,8 +655,10 @@ class WMSLayer(WMSLayerBase):
     """
     is_active = True
     layers = []
+    "Dimensions of the layer"
+    dimensions=[]
     def __init__(self, name, title, map_layers, info_layers=[], legend_layers=[],
-                 res_range=None, md=None):
+                 res_range=None, md=None, dimensions=[]):
         self.name = name
         self.title = title
         self.md = md or {}
@@ -668,6 +672,7 @@ class WMSLayer(WMSLayerBase):
         self.queryable = True if info_layers else False
         self.transparent = all(not map_lyr.is_opaque() for map_lyr in self.map_layers)
         self.has_legend = True if legend_layers else False
+        self.dimensions=dimensions
 
     def renders_query(self, query):
         if self.res_range and not self.res_range.contains(query.bbox, query.size, query.srs):

--- a/mapproxy/util/lazylist.py
+++ b/mapproxy/util/lazylist.py
@@ -1,0 +1,153 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2010 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+LazyList decorator and support helper function
+"""
+
+
+import threading
+# callable does not present in Python 3.0 - 3.2
+try:
+    callable
+except NameError:
+    from collections import Callable
+    callable=lambda x: isinstance(x,Callable)
+
+'''
+ Return true if y is attribute of x and y is instance of callable
+'''
+iscallable=lambda x,y: hasattr(x,y) and callable(getattr(x,y))
+
+'''
+ Check value of flat
+'''
+checkFlag=lambda src,flag: (iscallable(src,flag) and getattr(src,flag)()) or (not iscallable(src,flag) and hasattr(src,flag) and getattr(src,flag))
+
+'''    
+    Decorators installer
+'''
+def decorateList(decorator):
+    _props = (
+        '__str__', '__repr__', '__unicode__',
+        '__hash__', '__sizeof__', '__cmp__', '__nonzero__',
+        '__lt__', '__le__', '__eq__', '__ne__', '__gt__', '__ge__',
+        'append', 'count', 'index', 'extend', 'insert', 'pop', 'remove',
+        'reverse', 'sort', '__add__', '__radd__', '__iadd__', '__mul__',
+        '__rmul__', '__imul__', '__contains__', '__len__', '__nonzero__',
+        '__getitem__', '__setitem__', '__delitem__', '__iter__',
+        '__reversed__', '__getslice__', '__setslice__', '__delslice__')
+    def decorate(cls):
+        for attr in _props: 
+            if iscallable(cls,attr):
+                setattr(cls, attr, decorator(getattr(cls, attr)))
+        return cls
+    return decorate
+    
+'''
+    LazyList decorator
+    Use @decorateList(lazy())
+    or
+    Use @decorateList(lazy(fillname="data",lockname="_lock",ready="isdataready",once="isOnce"))
+'''   
+
+def lazy(fillname='get_value',lockname='_lazy_lock',ready="ready",once="once"): 
+    def _lazy(attr):
+        def __lazy(self, *args, **kw):
+            if not hasattr(self,lockname):
+                setattr(self,lockname,threading.Lock())
+            lock=getattr(self,lockname)
+            if hasattr(self,fillname):
+                src=getattr(self,fillname)
+                if src is not None:
+                    lock.acquire()
+                    try:
+                        if checkFlag(self,ready):
+                            if callable(src):
+                                listval=src()
+                            else:
+                                listval=src
+                            if list.__len__(self)>0:
+                                list.__delitem__(self,slice(0,list.__len__(self)))
+                            list.extend(self,listval)
+                            
+                            
+                            if checkFlag(self,once):
+                                    delattr(self,fillname)
+                    except (KeyboardInterrupt,SystemExit):
+                        raise
+                    except:
+                        pass
+                    finally:
+                        lock.release()
+                else:
+                    delattr(self,fillname)
+            return attr(self, *args, **kw)
+        return __lazy
+    return _lazy
+    
+'''    
+ Return function wich check this condition: "Is the time reached"?
+ Use
+    timeCondition=measure(5)
+    timeCondition() # return False
+    time.sleep(10)
+    timeCondition() # return True
+    
+ Full
+    timeCondition=measure(5,first=True,once=False) # return True on first call whenever is interval reached
+    timeCondition() # return True
+    timeCondition() # return False
+    time.sleep(10)
+    timeCondition() # return True
+    
+'''
+from datetime import datetime,timedelta
+from numbers import Number
+def measure(interval,first=False,once=False):
+
+    next=datetime.today()
+    if isinstance(interval,Number):
+        interval=timedelta(seconds=interval)
+    elif isinstance(interval,datetime):
+        interval=interval-next
+        once=True
+        first=False
+    elif interval is None:
+        interval=timedelta(seconds=0)
+        once=True
+    else:
+        raise TypeError("'delta' need to be one of this type: None, Number, timedelta, datatime")
+    if interval<=timedelta(seconds=0):
+        interval=timedelta(seconds=0)
+        once=True
+    if first:
+        next-=interval
+    param=dict([("next",next),("happend",False),("interval",interval)])
+
+    def _check():
+        if param["happend"] and once:
+            return False
+        current=datetime.today()
+        if current-param["next"]>=interval:
+            param["happend"]=True
+            param["next"]=current
+            return True
+        return False
+    
+    return _check
+    
+
+


### PR DESCRIPTION
When I has deployed some WMS-based configuration I found that the mapProxy has a very limited support of dimensions. In fact dimensions supported only in WMTS service and only with preconfigured values. So I wrote small improvements which added initial support of dimensions for WMS-based services and improve WMTS dimensions support.

This pull request contains next improvements:
- added dimension support in answer on WMS GetCapabilities requests (I changed appropriate templates);
- added some properties of dimension like 'unit', 'using current value' and so on;
- dimension values now can be obtained as a result of parsing answer on GetCapability request to designated source;
- added option to define period in seconds between dimension values updates.

To minimize changes in mapProxy  I wrote lazyList decorator (util/lazylist.py) and used it to periodically data updates.

I'm beg my pardon for  bad English