### PR TITLE
Pass resolution range through to WMS source from ArcGIS source.

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -621,10 +621,12 @@ class ArcGISSourceConfiguration(SourceConfiguration):
         request = create_request(self.conf["req"], params)
         http_client, request.url = self.http_client(request.url)
         coverage = self.coverage()
+        res_range = resolution_range(self.conf)
 
         client = ArcGISClient(request, http_client)
         image_opts = self.image_opts(format=params.get('format'))
         return ArcGISSource(client, image_opts=image_opts, coverage=coverage,
+                            res_range=res_range,
                             supported_srs=supported_srs,
                             supported_formats=supported_formats or None)
 

--- a/mapproxy/source/arcgis.py
+++ b/mapproxy/source/arcgis.py
@@ -21,9 +21,11 @@ log = logging.getLogger('mapproxy.source.arcgis')
 
 class ArcGISSource(WMSSource):
     def __init__(self, client, image_opts=None, coverage=None,
-                 supported_srs=None, supported_formats=None):
-        WMSSource.__init__(self, client, image_opts=image_opts, coverage=coverage,
-                           supported_srs=supported_srs, supported_formats=supported_formats)
+                 res_range=None, supported_srs=None, supported_formats=None):
+        WMSSource.__init__(self, client, image_opts=image_opts,
+                           coverage=coverage, res_range=res_range,
+                           supported_srs=supported_srs,
+                           supported_formats=supported_formats)
 
 
 class ArcGISInfoSource(WMSInfoSource):


### PR DESCRIPTION
I found that the `min_res` and `max_res` parameters had no effect on an ArcGIS source, even though they are supported for WMS sources.

This PR adds code to parse those parameters for ArcGIS sources and pass the resulting `res_range` through from `ArcGISSource` to `WMSSource`.