### PR TITLE
Add support for configurable layer advertisement

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1544,7 +1544,8 @@ class WMSLayerConfiguration(ConfigurationBase):
             layer = this_layer
         else:
             layer = WMSGroupLayer(name=self.conf.get('name'), title=self.conf.get('title'),
-                                  this=this_layer, layers=layers, md=self.conf.get('md'))
+                                  this=this_layer, layers=layers, md=self.conf.get('md'),
+                                  advertised=self.conf.get('advertised', True))
         return layer
 
 def cache_source_names(context, cache):
@@ -1613,7 +1614,8 @@ class LayerConfiguration(ConfigurationBase):
         res_range = resolution_range(self.conf)
 
         layer = WMSLayer(self.conf.get('name'), self.conf.get('title'),
-                         sources, fi_sources, lg_sources, res_range=res_range, md=self.conf.get('md'))
+                         sources, fi_sources, lg_sources, res_range=res_range, md=self.conf.get('md'),
+                         advertised=self.conf.get('advertised', True))
         return layer
 
     @memoize
@@ -1679,7 +1681,8 @@ class LayerConfiguration(ConfigurationBase):
                 md['cache_name'] = cache_name
                 md['extent'] = extent
                 tile_layers.append(TileLayer(self.conf['name'], self.conf['title'],
-                                             md, cache_source, dimensions=dimensions))
+                                             md, cache_source, dimensions=dimensions,
+                                             advertised=self.conf.get('advertised', True)))
 
         return tile_layers
 

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -543,6 +543,7 @@ mapproxy_yaml_spec = {
             'tile_sources': [string_type],
             'name': str(),
             required('title'): string_type,
+            'advertised': bool(),
             'legendurl': str(),
             'layers': recursive(),
             'md': wms_130_layer_md,

--- a/mapproxy/service/templates/tms_capabilities.xml
+++ b/mapproxy/service/templates/tms_capabilities.xml
@@ -4,10 +4,12 @@
     <Abstract>{{service.abstract}}</Abstract>
     <TileMaps>
 {{for layer in layers.values()}}
+{{if layer.advertised}}
         <TileMap title="{{layer.title}}"
                  srs="{{layer.grid.srs_name}}"
                  profile="{{layer.grid.profile}}"
                  href="{{service.url.rstrip('/')}}/{{'/'.join(layer.md['name_path'])}}" />
+{{endif}}
 {{endfor}}
     </TileMaps>
 </TileMapService>

--- a/mapproxy/service/templates/wms100capabilities.xml
+++ b/mapproxy/service/templates/wms100capabilities.xml
@@ -67,6 +67,7 @@
   </Exception>
 
 {{def layer_capabilities(layer, with_srs)}}
+{{if layer.advertised}}
   <Layer{{if layer.queryable}} queryable="1"{{endif}}>
     {{if layer.name}}
     <Name>{{ layer.name }}</Name>
@@ -93,6 +94,7 @@
 {{layer_capabilities(layer, False)|indent}}
     {{endfor}}
   </Layer>
+{{endif}}
 {{enddef}}
 
 {{layer_capabilities(layers, True)}}

--- a/mapproxy/service/templates/wms110capabilities.xml
+++ b/mapproxy/service/templates/wms110capabilities.xml
@@ -102,6 +102,7 @@
 {{endif}}
 
 {{def layer_capabilities(layer, with_srs)}}
+{{if layer.advertised}}
   <Layer{{if layer.queryable}} queryable="1"{{endif}}>
     {{if layer.name}}
     <Name>{{ layer.name }}</Name>
@@ -133,6 +134,7 @@
 {{layer_capabilities(layer, False)|indent}}
     {{endfor}}
   </Layer>
+{{endif}}
 {{enddef}}
 
 {{layer_capabilities(layers, True)}}

--- a/mapproxy/service/templates/wms111capabilities.xml
+++ b/mapproxy/service/templates/wms111capabilities.xml
@@ -114,6 +114,7 @@
 {{endif}}
 
 {{def layer_capabilities(layer, with_srs)}}
+{{if layer.advertised}}
   <Layer{{if layer.queryable}} queryable="1"{{endif}}>
     {{if layer.name}}
     <Name>{{ layer.name }}</Name>
@@ -164,6 +165,7 @@
 {{layer_capabilities(layer, False)|indent}}
     {{endfor}}
   </Layer>
+{{endif}}
 {{enddef}}
 
 {{layer_capabilities(layers, True)}}

--- a/mapproxy/service/templates/wms130capabilities.xml
+++ b/mapproxy/service/templates/wms130capabilities.xml
@@ -198,7 +198,7 @@
 {{endif}}
 {{def layer_capabilities(layer, with_srs)}}
   {{py: md = bunch(default='', **layer.md)}}
-
+{{if layer.advertised}}
   <Layer{{if layer.queryable}} queryable="1"{{endif}}>
     {{if layer.name}}
     <Name>{{ layer.name }}</Name>
@@ -291,6 +291,7 @@
 {{layer_capabilities(layer, False)|indent}}
     {{endfor}}
   </Layer>
+{{endif}}
 {{enddef}}
 
 {{def layer_meta_tag(tag, config)}}

--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -64,6 +64,7 @@
 {{endif}}
   <Contents>
 {{for layer in layers}}
+{{if layer.advertised}}
     <Layer>
       <ows:Title>{{layer.title}}</ows:Title>
       <ows:Abstract></ows:Abstract>
@@ -95,6 +96,7 @@
           template="{{format_resource_template(layer, resource_template, service)}}"/>
       {{endif}}
     </Layer>
+{{endif}}
 {{endfor}}
 {{for tile_matrix_set in tile_matrix_sets}}
     <TileMatrixSet>

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -203,13 +203,14 @@ class TileServer(Server):
         return template.substitute(service=bunch(default='', **service))
 
 class TileLayer(object):
-    def __init__(self, name, title, md, tile_manager, dimensions=None):
+    def __init__(self, name, title, md, tile_manager, dimensions=None, advertised=True):
         """
         :param md: the layer metadata
         :param tile_manager: the layer tile manager
         """
         self.name = name
         self.title = title
+        self.advertised = advertised
         self.md = md
         self.tile_manager = tile_manager
         self.dimensions = dimensions

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -654,9 +654,10 @@ class WMSLayer(WMSLayerBase):
     is_active = True
     layers = []
     def __init__(self, name, title, map_layers, info_layers=[], legend_layers=[],
-                 res_range=None, md=None):
+                 res_range=None, md=None, advertised=True):
         self.name = name
         self.title = title
+        self.advertised = advertised
         self.md = md or {}
         self.map_layers = map_layers
         self.info_layers = info_layers
@@ -720,9 +721,10 @@ class WMSGroupLayer(WMSLayerBase):
     Groups multiple wms layers, but can also contain a single layer (``this``)
     that represents this layer.
     """
-    def __init__(self, name, title, this, layers, md=None):
+    def __init__(self, name, title, this, layers, md=None, advertised=True):
         self.name = name
         self.title = title
+        self.advertised = advertised
         self.this = this
         self.md = md or {}
         self.is_active = True if this is not None else False


### PR DESCRIPTION
Here's a quick implementation of a new "advertised" property for layers, as you can find in GeoServer for example.
The goal is simply to hide the layer from the WMS / WMTS / TMS capabilities document.
Before spending more time on it (i.e. for unit tests & doc), I'd like to know if this feature would be deemed useful to be integrated.