### PR TITLE
Remove unused references to "lock_timeout" in file/S3 cache implementations

### DIFF
--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -31,7 +31,7 @@ class FileCache(TileCacheBase):
     This class is responsible to store and load the actual tile data.
     """
     def __init__(self, cache_dir, file_ext, directory_layout='tc',
-                 link_single_color_images=False, lock_timeout=60.0):
+                 link_single_color_images=False):
         """
         :param cache_dir: the path where the tile will be stored
         :param file_ext: the file extension that will be appended to

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -50,7 +50,7 @@ class S3ConnectionError(Exception):
 class S3Cache(TileCacheBase):
 
     def __init__(self, base_path, file_ext, directory_layout='tms',
-                 lock_timeout=60.0, bucket_name='mapproxy', profile_name=None):
+                 bucket_name='mapproxy', profile_name=None):
         super(S3Cache, self).__init__()
         self.lock_cache_id = hashlib.md5(base_path.encode('utf-8') + bucket_name.encode('utf-8')).hexdigest()
         self.bucket_name = bucket_name

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1018,13 +1018,10 @@ class CacheConfiguration(ConfigurationBase):
             log.warn('link_single_color_images not supported on windows')
             link_single_color_images = False
 
-        lock_timeout = self.context.globals.get_value('http.client_timeout', {})
-
         return FileCache(
             cache_dir,
             file_ext=file_ext,
             directory_layout=directory_layout,
-            lock_timeout=lock_timeout,
             link_single_color_images=link_single_color_images,
         )
 

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -46,7 +46,6 @@ class TestS3Cache(TileCacheTestBase):
         self.cache = S3Cache(dir_name,
             file_ext='png',
             directory_layout='tms',
-            lock_timeout=10,
             bucket_name=self.bucket_name,
             profile_name=None,
         )


### PR DESCRIPTION
I am probably overlooking something obvious but it seemed to me that the `lock_timeout` parameter is simply ignored in the file and S3 cache implementations.
So I propose to remove it to improve code readability.
