### PR TITLE
Fix link to TMS layer capabilities on demo page

### DIFF
--- a/mapproxy/service/templates/demo/demo.html
+++ b/mapproxy/service/templates/demo/demo.html
@@ -162,7 +162,7 @@ jscript_openlayers=None
                     {{if layer.grid.supports_access_with_origin('sw')}}
                     <td class="value"><a href="../demo/?tms_layer={{layer.name}}&format={{layer.format}}&srs={{layer.grid.srs.srs_code | quote}}">{{layer.grid.srs.srs_code}}</a></td>
                     <td class="value"><a href="../demo/?tms_layer={{layer.name}}&format={{layer.format}}&srs={{layer.grid.srs.srs_code | quote}}">{{layer.format}}</a></td>
-                    <td class="value"><a href="../demo/?tms_capabilities&layer={{layer.name}}&srs={{layer.md['name_path'][1]}}">click here</a></td>
+                    <td class="value"><a href="../demo/?tms_capabilities&layer={{layer.name}}&srs={{layer.grid.srs.srs_code | quote}}">click here</a></td>
                     {{else}}
                     <td class="value" colspan="3">
                         {{layer.grid.name}} not compatible with TMS

--- a/mapproxy/service/templates/demo/tms_demo.html
+++ b/mapproxy/service/templates/demo/tms_demo.html
@@ -32,7 +32,7 @@ function init(){
     map = new OpenLayers.Map('map', mapOptions);
 
     var layer = new OpenLayers.Layer.TMS('TMS {{layer.name}}', '../tms/',
-        {layername: '{{"/".join(layer.md["name_path"])}}', type: '{{format}}',
+        {layername: '{{layer.name}}/{{layer.grid.srs.srs_code}}', type: '{{format}}',
          tileSize: new OpenLayers.Size{{layer.grid.tile_size}}
     });
 


### PR DESCRIPTION
Given a configuration like:

```
grids:
  'EPSG:3857': {base: GLOBAL_WEBMERCATOR}
services:
  demo: {}
  tms: {use_grid_names: true}
caches:
  cache1:
    cache: ...
    format: image/png
    grids: ['EPSG:3857']
```

The link on the demo page pointing to a TMS layer capabilities is broken: the `srs` query parameter has a value of `EPSG3857` whereas it should have been `EPSG:3857`.
