### PR TITLE
Remove sqlite temp files on clean up level cache

### DIFF
--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import with_statement
+import glob
 import hashlib
 import os
 import sqlite3
@@ -28,6 +29,10 @@ from mapproxy.compat import BytesIO, PY2, itertools
 
 import logging
 log = logging.getLogger(__name__)
+
+if not hasattr(glob, 'escape'):
+    import re
+    glob.escape = lambda pathname: re.sub(r'([*?[])', r'[\1]', pathname)
 
 def sqlite_datetime_to_timestamp(datetime):
     if datetime is None:
@@ -381,6 +386,8 @@ class MBTilesLevelCache(TileCacheBase):
         if timestamp == 0:
             level_cache.cleanup()
             os.unlink(level_cache.mbtile_file)
+            for file in glob.glob("%s-*" % glob.escape(level_cache.mbtile_file)):
+                os.unlink(file)
             return True
         else:
             return level_cache.remove_level_tiles_before(level, timestamp)


### PR DESCRIPTION
In some cases temporary sqlite files may remain when deleting a sqlite
cache level, in particular WAL and shared memory files when WAL is
enabled.

Failing to delete these files raises an error when trying to recreate a
level's cache.

Information on sqlite temp files: https://www.sqlite.org/tempfiles.html