### PR TITLE
Add support for GeoTIFF (Fixes #205) WIP

### DIFF
--- a/mapproxy/image/georeferencing.py
+++ b/mapproxy/image/georeferencing.py
@@ -4,7 +4,6 @@ from mapproxy.srs import get_epsg_num
 import uuid
 
 def get_geotransform(size, bbox):
-    print bbox
     resx = (bbox[2] - bbox[0]) / float(size[0])
     resy = (bbox[3] - bbox[1]) / float(size[1])
     return (bbox[0], resx, 0.0, bbox[3], 0.0, -resy)

--- a/mapproxy/image/georeferencing.py
+++ b/mapproxy/image/georeferencing.py
@@ -1,0 +1,47 @@
+from osgeo import gdal, osr
+from mapproxy.proj import Proj, transform
+from mapproxy.srs import get_epsg_num
+
+def get_geotransform(size, bbox):
+    print bbox
+    resx = (bbox[2] - bbox[0]) / float(size[0])
+    resy = (bbox[3] - bbox[1]) / float(size[1])
+    return (bbox[0], resx, 0.0, bbox[3], 0.0, -resy)
+
+def georeference(image, buffer, srs, bbox):
+    # Open image in gdal
+    gdal.FileFromMemBuffer("/vsimem/tmp.tif", buffer.read())
+    source_dataset = gdal.Open('/vsimem/tmp.tif')
+
+    # Copy to source dataset
+    driver = gdal.GetDriverByName("GTiff")
+    destination_dataset = driver.CreateCopy('/vsimem/dest.tif', source_dataset, 0)
+
+
+    # Georeference
+    gt = get_geotransform(image.size, bbox)
+    destination_dataset.SetGeoTransform(gt)
+    srs2 = osr.SpatialReference()
+    srs2.ImportFromEPSG(get_epsg_num(srs.srs_code))
+    srs_as_wkt = srs2.ExportToWkt()
+    destination_dataset.SetProjection(srs_as_wkt)
+
+    print(gdal.Info(destination_dataset))
+
+    source_dataset = None
+    destination_dataset = None
+    # Convert to buffer
+    f = gdal.VSIFOpenL('/vsimem/dest.tif', 'rb')
+    gdal.VSIFSeekL(f, 0, 2) # seek to end
+    size = gdal.VSIFTellL(f)
+    print "size: " + str(size)
+    gdal.VSIFSeekL(f, 0, 0) # seek to beginning
+    georeferenced_buffer = gdal.VSIFReadL(1, size, f)
+    print len(georeferenced_buffer)
+    gdal.VSIFCloseL(f)
+
+    # Close
+    gdal.Unlink("/vsimem/tmp.tif")
+    
+    # Return
+    return georeferenced_buffer

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -85,8 +85,6 @@ class WMSServer(Server):
         params = map_request.params
         query = MapQuery(params.bbox, params.size, SRS(params.srs), params.format)
 
-        print query.__dict__
-
         if map_request.params.get('tiled', 'false').lower() == 'true':
             query.tiled_only = True
         orig_query = query

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -159,10 +159,8 @@ class WMSServer(Server):
             raise RequestError('error while processing image file: %s' % ex,
                 request=map_request)
 
-        # HERE GOES THE MAGIC
-        if query.format == 'GeoTIFF':
+        if query.format.lower() == 'geotiff':
             result_buf = georeference(result, result_buf, query.srs, query.bbox)
-        # END OF THE MAGIC
 
         resp = Response(result_buf, content_type=img_opts.format.mime_type)
 


### PR DESCRIPTION
This PR adds support for returning a complete GeoTIFF file with spatial metadata when the WMS request is made using format=image/geotiff.

This is a work in progress because it doesn't have tests. The thing is that in order to assert that the image was correctly georeferenced I would need to add gdal to requirements-test.txt. Is that OK?