### PR TITLE
Improve FeatureInfo requests

### DIFF
--- a/mapproxy/client/wms.py
+++ b/mapproxy/client/wms.py
@@ -134,18 +134,21 @@ class WMSInfoClient(object):
         """
         req_srs = query.srs
         req_bbox = query.bbox
+        req_coord = make_lin_transf((0, 0, query.size[0], query.size[1]), req_bbox)(query.pos)
+
         info_srs = self._best_supported_srs(req_srs)
         info_bbox = req_srs.transform_bbox_to(info_srs, req_bbox)
-
-        req_coord = make_lin_transf((0, query.size[1], query.size[0], 0), req_bbox)(query.pos)
+        # calculate new info_size to keep square pixels after transform_bbox_to
+        info_aratio = (info_bbox[3] - info_bbox[1])/(info_bbox[2] - info_bbox[0])
+        info_size = query.size[0], int(info_aratio*query.size[0])
 
         info_coord = req_srs.transform_to(info_srs, req_coord)
-        info_pos = make_lin_transf((info_bbox), (0, query.size[1], query.size[0], 0))(info_coord)
+        info_pos = make_lin_transf((info_bbox), (0, 0, info_size[0], info_size[1]))(info_coord)
         info_pos = int(round(info_pos[0])), int(round(info_pos[1]))
 
         info_query = InfoQuery(
             bbox=info_bbox,
-            size=query.size,
+            size=info_size,
             srs=info_srs,
             pos=info_pos,
             info_format=query.info_format,

--- a/mapproxy/layer.py
+++ b/mapproxy/layer.py
@@ -152,7 +152,7 @@ class InfoQuery(object):
 
     @property
     def coord(self):
-        return make_lin_transf((0, self.size[1], self.size[0], 0), self.bbox)(self.pos)
+        return make_lin_transf((0, 0, self.size[0], self.size[1]), self.bbox)(self.pos)
 
 class LegendQuery(object):
     def __init__(self, format, scale):

--- a/mapproxy/test/system/test_auth.py
+++ b/mapproxy/test/system/test_auth.py
@@ -264,7 +264,7 @@ class TestWMSAuth(SystemTest):
             return {
                 'authorized': 'partial',
                 'layers': {
-                    'layer1b': {'featureinfo': True, 'limited_to':  {'srs': 'EPSG:4326', 'geometry': [-40.0, -40.0, 0.0, 0.0]}},
+                    'layer1b': {'featureinfo': True, 'limited_to':  {'srs': 'EPSG:4326', 'geometry': [-80.0, -40.0, 0.0, -10.0]}},
                 }
             }
 

--- a/mapproxy/test/system/test_wms.py
+++ b/mapproxy/test/system/test_wms.py
@@ -528,17 +528,17 @@ class TestWMS111(WMSTest):
 
     def test_get_featureinfo_transformed(self):
         expected_req = ({'path': r'/service?LAYERs=foo,bar&SERVICE=WMS&FORMAT=image%2Fpng'
-                                  '&REQUEST=GetFeatureInfo&HEIGHT=200&SRS=EPSG%3A900913'
+                                  '&REQUEST=GetFeatureInfo&HEIGHT=212&SRS=EPSG%3A900913'
                                   '&BBOX=5197367.93088,5312902.73895,5311885.44223,5434731.78213'
                                   '&styles=&VERSION=1.1.1&feature_count=100'
-                                  '&WIDTH=200&QUERY_LAYERS=foo,bar&X=14&Y=78'},
+                                  '&WIDTH=200&QUERY_LAYERS=foo,bar&X=70&Y=18'},
                         {'body': b'info', 'headers': {'content-type': 'text/plain'}})
 
         # out fi point at x=10,y=20
-        p_25832  = (3570269+10*(3643458 - 3570269)/200, 5540889+20*(5614078 - 5540889)/200)
-        # the transformed fi point at x=10,y=22
-        p_900913 = (5197367.93088+14*(5311885.44223 - 5197367.93088)/200,
-                    5312902.73895+78*(5434731.78213 - 5312902.73895)/200)
+        p_25832  = (3570269+10*(3643458 - 3570269)/200, 5614078-20*(5614078 - 5540889)/200)
+        # the transformed fi point at x=70,y=18
+        p_900913 = (5197367.93088+70*(5311885.44223 - 5197367.93088)/200,
+                    5434731.78213-18*(5434731.78213 - 5312902.73895)/212)
 
         # are they the same?
         # check with tolerance: pixel resolution is ~570 and x/y position is rounded to pizel

--- a/mapproxy/test/unit/test_client.py
+++ b/mapproxy/test/unit/test_client.py
@@ -296,32 +296,32 @@ class TestWMSInfoClient(object):
         http = MockHTTPClient()
         wms = WMSInfoClient(req, http_client=http, supported_srs=[SRS(25832)])
         fi_req = InfoQuery((8, 50, 9, 51), (512, 512),
-                           SRS(4326), (256, 256), 'text/plain')
+                           SRS(4326), (128, 64), 'text/plain')
 
         wms.get_info(fi_req)
 
         assert wms_query_eq(http.requested[0],
             TESTSERVER_URL+'/service?map=foo&LAYERS=foo&SERVICE=WMS&FORMAT=image%2Fpng'
-                           '&REQUEST=GetFeatureInfo&HEIGHT=512&SRS=EPSG%3A25832&info_format=text/plain'
+                           '&REQUEST=GetFeatureInfo&SRS=EPSG%3A25832&info_format=text/plain'
                            '&query_layers=foo'
-                           '&VERSION=1.1.1&WIDTH=512&STYLES=&x=259&y=255'
-                           '&BBOX=428333.552496,5538630.70275,500000.0,5650300.78652')
+                           '&VERSION=1.1.1&WIDTH=512&HEIGHT=797&STYLES=&x=135&y=101'
+                           '&BBOX=428333.552496,5538630.70275,500000.0,5650300.78652'), http.requested[0]
 
     def test_transform_fi_request(self):
         req = WMS111FeatureInfoRequest(url=TESTSERVER_URL + '/service?map=foo', param={'layers':'foo', 'srs': 'EPSG:25832'})
         http = MockHTTPClient()
         wms = WMSInfoClient(req, http_client=http)
         fi_req = InfoQuery((8, 50, 9, 51), (512, 512),
-                           SRS(4326), (256, 256), 'text/plain')
+                           SRS(4326), (128, 64), 'text/plain')
 
         wms.get_info(fi_req)
 
         assert wms_query_eq(http.requested[0],
             TESTSERVER_URL+'/service?map=foo&LAYERS=foo&SERVICE=WMS&FORMAT=image%2Fpng'
-                           '&REQUEST=GetFeatureInfo&HEIGHT=512&SRS=EPSG%3A25832&info_format=text/plain'
+                           '&REQUEST=GetFeatureInfo&SRS=EPSG%3A25832&info_format=text/plain'
                            '&query_layers=foo'
-                           '&VERSION=1.1.1&WIDTH=512&STYLES=&x=259&y=255'
-                           '&BBOX=428333.552496,5538630.70275,500000.0,5650300.78652')
+                           '&VERSION=1.1.1&WIDTH=512&HEIGHT=797&STYLES=&x=135&y=101'
+                           '&BBOX=428333.552496,5538630.70275,500000.0,5650300.78652'), http.requested[0]
 
 class TestWMSMapRequest100(object):
     def setup(self):

--- a/mapproxy/test/unit/test_wms_layer.py
+++ b/mapproxy/test/unit/test_wms_layer.py
@@ -15,7 +15,7 @@
 
 from __future__ import with_statement, division
 
-from mapproxy.layer import MapQuery
+from mapproxy.layer import MapQuery, InfoQuery
 from mapproxy.srs import SRS
 from mapproxy.service.wms import combined_layers
 from nose.tools import eq_
@@ -76,3 +76,9 @@ class TestCombinedLayers(object):
         eq_(combined[1].client.request_template.params.layers, ['c', 'd'])
         eq_(combined[2].client.request_template.params.layers, ['e', 'f'])
 
+
+class TestInfoQuery(object):
+    def test_coord(self):
+        query = InfoQuery((8, 50, 9, 51), (400, 1000),
+                           SRS(4326), (100, 600), 'text/plain')
+        eq_(query.coord, (8.25, 50.4))


### PR DESCRIPTION
- fix featureinto requests that require transformations where the aspect ratio of the transformed bbox is different (e.g. EPSG:4326 -> EPSG:3857)
- fix featureinfo for limited layers (closes #215)