### PR TITLE
Support for custom S3 server (eq. DigitalOcean Spaces)

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -434,7 +434,7 @@ You can set the ``sources`` to an empty list, if you use an existing geopackage 
 
 .. versionadded:: 1.10.0
 
-Store tiles in a `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_.
+Store tiles in a `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_ or any other S3 compatible object server.
 
 
 Requirements
@@ -453,6 +453,12 @@ Available options:
 ``profile_name``:
   Optional profile name for `shared credentials <http://boto3.readthedocs.io/en/latest/guide/configuration.html>`_ for this cache. Alternative methods of authentification are using the  ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` environmental variables, or by using an `IAM role <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_ when using an Amazon EC2 instance.
   You can set the default profile with ``globals.cache.s3.profile_name``.
+
+``region_name``:
+  Optional name of the region. You can set the default region_name with ``globals.cache.s3.region_name``
+
+``endpoint_url``:
+  Optional endpoint_url for the S3. You can set the default endpoint_url with ``globals.cache.s3.endpoint_url``.
 
 ``directory``:
   Base directory (path) where all tiles are stored.
@@ -480,6 +486,27 @@ Example
     cache:
       s3:
         profile_name: default
+
+
+Example usage with DigitalOcean Spaces 
+--------------------------------------
+
+::
+
+  cache:
+    my_layer_20110501_epsg_4326_cache_out:
+      sources: [my_layer_20110501_cache]
+      cache:
+        type: s3
+        directory: /1.0.0/my_layer/default/20110501/4326/
+        bucket_name: my-s3-tiles-cache
+
+  globals:
+    cache:
+      s3:
+        profile_name: default
+        region_name: nyc3
+        endpoint_url: https://nyc3.digitaloceanspaces.com
 
 
 .. _cache_compact:

--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -434,7 +434,7 @@ You can set the ``sources`` to an empty list, if you use an existing geopackage 
 
 .. versionadded:: 1.10.0
 
-Store tiles in a `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_ or any other S3 compatible object server.
+Store tiles in a `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_ or any other S3 compatible object storage.
 
 
 Requirements

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -50,11 +50,14 @@ class S3ConnectionError(Exception):
 class S3Cache(TileCacheBase):
 
     def __init__(self, base_path, file_ext, directory_layout='tms',
-                 bucket_name='mapproxy', profile_name=None,
+                 bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
                  _concurrent_writer=4):
         super(S3Cache, self).__init__()
         self.lock_cache_id = hashlib.md5(base_path.encode('utf-8') + bucket_name.encode('utf-8')).hexdigest()
         self.bucket_name = bucket_name
+        self.region_name = region_name
+        self.endpoint_url = endpoint_url
+
         try:
             self.bucket = self.conn().head_bucket(Bucket=bucket_name)
         except botocore.exceptions.ClientError as e:
@@ -82,7 +85,7 @@ class S3Cache(TileCacheBase):
             raise ImportError("S3 Cache requires 'boto3' package.")
 
         try:
-            return s3_session().client("s3")
+            return s3_session().client("s3", region_name=self.region_name, endpoint_url=self.endpoint_url)
         except Exception as e:
             raise S3ConnectionError('Error during connection %s' % e)
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1109,6 +1109,12 @@ class CacheConfiguration(ConfigurationBase):
         profile_name = self.context.globals.get_value('cache.profile_name', self.conf,
             global_key='cache.s3.profile_name')
 
+        region_name = self.context.globals.get_value('cache.region_name', self.conf,
+            global_key='cache.s3.region_name')
+
+        endpoint_url = self.context.globals.get_value('cache.endpoint_url', self.conf,
+            global_key='cache.s3.endpoint_url')
+
         directory_layout = self.conf['cache'].get('directory_layout', 'tms')
 
         base_path = self.conf['cache'].get('directory', None)
@@ -1121,6 +1127,8 @@ class CacheConfiguration(ConfigurationBase):
             directory_layout=directory_layout,
             bucket_name=bucket_name,
             profile_name=profile_name,
+            region_name=region_name,
+            endpoint_url=endpoint_url
         )
 
     def _sqlite_cache(self, grid_conf, file_ext):

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -143,6 +143,8 @@ cache_types = {
         'directory_layout': str(),
         'directory': str(),
         'profile_name': str(),
+        'region_name': str(),
+        'endpoint_url': str(),
         'tile_lock_dir': str(),
      },
     'riak': {

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -371,6 +371,8 @@ mapproxy_yaml_spec = {
             's3': {
                 'bucket_name': str(),
                 'profile_name': str(),
+                'region_name': str(),
+                'endpoint_url': str(),
             },
         },
         'grid': {


### PR DESCRIPTION
This pull request adds possibility to use custom S3 server for the S3 cache. It does it by adding two additional config parameters `region_name` and `endpoint_url`. Example usage with DigitalOcean Spaces added to the documentation.