### PR TITLE
Bug Fix Add same logic as other tile sources without timestamps

### DIFF
--- a/mapproxy/cache/geopackage.py
+++ b/mapproxy/cache/geopackage.py
@@ -481,7 +481,12 @@ AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]\
             return False
 
     def load_tile_metadata(self, tile):
-        self.load_tile(tile)
+        if not self.supports_timestamp:
+            # GPKG specification does not include tile timestamps.
+            # This sets the timestamp of the tile to epoch (1970s)
+            tile.timestamp = -1
+        else:
+            self.load_tile(tile)
 
 
 class GeopackageLevelCache(TileCacheBase):
@@ -507,7 +512,7 @@ class GeopackageLevelCache(TileCacheBase):
                     geopackage_filename,
                     self.tile_grid,
                     self.table_name,
-                    with_timestamps=True,
+                    with_timestamps=False,
                     timeout=self.timeout,
                     wal=self.wal,
                 )


### PR DESCRIPTION
This fixes a bug with continuing a seed using geopackage.  Currently trying to continue seeding a geopackage will result in a TypeError if using a progress file.  This changes the logic to match  other tile sources without timestamps (i.e. MBTiles). 

To test create a seed job using a geopackage using a progress file.  Then try to continue that seed job. 