### PR TITLE
Support "tile_lock_dir" configuration property for S3 cache

### DIFF
--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -136,6 +136,7 @@ cache_types = {
         'bucket_name': str(),
         'directory_layout': str(),
         'directory': str(),
+        'tile_lock_dir': str(),
         'profile_name': str(),
      },
     'riak': {


### PR DESCRIPTION
For some reason, the S3 cache does not seem to currently support the `tile_lock_dir` configuration property:
```2016-10-31 21:35:42,697 - WARNING - mapproxy.config - unknown 'tile_lock_dir' in caches.cache_ABC.cache```