### PR TITLE
Disable tag_date for reproducible builds.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ with-doctest = 1
 
 [egg_info]
 #tag_build = .dev
-tag_date = true
+tag_date = false
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
See: https://wiki.debian.org/ReproducibleBuilds/TimestampsInPythonVersionNumbers