### PR TITLE
Caches mapnik map objects per process/thread

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -893,16 +893,9 @@ class MapnikSourceConfiguration(SourceConfiguration):
         if mapnik_api is None:
             raise ConfigurationError('Could not import Mapnik, please verify it is installed!')
 
-        if self.context.renderd:
-            # only renderd guarantees that we have a single proc/thread
-            # that accesses the same mapnik map object
-            reuse_map_objects = True
-        else:
-            reuse_map_objects = False
-
         return MapnikSource(mapfile, layers=layers, image_opts=image_opts,
             coverage=coverage, res_range=res_range, lock=lock,
-            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor)
+            scale_factor=scale_factor)
 
 class TileSourceConfiguration(SourceConfiguration):
     supports_meta_tiles = False


### PR DESCRIPTION
Sorry create this PR again from the correct branch.

I've determined that the mapproxy mapnik source class is not caching mapnik objects during the seeding process if multi-processing is used. This means mapnik map objects are unnecessarily constructed for each set of tile renders. The current code is designed to not reuse mapnik objects across proccess/thread because of unsafe sharing of database connections and filehandles.

This PR now reuses mapnik map objects when multi-processing is used by caching mapnik map objects by process/thread to ensure safe sharing of objects. I have also removed the reuse_map_objects parameter from the mapnik source class constructor as this is no longer required.

In my testing this results in up to 500% seeding performance increase when using parallel seed processes.
