### PR TITLE
Request for advice: Creating a cartopy source

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -928,11 +928,28 @@ class DebugSourceConfiguration(SourceConfiguration):
         return DebugSource()
 
 
+class CartopyConfiguration(SourceConfiguration):
+    source_type = ('cartopy',)
+
+    def source(self, params=None):
+        from mapproxy.source.cartopy import CartopySource
+        import imp
+
+        mod_fname = self.context.globals.abspath(self.conf['module'])
+        mod_name = os.path.splitext(mod_fname)[0]
+        func_name = self.conf.get('function', 'main')
+
+        module = imp.load_source(mod_name, mod_fname)
+        axes_fn = getattr(module, func_name)
+        return CartopySource(axes_fn)
+
+
 source_configuration_types = {
     'wms': WMSSourceConfiguration,
     'arcgis': ArcGISSourceConfiguration,
     'tile': TileSourceConfiguration,
     'debug': DebugSourceConfiguration,
+    'cartopy': CartopyConfiguration,
     'mapserver': MapServerSourceConfiguration,
     'mapnik': MapnikSourceConfiguration,
 }

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -489,7 +489,11 @@ mapproxy_yaml_spec = {
                 'supported_srs': [str()],
                 'http': http_opts
             }),
-            'debug': {
+            'cartopy': {
+               required('module'): str(),
+               required('function'): str()
+            },
+           'debug': {
             },
         })
     },

--- a/mapproxy/source/cartopy.py
+++ b/mapproxy/source/cartopy.py
@@ -1,0 +1,101 @@
+# This module is released under the BSD 3-clause license by Philip Elson (@pelson) 2016.
+
+from __future__ import with_statement, absolute_import
+
+import io
+import sys
+import time
+
+import cartopy.crs as ccrs
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+from mapproxy.image import ImageSource
+from mapproxy.image.opts import ImageOptions
+from mapproxy.layer import MapExtent, DefaultMapExtent, BlankImage, MapLayer
+from mapproxy.source import SourceError
+from mapproxy.client.log import log_request
+from mapproxy.util.py import reraise_exception
+
+
+class CartopySource(MapLayer):
+    supports_meta_tiles = False
+
+    def __init__(self, axes_function, layers=None, image_opts=None, coverage=None,
+                 res_range=None, lock=None, reuse_map_objects=False, scale_factor=None):
+        MapLayer.__init__(self, image_opts=image_opts)
+        self.axes_function = axes_function
+        self.coverage = coverage
+        self.res_range = res_range
+        self.layers = set(layers) if layers else None
+        self.scale_factor = scale_factor
+        self.lock = lock
+        if self.coverage:
+            self.extent = MapExtent(self.coverage.bbox, self.coverage.srs)
+        else:
+            self.extent = DefaultMapExtent()
+        self._axes_cache = {}
+
+    def get_map(self, query):
+        if self.res_range and not self.res_range.contains(query.bbox, query.size,
+                                                          query.srs):
+            raise BlankImage()
+        if self.coverage and not self.coverage.intersects(query.bbox, query.srs):
+            raise BlankImage()
+
+        try:
+            resp = self.render(query)
+        except RuntimeError as ex:
+            reraise_exception(SourceError(ex.args[0]), sys.exc_info())
+        return resp
+
+    def render(self, query):
+        if self.lock:
+            with self.lock():
+                return self._render(query)
+        else:
+            return self._render(query)
+
+    def _render(self, query):
+        start_time = time.time()
+        proj_code = '+init=%s' % str(query.srs.srs_code.lower())
+        envelope = query.bbox
+        if proj_code in ['+init=crs:84', '+init=epsg:4326']:
+            crs = ccrs.PlateCarree()
+        elif proj_code in ['+init=epsg:3857', '+init=epsg:3785', '+init=epsg:900913']:
+            # TODO: I'm not sure this it correct.
+            crs = ccrs.Mercator.GOOGLE
+        else:
+            raise ValueError('Unsupported projection {}'.format(proj_code))
+
+        def _prepare_axes(ax):
+            ax.outline_patch.set_visible(False)
+            ax.background_patch.set_visible(False)
+            ax.set_aspect('auto')
+            ax.set_xlim(envelope[0], envelope[2])
+            ax.set_ylim(envelope[1], envelope[3])
+            ax._mapproxy_context = {'self': self, 'query': query}
+
+            fig = ax.figure
+            fig.set_size_inches((query.size[0]/100, query.size[1]/100))
+            fig.set_dpi(100)
+
+        if proj_code not in self._axes_cache:
+            fig = plt.figure()
+            ax = fig.add_axes([0, 0, 1, 1], projection=crs)
+            _prepare_axes(ax)
+            self.axes_function(ax)
+            self._axes_cache[proj_code] = ax
+
+        ax = self._axes_cache[proj_code]
+        _prepare_axes(ax)
+
+        data = io.BytesIO()
+        ax.figure.savefig(data, format=str(query.format), dpi=100, transparent=True)
+        data.seek(0)
+        log_request('%s:%s:%s:%s' % (proj_code, query.bbox, query.srs.srs_code, query.size),
+                    status='200', method='API', duration=time.time()-start_time)
+        return ImageSource(data, size=query.size,
+                           image_opts=ImageOptions(transparent=self.transparent,
+                                                   format=query.format))


### PR DESCRIPTION
This isn't so much a request to merge as a request for some guidance, which I would greatly appreciate.

I have put together the necessary pieces to render requests using cartopy's matplotlib backend (I am also the author of cartopy). Being able to render with cartopy has some big benefits, not so much as a cartographic visualisation tool such as mapnik, but more as a geospatial data visualisation tool. With this kind of capability, it would be trivial to publish geospatial scientific data visualisations from sources such as NetCDF, GRIB and even bespoke formats for things like unstructured grids.

I have put together a [sample configuration](https://gist.github.com/pelson/80e8038fad80e1febdfb91f9a262aaa8) which is running on Heroku so that you can [see the code in action](https://rawgit.com/pelson/682c09838cb3f93cef77922b12fb0ed5/raw/ec2f6747ccf0b74efeafb37ae1ed4fc199fb21cb/). I'm super pleased by outcome, and have been really impressed with the quality of the MapProxy codebase.

What I'd love to discuss is a healthy way to take this forwards. I would be more than happy to maintain the code, and would be happy for this to live in cartopy itself; unfortunately though, there don't appear to be sufficient hooks to make this practical currently. One option would be to make the config loader extensible (through entrypoints or some other import time mechanism), or for some part of the codebase (CartopySource) to live externally, and for the CartopyConfiguration to know about the source.

I'm sure there is plenty to think about in terms of structuring this, and would greatly value your input.

Thanks,
