### PR TITLE
mapproxy-util export arcgis

### DIFF
--- a/doc/mapproxy_util.rst
+++ b/doc/mapproxy_util.rst
@@ -506,6 +506,9 @@ Export types
 ``mbtile``:
     Exports tiles into a MBTile file.
 
+``arcgis``:
+    Exports tiles in a ArcGIS exploded cache directory structure.
+
 
 
 Examples

--- a/mapproxy/script/export.py
+++ b/mapproxy/script/export.py
@@ -209,6 +209,12 @@ def export_command(args=None):
             'type': 'file',
             'directory': options.dest,
         }
+    elif options.type == 'arcgis':
+        cache_conf['cache'] = {
+            'type': 'file',
+            'directory_layout': 'arcgis',
+            'directory': options.dest,
+        }
     elif options.type in ('tms', None): # default
         cache_conf['cache'] = {
             'type': 'file',


### PR DESCRIPTION
Ok, here comes a new Pull Request for ArcGIS cache support for mapproxy-util export which includes only the modified files. I had to struggle a bit with Git and GitHub as I'm not really into it. Hope this will do. The documentation is also extended.