### PR TITLE
Support WMS GetFeatureInfoRequests on tile sources with UTFGrids

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -372,6 +372,18 @@ You need to enable ``transparent`` for your source, if you use ``on_error`` resp
         cache: False
 
 
+``featureinfo_utfgrid_url``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An optional URL template that points to `UTFGrid tiles <https://github.com/mapbox/utfgrid-spec/blob/master/1.3/utfgrid.md>`_ containing information about features at a given point. This can be used to answer WMS GetFeatureInfo requests. It uses the same format as the ``url`` option.
+
+
+``featureinfo_utfgrid_template``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An optional `mustache template string <https://mustache.github.io/mustache.5.html>`_ that will be used to render GetFeatureInfo text or html responses.
+
+
 Example configuration
 ^^^^^^^^^^^^^^^^^^^^^
 ::

--- a/mapproxy/client/tile.py
+++ b/mapproxy/client/tile.py
@@ -81,7 +81,7 @@ class UTFGrid(object):
             key -= 1
         key -= 32
         decoded = self.keys[key]
-        return self.data[decoded]
+        return self.data.get(decoded)
 
 class TileURLTemplate(object):
     """

--- a/mapproxy/client/tile.py
+++ b/mapproxy/client/tile.py
@@ -76,9 +76,9 @@ class UTFGrid(object):
         col = int(x / self.factor)
         key = ord(self.grid[row][col])
         if key > 93:
-            key-=1
+            key -= 1
         if key > 35:
-            key-=1
+            key -= 1
         key -= 32
         decoded = self.keys[key]
         return self.data[decoded]

--- a/mapproxy/client/tile.py
+++ b/mapproxy/client/tile.py
@@ -16,9 +16,10 @@
 from mapproxy.client.http import retrieve_image, retrieve_url
 
 try:
-    import simrplejson as json
+    import simplejson as json
 except ImportError:
     import json
+
 
 class TMSClient(object):
     def __init__(self, url, format='png', http_client=None):

--- a/mapproxy/client/tile.py
+++ b/mapproxy/client/tile.py
@@ -1,12 +1,12 @@
 # This file is part of the MapProxy project.
 # Copyright (C) 2010 Omniscale <http://omniscale.de>
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ class TMSClient(object):
         self.url = url
         self.http_client = http_client
         self.format = format
-    
+
     def get_tile(self, tile_coord, format=None):
         x, y, z = tile_coord
         url = '%s/%d/%d/%d.%s' % (self.url, z, x, y, format or self.format)
@@ -28,7 +28,7 @@ class TMSClient(object):
             return self.http_client.open_image(url)
         else:
             return retrieve_image(url)
-    
+
     def __repr__(self):
         return '%s(%r, %r)' % (self.__class__.__name__, self.url, self.format)
 
@@ -37,14 +37,14 @@ class TileClient(object):
         self.url_template = url_template
         self.http_client = http_client
         self.grid = grid
-    
+
     def get_tile(self, tile_coord, format=None):
         url = self.url_template.substitute(tile_coord, format, self.grid)
         if self.http_client:
             return self.http_client.open_image(url)
         else:
             return retrieve_image(url)
-    
+
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self.url_template)
 
@@ -61,15 +61,15 @@ class TileURLTemplate(object):
     >>> t = TileURLTemplate('http://foo/tiles/%(tc_path)s.png')
     >>> t.substitute((7, 4, 3))
     'http://foo/tiles/03/000/000/007/000/000/004.png'
-    
+
     >>> t = TileURLTemplate('http://foo/tms/1.0.0/%(tms_path)s.%(format)s')
     >>> t.substitute((7, 4, 3))
     'http://foo/tms/1.0.0/3/7/4.png'
-    
+
     >>> t = TileURLTemplate('http://foo/tms/1.0.0/lyr/%(tms_path)s.%(format)s')
     >>> t.substitute((7, 4, 3), 'jpeg')
     'http://foo/tms/1.0.0/lyr/3/7/4.jpeg'
-    
+
     """
     def __init__(self, template, format='png'):
         self.template= template
