### PR TITLE
Update wmts100capabilities.xml: ows:Keywords

### DIFF
--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -4,14 +4,14 @@
     <ows:Title>{{service.title}}</ows:Title>
     <ows:Abstract>{{service.abstract}}</ows:Abstract>
     {{if service.keyword_list and len(service.keyword_list) > 0}}
-    <ows:KeywordList>
+    <ows:Keywords>
     {{for list in service.keyword_list}}
       {{py: kw=bunch(default='', **list)}}
       {{for keyword in kw.keywords}}
         <ows:Keyword{{if kw.vocabulary}} vocabulary="{{kw.vocabulary}}"{{endif}}>{{keyword}}</ows:Keyword>
       {{endfor}}
     {{endfor}}
-    </ows:KeywordList> 
+    </ows:Keywords> 
     {{endif}}
     <ows:ServiceType>OGC WMTS</ows:ServiceType>
     <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>


### PR DESCRIPTION
In WMTS 1.0.0 it is ows:Keywords not ows:KeywordList http://schemas.opengis.net/wmts/1.0/examples/wmtsGetCapabilities_response_RESTful.xml

What a mess.