### PR TITLE
Support for HTTP cookies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Nightly
+~~~~~~~~~~~~~~~~~
+
+Improvements:
+
+- Support cookie management for HTTP sources.
+
+
 1.11.0 2017-11-20
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -968,6 +968,16 @@ Add additional HTTP headers to all requests to your sources.
 
 Sets the ``Access-control-allow-origin`` header to HTTP responses for `Cross-origin resource sharing <http://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_. This header is required for WebGL or Canvas web clients. Defaults to `*`. Leave empty to disable the header. This option is only available in `globals`.
 
+``manage_cookies``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 1.12.0
+
+Enables MapProxy cookie management for HTTP sources. When enabled MapProxy will accept and store server cookies. Accepted cookies will be passed 
+back to the source on subsequent requests. Usefull for sources which require to maintain an HTTP session to work efficiently, maybe in combination
+with basic authentication. Depending on your deployment MapProxy will still start multiple sessions (e.g. one per MapProxy process). 
+At least after a restart new sessions will be started.
+Cookie handling is based on Python `CookieJar <https://docs.python.org/3/library/http.cookiejar.html>`_. Disabled by default.
 
 ``tiles``
 """"""""""

--- a/doc/configuration_examples.rst
+++ b/doc/configuration_examples.rst
@@ -701,6 +701,8 @@ You can disable the certificate verification if you you don't need it.
       url: https://username:mypassword@example.org/service?
       layers: securelayer
 
+.. note:: Regarding authentication see issue `Basic auth header not added to request <https://github.com/mapproxy/mapproxy/issues/182>`_.
+
 .. _http_proxy:
 
 Access sources through HTTP proxy
@@ -726,11 +728,28 @@ You can also set this in your :ref:`server script <server_script>`::
 
 Add a username and password to the URL if your HTTP proxy requires authentication. For example ``http://username:password@example.com:3128``.
 
+.. note:: Regarding authentication see issue `Basic auth header not added to request <https://github.com/mapproxy/mapproxy/issues/182>`_.
+
 You can use the ``no_proxy`` environment variable if you need to bypass the proxy for some hosts::
 
   $ export no_proxy="localhost,127.0.0.1,196.168.1.99"
 
 ``no_proxy`` is available since Python 2.6.3.
+
+Cookie Management
+==================
+
+MapProxy can handle server cookies of HTTP sources, like browsers do. That is, MapProxy accepts cookies and passes them back
+on subsequent calls::
+
+  sources:
+    wms_with_session_management:
+      type: wms
+      http:
+        manage_cookies: true
+      req:
+        url: http://example.org/service?
+        layers: layer0
 
 .. _paster_urlmap:
 

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -179,6 +179,7 @@ You can configure the following HTTP related options for this source:
 - ``client_timeout``
 - ``ssl_ca_certs``
 - ``ssl_no_cert_checks``
+- ``manage_cookies``
 
 See :ref:`HTTP Options <http_ssl>` for detailed documentation.
 
@@ -386,6 +387,7 @@ You can configure the following HTTP related options for this source:
 - ``client_timeout``
 - ``ssl_ca_certs``
 - ``ssl_no_cert_checks``
+- ``manage_cookies``
 
 See :ref:`HTTP Options <http_ssl>` for detailed documentation.
 

--- a/mapproxy/client/http.py
+++ b/mapproxy/client/http.py
@@ -145,7 +145,7 @@ class _URLOpenerCache(object):
             handlers.append(authhandler)
             authhandler = urllib2.HTTPDigestAuthHandler(passman)
             handlers.append(authhandler)
-            if (manage_cookies):
+            if manage_cookies:
                 cj = CookieJar()
                 handlers.append(HTTPCookieProcessor(cj))
 

--- a/mapproxy/config/defaults.py
+++ b/mapproxy/config/defaults.py
@@ -93,4 +93,5 @@ http = dict(
     concurrent_requests = 0,
     method = 'AUTO',
     access_control_allow_origin = '*',
+    manage_cookies = False,
 )

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -561,10 +561,11 @@ class SourceConfiguration(ConfigurationBase):
 
         timeout = self.context.globals.get_value('http.client_timeout', self.conf)
         headers = self.context.globals.get_value('http.headers', self.conf)
+        manage_cookies = self.context.globals.get_value('http.manage_cookies', self.conf)
 
         http_client = HTTPClient(url, username, password, insecure=insecure,
                                  ssl_ca_certs=ssl_ca_certs, timeout=timeout,
-                                 headers=headers)
+                                 headers=headers, manage_cookies=manage_cookies)
         return http_client, url
 
     @memoize

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -74,6 +74,7 @@ http_opts = {
     'headers': {
         anything(): str()
     },
+    'manage_cookies': bool(),
 }
 
 mapserver_opts = {

--- a/mapproxy/config_template/base_config/full_example.yaml
+++ b/mapproxy/config_template/base_config/full_example.yaml
@@ -425,7 +425,24 @@ sources:
     req:
       # username and password are extracted from the URL and do not show
       # up in log files
+      # ATTENTION: see https://github.com/mapproxy/mapproxy/issues/182
       url: https://username:mypassword@example.org/service?
+      transparent: true
+      layers: securelayer
+
+  # WMS source that requires authentication and session management
+  # through HTTP cookies
+  session_source:
+    type: wms
+    http:
+      # Accept session cookies and forward on subsequent requests
+      manage_cookies: true
+      # Use basic auth header directly
+      # see https://github.com/mapproxy/mapproxy/issues/182
+      headers:
+        Authorization: Basic YWRtaW46Z2Vvc2VydmVy
+    req:
+      url: https://my-service.com/service?
       transparent: true
       layers: securelayer
 


### PR DESCRIPTION
Hi Oliver,
I would like to propose an enhancement: Optional cookie management for HTTP sources (disabled by default).

Background: We have to integrate a proprietary WMS as source, which has difficulties if clients do not support HTTP session management through cookies. In other words: The client (mapproxy) has to accept and pass back session cookies.

I would be glad if you would agree to support such a scenario with MapProxy and accept this contribution.

So: Could you please review the changes? Important: I know almost nothing about python, so please let me know if something is not Ok. Luckily it is quite easy to make MapProxy support cookies. 
I can also offer to adjust the documentation. But before I start working on the docs, please let me know if you can image to accept this.

With best regards,
Andreas