### PR TITLE
arcgiscache directory layout for FileCache

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -31,10 +31,10 @@ The following backend types are available.
 This is the default cache type and it uses a single file for each tile. Available options are:
 
 ``directory_layout``:
-  The directory layout MapProxy uses to store tiles on disk. Defaults to ``tc`` which uses a TileCache compatible directory layout (``zz/xxx/xxx/xxx/yyy/yyy/yyy.format``). ``mp`` uses a directory layout with less nesting (``zz/xxxx/xxxx/yyyy/yyyy.format```). ``tms`` uses TMS compatible directories (``zz/xxxx/yyyy.format``). ``quadkey`` uses Microsoft Virtual Earth or quadkey compatible directories (see http://msdn.microsoft.com/en-us/library/bb259689.aspx);
+  The directory layout MapProxy uses to store tiles on disk. Defaults to ``tc`` which uses a TileCache compatible directory layout (``zz/xxx/xxx/xxx/yyy/yyy/yyy.format``). ``mp`` uses a directory layout with less nesting (``zz/xxxx/xxxx/yyyy/yyyy.format```). ``tms`` uses TMS compatible directories (``zz/xxxx/yyyy.format``). ``quadkey`` uses Microsoft Virtual Earth or quadkey compatible directories (see http://msdn.microsoft.com/en-us/library/bb259689.aspx). ``arcgis`` uses a directory layout with hexadecimal row and column numbers that is compatible to ArcGIS exploded caches (``Lzz/Rxxxxxxxx/Cyyyyyyyy.format``).
 
   .. note::
-    ``tms`` and ``quadkey`` layout are not suited for large caches, since it will create directories with thousands of files, which most file systems do not handle well.
+    ``tms``, ``quadkey`` and ``arcgis`` layout are not suited for large caches, since it will create directories with thousands of files, which most file systems do not handle well.
 
 ``use_grid_names``:
   When ``true`` MapProxy will use the actual grid name in the path instead of the SRS code. E.g. tiles will be stored in ``./cache_data/mylayer/mygrid/`` instead of ``./cache_data/mylayer/EPSG1234/``.

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -195,13 +195,11 @@ class FileCache(TileCacheBase):
         >>> from mapproxy.cache.file import FileCache
         >>> c = FileCache(cache_dir='/tmp/cache/', file_ext='png', directory_layout='arcgis')
         >>> c.tile_location(Tile((1234567, 87654321, 9))).replace('\\\\', '/')
-        '/tmp/cache/L09/R05397FB1/C0012D687.png'
+        '/tmp/cache/L09/R05397fb1/C0012d687.png'
         """
         if tile.location is None:
             x, y, z = tile.coord
-            row = ('R%08x' % y).upper()
-            col = ('C%08x' % x).upper()
-            parts = (self.level_location('L%02d' % z), row, '%s.%s' % (col, self.file_ext))
+            parts = (self.level_location('L%02d' % z), 'R%08x' % y, 'C%08x.%s' % (x, self.file_ext))
             tile.location = os.path.join(*parts)
         if create_dir:
             ensure_directory(tile.location)

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -195,11 +195,13 @@ class FileCache(TileCacheBase):
         >>> from mapproxy.cache.file import FileCache
         >>> c = FileCache(cache_dir='/tmp/cache/', file_ext='png', directory_layout='arcgis')
         >>> c.tile_location(Tile((1234567, 87654321, 9))).replace('\\\\', '/')
-        '/tmp/cache/L09/R05397fb1/C0012d687.png'
+        '/tmp/cache/L09/R05397FB1/C0012D687.png'
         """
         if tile.location is None:
             x, y, z = tile.coord
-            parts = (self.level_location('L%02d' % z), 'R%08x' % y, 'C%08x.%s' % (x, self.file_ext))
+            row = ('R%08x' % y).upper()
+            col = ('C%08x' % x).upper()
+            parts = (self.level_location('L%02d' % z), row, '%s.%s' % (col, self.file_ext))
             tile.location = os.path.join(*parts)
         if create_dir:
             ensure_directory(tile.location)


### PR DESCRIPTION
This adds support for ArcGIS exploded cache directory structures in FileCache. So it's possible to use or create ArcGIS compatible caches.

Within the cache configurateion use:
  type: file
  directory_layout: arcgis