### PR TITLE
Advertise MaxWidth/MaxHeight as square root of max_output_pixels

### DIFF
--- a/mapproxy/service/templates/wms130capabilities.xml
+++ b/mapproxy/service/templates/wms130capabilities.xml
@@ -41,6 +41,10 @@
 {{endif}}
     <Fees>{{service.get('fees', 'none')}}</Fees>
     <AccessConstraints>{{service.get('access_constraints', 'none')}}</AccessConstraints>
+{{if max_output_size}}
+    <MaxWidth>{{max_output_size[0]}}</MaxWidth>
+    <MaxHeight>{{max_output_size[1]}}</MaxHeight>
+{{endif}}
 </Service>
 
 <Capability>


### PR DESCRIPTION
Related to issue https://github.com/mapproxy/mapproxy/issues/313. If we would like to map values of max_output_pixels (in case of max_output_pixels is a list) to MaxWidth and MaxHeight then we have to change WMSServer's [constructor](https://github.com/mapproxy/mapproxy/blob/master/mapproxy/config/loader.py#L1901) signature.