### PR TITLE
Hide backend url in exception

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -561,10 +561,11 @@ class SourceConfiguration(ConfigurationBase):
 
         timeout = self.context.globals.get_value('http.client_timeout', self.conf)
         headers = self.context.globals.get_value('http.headers', self.conf)
+        hide_exception_url = self.context.globals.get_value('http.hide_exception_url', self.conf)
 
         http_client = HTTPClient(url, username, password, insecure=insecure,
                                  ssl_ca_certs=ssl_ca_certs, timeout=timeout,
-                                 headers=headers)
+                                 headers=headers, hide_exception_url=hide_exception_url)
         return http_client, url
 
     @memoize

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -71,6 +71,7 @@ http_opts = {
     'client_timeout': number(),
     'ssl_no_cert_checks': bool(),
     'ssl_ca_certs': str(),
+    'hide_exception_url': bool(),
     'headers': {
         anything(): str()
     },

--- a/mapproxy/test/unit/test_client.py
+++ b/mapproxy/test/unit/test_client.py
@@ -83,6 +83,15 @@ class TestHTTPClient(object):
             assert_re(e.args[0], r'No response .* "http://localhost.*": Connection refused')
         else:
             assert False, 'expected HTTPClientError'
+    def test_internal_error_hide_exception_url(self):
+        try:
+            with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/'},
+                                                  {'status': '500', 'body': b''})]):
+                HTTPClient(hide_exception_url=True).open(TESTSERVER_URL + '/')
+        except HTTPClientError as e:
+            assert_re(e.args[0], r'HTTP Error: 500')
+        else:
+            assert False, 'expected HTTPClientError'
 
     @attr('online')
     def test_https_untrusted_root(self):


### PR DESCRIPTION
When one of the backend WMS servers of one of our MapProxy servers was having problems, I noticed that MapProxy was returning service exceptions with the backend URL exposed in it. This way internal host names, port numbers, layer names, and other information can be exposed to the outer world. This is fine for testing/debugging purposes, but undesirable for production servers.

Therefor I've created a patch to hide the backend URL in the OGC service exception. It is a boolean option, named hide_exception_url, in the HTTP options. By default the URL is not hidden, in order not to break current deployments. The URLs are only being hidden when the value is set to true.

I hope this patch will also be useful for others. I've also added a unit test. I'm not sure if more tests are necessary. For instance, the ssl settings in http_opts aren't always unit tested either.