### PR TITLE
Fix spelling errors.

### DIFF
--- a/doc/mapproxy_util_autoconfig.rst
+++ b/doc/mapproxy_util_autoconfig.rst
@@ -78,7 +78,7 @@ Write MapProxy configuration with caches for grids from ``base.yaml``::
 Overwrites
 ==========
 
-It's likely that you need to tweak the created configuration – e.g. to define another coverage, disable featureinfo, etc. You can do this by editing the output file of course, or you can modify the output by defining all changes to an overwrite file. Overwrite files are applied everytime you call ``mapproxy-util autoconfig``.
+It's likely that you need to tweak the created configuration – e.g. to define another coverage, disable featureinfo, etc. You can do this by editing the output file of course, or you can modify the output by defining all changes to an overwrite file. Overwrite files are applied every time you call ``mapproxy-util autoconfig``.
 
 Overwrites are YAML files that will be merged with the created configuration file.
 


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the latest Debian package build:

 * everytime -> every time