### PR TITLE
add missing comma in response header

### DIFF
--- a/mapproxy/response.py
+++ b/mapproxy/response.py
@@ -91,7 +91,7 @@ class Response(object):
 
         self.last_modified = timestamp
         if (timestamp or etag_data) and max_age is not None:
-            self.headers['Cache-control'] = 'max-age=%d public' % max_age
+            self.headers['Cache-control'] = 'public, max-age=%d, s-maxage=%d' % (max_age, max_age)
 
     def make_conditional(self, req):
         """

--- a/mapproxy/test/system/test_kml.py
+++ b/mapproxy/test/system/test_kml.py
@@ -88,7 +88,7 @@ class TestKML(SystemTest):
             assert 'Last-modified' not in resp.headers
         else:
             eq_(resp.headers['Last-modified'], format_httpdate(timestamp))
-        eq_(resp.headers['Cache-control'], 'max-age=%d public' % max_age)
+        eq_(resp.headers['Cache-control'], 'public, max-age=%d, s-maxage=%d' % (max_age, max_age))
 
     def test_get_cached_tile(self):
         etag, max_age = self._update_timestamp()

--- a/mapproxy/test/system/test_tms.py
+++ b/mapproxy/test/system/test_tms.py
@@ -179,7 +179,7 @@ class TestTileService(SystemTest):
     def _check_cache_control_headers(self, resp, etag, max_age):
         eq_(resp.headers['ETag'], etag)
         eq_(resp.headers['Last-modified'], 'Fri, 13 Feb 2009 23:31:30 GMT')
-        eq_(resp.headers['Cache-control'], 'max-age=%d public' % max_age)
+        eq_(resp.headers['Cache-control'], 'public, max-age=%d, s-maxage=%d' % (max_age, max_age))
 
     def test_get_cached_tile(self):
         etag, max_age = self._update_timestamp()


### PR DESCRIPTION
This fixes non working client cache due to wrong http header format. We have issues with browsers and JOSM.
Directive `s-maxage` lets to store tiles in reverse proxy caches, so it might improve overall performance for people, who share same connection to internet.