### PR TITLE
Disable tests that require network via OFFLINE_TESTS env var.

### DIFF
--- a/mapproxy/test/system/test_util_wms_capabilities.py
+++ b/mapproxy/test/system/test_util_wms_capabilities.py
@@ -17,6 +17,7 @@ from __future__ import with_statement
 import os
 
 from nose.tools import assert_raises
+from nose.plugins.skip import SkipTest
 
 from mapproxy.client.http import HTTPClient
 from mapproxy.script.wms_capabilities import wms_capabilities_command
@@ -36,6 +37,9 @@ class TestUtilWMSCapabilities(object):
         self.args = ['command_dummy', '--host', TESTSERVER_URL + '/service']
 
     def test_http_error(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         self.args = ['command_dummy', '--host', 'http://foo.doesnotexist']
         with capture() as (out,err):
             assert_raises(SystemExit, wms_capabilities_command, self.args)
@@ -47,6 +51,9 @@ class TestUtilWMSCapabilities(object):
         assert err.getvalue().startswith("ERROR:")
 
     def test_request_not_parsable(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/service?request=GetCapabilities&version=1.1.1&service=WMS', 'method': 'GET'},
                                               {'status': '200', 'body': ''})]):
             with capture() as (out,err):
@@ -55,6 +62,9 @@ class TestUtilWMSCapabilities(object):
             assert error_msg.startswith('Could not parse the document')
 
     def test_service_exception(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         self.args = ['command_dummy', '--host', TESTSERVER_URL + '/service?request=GetCapabilities']
         with open(SERVICE_EXCEPTION_FILE, 'rb') as fp:
             capabilities_doc = fp.read()
@@ -66,6 +76,9 @@ class TestUtilWMSCapabilities(object):
                 assert 'Not a capabilities document' in error_msg
 
     def test_parse_capabilities(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         self.args = ['command_dummy', '--host', TESTSERVER_URL + '/service?request=GetCapabilities', '--version', '1.1.1']
         with open(CAPABILITIES111_FILE, 'rb') as fp:
             capabilities_doc = fp.read()
@@ -77,6 +90,9 @@ class TestUtilWMSCapabilities(object):
                 assert lines[1].startswith('Capabilities Document Version 1.1.1')
 
     def test_parse_130capabilities(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         self.args = ['command_dummy', '--host', TESTSERVER_URL + '/service?request=GetCapabilities', '--version', '1.3.0']
         with open(CAPABILITIES130_FILE, 'rb') as fp:
             capabilities_doc = fp.read()
@@ -88,6 +104,9 @@ class TestUtilWMSCapabilities(object):
                 assert lines[1].startswith('Capabilities Document Version 1.3.0')
 
     def test_key_error(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         self.args = ['command_dummy', '--host', TESTSERVER_URL + '/service?request=GetCapabilities']
         with open(CAPABILITIES111_FILE, 'rb') as fp:
             capabilities_doc = fp.read()

--- a/mapproxy/test/unit/test_cache.py
+++ b/mapproxy/test/unit/test_cache.py
@@ -56,6 +56,7 @@ from mapproxy.test.http import assert_query_eq, wms_query_eq, query_eq, mock_htt
 from collections import defaultdict
 
 from nose.tools import eq_, raises, assert_not_equal, assert_raises
+from nose.plugins.skip import SkipTest
 
 TEST_SERVER_ADDRESS = ('127.0.0.1', 56413)
 GLOBAL_GEOGRAPHIC_EXTENT = MapExtent((-180, -90, 180, 90), SRS(4326))
@@ -744,6 +745,9 @@ class TestWMSSourceWithClient(object):
         self.source = WMSSource(self.client)
 
     def test_get_map(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         with tmp_image((512, 512)) as img:
             expected_req = ({'path': r'/service?LAYERS=foo&SERVICE=WMS&FORMAT=image%2Fpng'
                                      '&REQUEST=GetMap&HEIGHT=512&SRS=EPSG%3A4326&styles='
@@ -757,6 +761,9 @@ class TestWMSSourceWithClient(object):
                 assert is_png(result.as_buffer(seekable=True))
                 eq_(result.as_image().size, (512, 512))
     def test_get_map_non_image_content_type(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         with tmp_image((512, 512)) as img:
             expected_req = ({'path': r'/service?LAYERS=foo&SERVICE=WMS&FORMAT=image%2Fpng'
                                      '&REQUEST=GetMap&HEIGHT=512&SRS=EPSG%3A4326&styles='
@@ -771,6 +778,9 @@ class TestWMSSourceWithClient(object):
                 else:
                     assert False, 'no SourceError raised'
     def test_basic_auth(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         http_client = HTTPClient(self.req_template.url, username='foo', password='bar@')
         self.client.http_client = http_client
         def assert_auth(req_handler):

--- a/mapproxy/test/unit/test_client.py
+++ b/mapproxy/test/unit/test_client.py
@@ -43,11 +43,17 @@ class TestHTTPClient(object):
         self.client = HTTPClient()
 
     def test_post(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/service?foo=bar', 'method': 'POST'},
                                               {'status': '200', 'body': b''})]):
             self.client.open(TESTSERVER_URL + '/service', data=b"foo=bar")
 
     def test_internal_error_response(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         try:
             with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/'},
                                                   {'status': '500', 'body': b''})]):
@@ -87,6 +93,9 @@ class TestHTTPClient(object):
 
     @attr('online')
     def test_https_no_ssl_module_error(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         from mapproxy.client import http
         old_ssl = http.ssl
         try:
@@ -102,6 +111,9 @@ class TestHTTPClient(object):
 
     @attr('online')
     def test_https_no_ssl_module_insecure(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         from mapproxy.client import http
         old_ssl = http.ssl
         try:
@@ -113,6 +125,9 @@ class TestHTTPClient(object):
 
     @attr('online')
     def test_https_valid_cert(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         try:
             import ssl; ssl
         except ImportError:
@@ -131,6 +146,9 @@ class TestHTTPClient(object):
 
     @attr('online')
     def test_https_invalid_cert(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         try:
             import ssl; ssl
         except ImportError:
@@ -144,6 +162,9 @@ class TestHTTPClient(object):
                 assert_re(e.args[0], r'Could not verify connection to URL')
 
     def test_timeouts(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         test_req = ({'path': '/', 'req_assert_function': lambda x: time.sleep(0.9) or True},
                     {'body': b'nothing'})
 
@@ -209,6 +230,9 @@ class TestTMSClient(object):
     def setup(self):
         self.client = TMSClient(TESTSERVER_URL)
     def test_get_tile(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/9/5/13.png'},
                                                 {'body': b'tile', 'headers': {'content-type': 'image/png'}})]):
             resp = self.client.get_tile((5, 13, 9)).source.read()
@@ -216,6 +240,9 @@ class TestTMSClient(object):
 
 class TestTileClient(object):
     def test_tc_path(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         template = TileURLTemplate(TESTSERVER_URL + '/%(tc_path)s.png')
         client = TileClient(template)
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/09/000/000/005/000/000/013.png'},
@@ -225,6 +252,9 @@ class TestTileClient(object):
             eq_(resp, b'tile')
 
     def test_quadkey(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         template = TileURLTemplate(TESTSERVER_URL + '/key=%(quadkey)s&format=%(format)s')
         client = TileClient(template)
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/key=000002303&format=png'},
@@ -233,6 +263,9 @@ class TestTileClient(object):
             resp = client.get_tile((5, 13, 9)).source.read()
             eq_(resp, b'tile')
     def test_xyz(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         template = TileURLTemplate(TESTSERVER_URL + '/x=%(x)s&y=%(y)s&z=%(z)s&format=%(format)s')
         client = TileClient(template)
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/x=5&y=13&z=9&format=png'},
@@ -242,6 +275,9 @@ class TestTileClient(object):
             eq_(resp, b'tile')
 
     def test_arcgiscache_path(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         template = TileURLTemplate(TESTSERVER_URL + '/%(arcgiscache_path)s.png')
         client = TileClient(template)
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/L09/R0000000d/C00000005.png'},
@@ -251,6 +287,9 @@ class TestTileClient(object):
             eq_(resp, b'tile')
 
     def test_bbox(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         grid = tile_grid(4326)
         template = TileURLTemplate(TESTSERVER_URL + '/service?BBOX=%(bbox)s')
         client = TileClient(template, grid=grid)

--- a/mapproxy/test/unit/test_tiled_source.py
+++ b/mapproxy/test/unit/test_tiled_source.py
@@ -15,6 +15,8 @@
 
 from __future__ import with_statement
 
+import os
+
 from mapproxy.client.tile import TMSClient
 from mapproxy.grid import TileGrid
 from mapproxy.srs import SRS
@@ -24,6 +26,7 @@ from mapproxy.layer import MapQuery
 
 from mapproxy.test.http import mock_httpd
 from nose.tools import eq_
+from nose.plugins.skip import SkipTest
 
 TEST_SERVER_ADDRESS = ('127.0.0.1', 56413)
 TESTSERVER_URL = 'http://%s:%d' % TEST_SERVER_ADDRESS
@@ -34,6 +37,9 @@ class TestTileClientOnError(object):
         self.client = TMSClient(TESTSERVER_URL)
 
     def test_cacheable_response(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         error_handler = HTTPSourceErrorHandler()
         error_handler.add_handler(500, (255, 0, 0), cacheable=True)
         self.source = TiledSource(self.grid, self.client, error_handler=error_handler)
@@ -45,6 +51,9 @@ class TestTileClientOnError(object):
             eq_(resp.as_image().getcolors(), [((256*256), (255, 0, 0))])
 
     def test_image_response(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         error_handler = HTTPSourceErrorHandler()
         error_handler.add_handler(500, (255, 0, 0), cacheable=False)
         self.source = TiledSource(self.grid, self.client, error_handler=error_handler)
@@ -56,6 +65,9 @@ class TestTileClientOnError(object):
             eq_(resp.as_image().getcolors(), [((256*256), (255, 0, 0))])
 
     def test_multiple_image_responses(self):
+        if 'OFFLINE_TESTS' in os.environ:
+            raise SkipTest
+
         error_handler = HTTPSourceErrorHandler()
         error_handler.add_handler(500, (255, 0, 0), cacheable=False)
         error_handler.add_handler(204, (255, 0, 127, 200), cacheable=True)


### PR DESCRIPTION
Skipping the tests that require network connectivity is required for the Debian package builds whose build environment doesn't have network connectivity per [Debian Policy section 4.9](https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules).

The tests are only skipped when the OFFLINE_TESTS environment variable is present.
