### PR TITLE
Fix 'configration' typo, replace with 'configuration'.

### DIFF
--- a/doc/seed.rst
+++ b/doc/seed.rst
@@ -21,7 +21,7 @@ Options
 
 .. option:: -s <seed.yaml>, --seed-conf==<seed.yaml>
 
-  The seed configuration. You can also pass the configration as the last argument to ``mapproxy-seed``
+  The seed configuration. You can also pass the configuration as the last argument to ``mapproxy-seed``
 
 .. option:: -f <mapproxy.yaml>, --proxy-conf=<mapproxy.yaml>
 


### PR DESCRIPTION
The spelling error was reported by the lintian QA tool for the Debian package build.