### PR TITLE
fix: InfoQuery coordinate transformation is inverted for y axis

### DIFF
--- a/mapproxy/layer.py
+++ b/mapproxy/layer.py
@@ -152,7 +152,7 @@ class InfoQuery(object):
 
     @property
     def coord(self):
-        return make_lin_transf((0, self.size[1], self.size[0], 0), self.bbox)(self.pos)
+        return make_lin_transf((0, 0, self.size[0], self.size[1]), self.bbox)(self.pos)
 
 class LegendQuery(object):
     def __init__(self, format, scale):

--- a/mapproxy/test/unit/test_wms_layer.py
+++ b/mapproxy/test/unit/test_wms_layer.py
@@ -15,7 +15,7 @@
 
 from __future__ import with_statement, division
 
-from mapproxy.layer import MapQuery
+from mapproxy.layer import MapQuery, InfoQuery
 from mapproxy.srs import SRS
 from mapproxy.service.wms import combined_layers
 from nose.tools import eq_
@@ -76,3 +76,9 @@ class TestCombinedLayers(object):
         eq_(combined[1].client.request_template.params.layers, ['c', 'd'])
         eq_(combined[2].client.request_template.params.layers, ['e', 'f'])
 
+
+class TestInfoQuery(object):
+    def test_coord(self):
+        query = InfoQuery((8, 50, 9, 51), (400, 1000),
+                           SRS(4326), (100, 600), 'text/plain')
+        eq_(query.coord, (8.25, 50.4))


### PR DESCRIPTION
Short version:
Looks like the coordinate transformation being done for `InfoQuery.coord` has the y bounds inverted and is getting errors in the results for the Y coordinate transformation.

Longer version:
For WMS GetFeatureInfo requests, position is queried as coordinates I and J in image coordinates based on a bbox taken from the bounds of the viewing window. The bbox is in geographic coordinates, but the position is in image coordinates where the origin (0, 0) is upper left and (WIDTH, HEIGHT) are lower right. The `srs.make_lin_transf()` function used to transform between cartesian and image coordinates expects image bounds to be defined as (0, 0, WIDTH, HEIGHT) but when called for `InfoQuery.coord`, it is being defined as (0, HEIGHT, WIDTH, 0) so the Y coordinate ends up being off.