@@ -96,7 +96,7 @@ class TileURLTemplate(object):
             data['bbox'] = bbox(tile_coord, grid)
 
         return self.template % data
-    
+
     def __repr__(self):
         return '%s(%r, format=%r)' % (
             self.__class__.__name__, self.template, self.format)
@@ -159,7 +159,7 @@ def bbox(tile_coord, grid):
     '0.00000000,-15.00000000,10.00000000,-5.00000000'
     >>> bbox((0, 0, 1), grid)
     '0.00000000,-15.00000000,5.00000000,-10.00000000'
-    
+
     >>> grid = tile_grid(4326, bbox=(0, -15, 10, -5), origin='nw')
     >>> bbox((0, 0, 1), grid)
     '0.00000000,-10.00000000,5.00000000,-5.00000000'

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -907,36 +907,6 @@ class TileSourceConfiguration(SourceConfiguration):
 
         return fi_source
 
-        #from mapproxy.client.wms import WMSInfoClient
-        #from mapproxy.request.wms import create_request
-        #from mapproxy.source.wms import WMSInfoSource
-        #from mapproxy.srs import SRS
-
-        #if params is None: params = {}
-        #request_format = self.conf['req'].get('format')
-        #if request_format:
-            #params['format'] = request_format
-        #supported_srs = [SRS(code) for code in self.conf.get('supported_srs', [])]
-        #fi_source = None
-        #if self.conf.get('wms_opts', {}).get('featureinfo', False):
-            #wms_opts = self.conf['wms_opts']
-            #version = wms_opts.get('version', '1.1.1')
-            #if 'featureinfo_format' in wms_opts:
-                #params['info_format'] = wms_opts['featureinfo_format']
-            #fi_request = create_request(self.conf['req'], params,
-                #req_type='featureinfo', version=version,
-                #abspath=self.context.globals.abspath)
-
-            #fi_transformer = self.fi_xslt_transformer(self.conf.get('wms_opts', {}),
-                                                     #self.context)
-
-            #http_client, fi_request.url = self.http_client(fi_request.url)
-            #fi_client = WMSInfoClient(fi_request, supported_srs=supported_srs,
-                                      #http_client=http_client)
-            #fi_source = WMSInfoSource(fi_client, fi_transformer=fi_transformer)
-        #return fi_source
-
-
 
 def file_ext(mimetype):
     from mapproxy.request.base import split_mime_type

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -878,13 +878,15 @@ class TileSourceConfiguration(SourceConfiguration):
         client = TileClient(TileURLTemplate(url, format=format), http_client=http_client, grid=grid)
 
         return TiledSource(grid, client, coverage=coverage, image_opts=image_opts,
-            error_handler=error_handler, res_range=res_range,
-            fi_utfgrid_client=fi_utfgrid_client)
+            error_handler=error_handler, res_range=res_range)
 
     def fi_source(self, params=None):
+        from mapproxy.client.tile import UTFGridClient, TileURLTemplate
+        from mapproxy.source.tile import UTFGridFeatureInfoSource
         fi_source = None
 
-        if self.conf['featureinfo_utfgrid']:
+        featureinfo_utfgrid_url = self.conf.get('featureinfo_utfgrid_url')
+        if featureinfo_utfgrid_url:
             grid_name = self.conf.get('grid')
             if grid_name is None:
                 log.warn("tile source for %s does not have a grid configured and defaults to GLOBAL_MERCATOR. default will change with MapProxy 2.0", url)
@@ -897,14 +899,11 @@ class TileSourceConfiguration(SourceConfiguration):
             image_opts = self.image_opts()
             error_handler = self.on_error_handler()
 
-            url = self.conf['featureinfo_utfgrid']
-            http_client, url = self.http_client(url)
-            utfgrid_client = TileClient(TileURLTemplate(url, format=format),
-                http_client=fi_http_client, grid=grid)
+            http_client, url = self.http_client(featureinfo_utfgrid_url)
+            utfgrid_client = UTFGridClient(TileURLTemplate(url, format=format),
+                http_client=http_client, grid=grid)
 
