### PR TITLE
Addressing FutureWarning for elem check

### DIFF
--- a/mapproxy/util/ext/wmsparse/parse.py
+++ b/mapproxy/util/ext/wmsparse/parse.py
@@ -53,7 +53,7 @@ class WMSCapabilities(object):
 
     def parse_contact(self):
         elem = self.find(self.tree, 'Service/ContactInformation')
-        if elem is not None:
+        if elem is None or len(elem) == 0:
             elem = etree.Element(None)
         md = dict(
             person = self.findtext(elem, 'ContactPersonPrimary/ContactPerson'),

--- a/mapproxy/util/ext/wmsparse/parse.py
+++ b/mapproxy/util/ext/wmsparse/parse.py
@@ -53,7 +53,7 @@ class WMSCapabilities(object):
 
     def parse_contact(self):
         elem = self.find(self.tree, 'Service/ContactInformation')
-        if not elem:
+        if elem is not None:
             elem = etree.Element(None)
         md = dict(
             person = self.findtext(elem, 'ContactPersonPrimary/ContactPerson'),

--- a/mapproxy/util/ext/wmsparse/parse.py
+++ b/mapproxy/util/ext/wmsparse/parse.py
@@ -53,7 +53,7 @@ class WMSCapabilities(object):
 
     def parse_contact(self):
         elem = self.find(self.tree, 'Service/ContactInformation')
-        if elem is None or len(elem) == 0:
+        if elem is None or len(elem) is 0:
             elem = etree.Element(None)
         md = dict(
             person = self.findtext(elem, 'ContactPersonPrimary/ContactPerson'),


### PR DESCRIPTION
Line 56 of parse.py emits a FutureWarning in debug logs, saying the default behavior of `not elem` will change in new versions.  Changing this call to `elem is not None` to address the warning.