-            fi_source = UTFGridFeatureInfoSource()
-        else:
-            fi_utfgrid_client = None
+            fi_source = UTFGridFeatureInfoSource(grid=grid, client=utfgrid_client)
 
         return fi_source
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -903,7 +903,8 @@ class TileSourceConfiguration(SourceConfiguration):
             utfgrid_client = UTFGridClient(TileURLTemplate(url, format=format),
                 http_client=http_client, grid=grid)
 
-            fi_source = UTFGridFeatureInfoSource(grid=grid, client=utfgrid_client)
+            template = self.conf.get('featureinfo_utfgrid_template')
+            fi_source = UTFGridFeatureInfoSource(grid=grid, client=utfgrid_client, template=template)
 
         return fi_source
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -876,8 +876,67 @@ class TileSourceConfiguration(SourceConfiguration):
 
         format = file_ext(params['format'])
         client = TileClient(TileURLTemplate(url, format=format), http_client=http_client, grid=grid)
+
         return TiledSource(grid, client, coverage=coverage, image_opts=image_opts,
-            error_handler=error_handler, res_range=res_range)
+            error_handler=error_handler, res_range=res_range,
+            fi_utfgrid_client=fi_utfgrid_client)
+
+    def fi_source(self, params=None):
+        fi_source = None
+
+        if self.conf['featureinfo_utfgrid']:
+            grid_name = self.conf.get('grid')
+            if grid_name is None:
+                log.warn("tile source for %s does not have a grid configured and defaults to GLOBAL_MERCATOR. default will change with MapProxy 2.0", url)
+                grid_name = "GLOBAL_MERCATOR"
+
+            grid = self.context.grids[grid_name].tile_grid()
+            coverage = self.coverage()
+            res_range = resolution_range(self.conf)
+
+            image_opts = self.image_opts()
+            error_handler = self.on_error_handler()
+
+            url = self.conf['featureinfo_utfgrid']
+            http_client, url = self.http_client(url)
+            utfgrid_client = TileClient(TileURLTemplate(url, format=format),
+                http_client=fi_http_client, grid=grid)
+
+            fi_source = UTFGridFeatureInfoSource()
+        else:
+            fi_utfgrid_client = None
+
+        return fi_source
+
+        #from mapproxy.client.wms import WMSInfoClient
+        #from mapproxy.request.wms import create_request
+        #from mapproxy.source.wms import WMSInfoSource
+        #from mapproxy.srs import SRS
+
+        #if params is None: params = {}
+        #request_format = self.conf['req'].get('format')
+        #if request_format:
+            #params['format'] = request_format
+        #supported_srs = [SRS(code) for code in self.conf.get('supported_srs', [])]
+        #fi_source = None
+        #if self.conf.get('wms_opts', {}).get('featureinfo', False):
+            #wms_opts = self.conf['wms_opts']
+            #version = wms_opts.get('version', '1.1.1')
+            #if 'featureinfo_format' in wms_opts:
+                #params['info_format'] = wms_opts['featureinfo_format']
+            #fi_request = create_request(self.conf['req'], params,
+                #req_type='featureinfo', version=version,
+                #abspath=self.context.globals.abspath)
+
+            #fi_transformer = self.fi_xslt_transformer(self.conf.get('wms_opts', {}),
+                                                     #self.context)
+
+            #http_client, fi_request.url = self.http_client(fi_request.url)
+            #fi_client = WMSInfoClient(fi_request, supported_srs=supported_srs,
+                                      #http_client=http_client)
+            #fi_source = WMSInfoSource(fi_client, fi_transformer=fi_transformer)
+        #return fi_source
+
 
 
 def file_ext(mimetype):

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -451,7 +451,8 @@ mapproxy_yaml_spec = {
                 'transparent': bool(),
                 'image': image_opts,
                 'grid': str(),
-                'featureinfo_utfgrid': str(),
+                'featureinfo_utfgrid_url': str(),
+                'featureinfo_utfgrid_template': str(),
                 'request_format': str(),
                 'origin': str(), # TODO: remove with 1.5
                 'http': http_opts,

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -451,6 +451,7 @@ mapproxy_yaml_spec = {
                 'transparent': bool(),
                 'image': image_opts,
                 'grid': str(),
+                'featureinfo_utfgrid': str(),
                 'request_format': str(),
                 'origin': str(), # TODO: remove with 1.5
                 'http': http_opts,

--- a/mapproxy/layer.py
+++ b/mapproxy/layer.py
@@ -152,7 +152,7 @@ class InfoQuery(object):
 
     @property
     def coord(self):
-        return make_lin_transf((0, self.size[1], self.size[0], 0), self.bbox)(self.pos)
+        return make_lin_transf((0, 0, self.size[0], self.size[1]), self.bbox)(self.pos)
 
 class LegendQuery(object):
     def __init__(self, format, scale):

--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -33,12 +33,6 @@ from mapproxy.srs import make_lin_transf
 from mapproxy.util.py import reraise_exception
 from math import log as _log, pi as _pi
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
-
 import logging
 log = logging.getLogger('mapproxy.source.tile')
 log_config = logging.getLogger('mapproxy.config')

--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -93,19 +93,11 @@ class UTFGridFeatureInfoSource(InfoSource):
         self.client = client
 
     def get_info(self, query):
-        # convert query bbox to grid srs
-        query_bbox_pts = [
-            (query.bbox[0], query.bbox[1]),
-            (query.bbox[2], query.bbox[3])
-        ]
-        grid_bbox_pts = query.srs.transform_to(self.grid.srs, query_bbox_pts)
-        grid_bbox = [i for i in itertools.chain(*grid_bbox_pts)]
-
-        # convert query coordinates to grid srs
-        grid_x, grid_y = query.srs.transform_to(self.grid.srs, query.coord)
-
         # get zoom level
-        src_bbox, level = self.grid.get_affected_bbox_and_level(grid_bbox, self.grid.tile_size)
+        src_bbox, level = self.grid.get_affected_bbox_and_level(query.bbox, query.size, req_srs=query.srs)
+
+        # transform query coordinates to grid srs
+        grid_x, grid_y = query.srs.transform_to(self.grid.srs, query.coord)
 
         # get tile TMS numbers (x/y/z)
         tile_coord = self.grid.tile(grid_x, grid_y, level)

--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -81,6 +81,16 @@ class TiledSource(MapLayer):
             log.warn('could not retrieve tile: %s', e)
             reraise_exception(SourceError(e.args[0]), sys.exc_info())
 
+
+class UTFGridFeatureInfoSource(InfoSource):
+    def __init__(self, grid, client);
+        pass
+
+    def get_info(self, query):
+        tile = self.client.get_tile(tile_coord, format=query.format)
+        return create_featureinfo_doc('yo dawg', 'text/plain')
+
+
 class CacheSource(CacheMapLayer):
     def __init__(self, tile_manager, extent=None, image_opts=None,
         max_tile_limit=None, tiled_only=False):

--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -20,9 +20,6 @@ Retrieve tiles from different tile servers (TMS/TileCache/etc.).
 import itertools
 import sys
 
-import dicttoxml
-import pystache
-
 from mapproxy.image.opts import ImageOptions
 from mapproxy.source import SourceError
 from mapproxy.client.http import HTTPClientError
@@ -92,10 +89,21 @@ class TiledSource(MapLayer):
 
 class UTFGridFeatureInfoSource(InfoSource):
     def __init__(self, grid, client, template=None):
+        try:
+            import dicttoxml
+        except ImportError:
+            raise ImportError('could not find the dicttoxml package, which is required to support utfgrid featureinfo sources')
+
         self.grid = grid
         self.client = client
         self.template = template
+
         if self.template:
+            try:
+                import pystache
+            except ImportError:
+                raise ImportError('could not find the pystache package, which is required to support utfgrid featureinfo sources')
+
             self.renderer = pystache.Renderer()
             self.parsed_template = pystache.parse(unicode(template))
 

--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -127,20 +127,3 @@ class CacheSource(CacheMapLayer):
         if self.tiled_only:
             query.tiled_only = True
         return CacheMapLayer.get_map(self, query)
-
-
-def _webmercator_to_tms(x, y):
-    """ Convert from Point object in EPSG:900913 to a TMS coordinate (x, y, z)
-
-    borrowed from TileStache
-    (https://github.com/TileStache/TileStache/blob/291271657b1ee809a0aedb74a0b813a44992c429/TileStache/Geography.py#L74)
-    """
-    # the zoom at which we're dealing with meters on the ground
-    diameter = 2 * _pi * 6378137
-    zoom = _log(diameter) / _log(2)
-
-    # global offsets
-    column = x + diameter/2
-    row = diameter/2 - y
-
-    return column, row, zoom

--- a/mapproxy/test/unit/test_wms_layer.py
+++ b/mapproxy/test/unit/test_wms_layer.py
@@ -15,7 +15,7 @@
 
 from __future__ import with_statement, division
 
-from mapproxy.layer import MapQuery
+from mapproxy.layer import MapQuery, InfoQuery
 from mapproxy.srs import SRS
 from mapproxy.service.wms import combined_layers
 from nose.tools import eq_
@@ -76,3 +76,9 @@ class TestCombinedLayers(object):
         eq_(combined[1].client.request_template.params.layers, ['c', 'd'])
         eq_(combined[2].client.request_template.params.layers, ['e', 'f'])
 
+
+class TestInfoQuery(object):
+    def test_coord(self):
+        query = InfoQuery((8, 50, 9, 51), (400, 1000),
+                           SRS(4326), (100, 600), 'text/plain')
+        eq_(query.coord, (8.25, 50.4))

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,5 +10,3 @@ coverage==3.7
 requests==2.0.1
 six==1.4.1
 waitress==0.8.7
-dicttoxml==1.6.6
-pystache==0.5.4

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,3 +10,5 @@ coverage==3.7
 requests==2.0.1
 six==1.4.1
 waitress==0.8.7
+dicttoxml==1.6.6
+pystache==0.5.4

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -7,5 +7,3 @@ Shapely==1.2.15
 PyYAML==3.10
 Pillow==1.7.7
 eventlet==0.9.17
-dicttoxml==1.6.6
-pystache==0.5.4

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -7,3 +7,5 @@ Shapely==1.2.15
 PyYAML==3.10
 Pillow==1.7.7
 eventlet==0.9.17
+dicttoxml==1.6.6
+pystache==0.5.4


### PR DESCRIPTION
This allows tile sources to support WMS GetFeatureInfo queries via [utfgrid](https://github.com/mapbox/utfgrid-spec). It adds two new optional variables to tile source configurations:
- `featureinfo_utfgrid_url` is a url in the same format as `url`, with an interpolated %(tms_path)
- `featureinfo_utfgrid_template` is a [mustache](http://mustache.github.com/mustache.5.html) template string that is used to represent when the requested MIMETYPE is `text/plain` or `text/html` . This allows reuse of templates defined for interactivity, per [utfgrid 1.3 interaction](https://github.com/mapbox/utfgrid-spec/blob/master/1.3/interaction.md). If this variable string is not defined, then just the json data for a grid point will be returned

This uses pystache and dicttoxml libraries to render to text and to XML, and wanted to make those only be soft dependencies so they will raise an ImportError only if this feature is used. Is this an okay approach?

Still needs:
- [ ] tests
- [x] to be added to the tile source docs

But I figure we can start a conversation about the PR and fix/adjust anything else while that happens.

note: This PR will implicitly merge #215 as well, since it depends on that fix.
