### PR TITLE
Hardlink option for single color images in file caches

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -415,6 +415,12 @@ with no data (e.g. water areas, areas with no roads, etc.).
 
 If set to ``hardlink``, MapProxy will store the duplicate tiles as hard links.
 
+This avoids using up inodes for symlinks, which is especially useful if single color images outnumber others (as might be the case in world maps or low-detail maps for example). Directory entries for the hardlinks will still be created of course.
+
+The usual limitation applies: files can only be linked on the same filesystem, assuming it has support for hardlinks in the first place. Furthermore, all the linked files will have the same metadata, in particular the modification time (``mtime``), which is used in seeding or cleanups with the ``refresh_before`` or ``remove_before`` directives.
+
+In practice this means that all the linked images will have the first such tile's modification date and therefore will appear older to the seeding or cleanup process than when they were actually linked. This means that they are *more likely* to be included in the ``refresh_before`` or ``remove_before`` filters, which may or may not be an issue depending on your seeding or cleanup use-cases.
+
 .. note:: This feature is only available on Unix, since Windows has no support for symbolic links.
 
 ``minimize_meta_requests``

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -408,10 +408,12 @@ MapProxy will try to use this format to request new tiles, if it is not set ``fo
 ``link_single_color_images``
 """"""""""""""""""""""""""""
 
-If set to ``true``, MapProxy will not store tiles that only contain a single color as a
+If set to ``true`` or ``symlink``, MapProxy will not store tiles that only contain a single color as a
 separate file. MapProxy stores these tiles only once and uses symbolic links to this file
 for every occurrence. This can reduce the size of your tile cache if you have larger areas
 with no data (e.g. water areas, areas with no roads, etc.).
+
+If set to ``hardlink``, MapProxy will store the duplicate tiles as hard links.
 
 .. note:: This feature is only available on Unix, since Windows has no support for symbolic links.
 
@@ -910,7 +912,7 @@ The following options define how tiles are created and stored. Most options can 
 
 
 ``link_single_color_images``
-  Enables the ``link_single_color_images`` option for all caches if set to ``true``. See :ref:`link_single_color_images`.
+  Enables the ``link_single_color_images`` option for all caches if set to ``true``, ``symlink`` or ``hardlink``. See :ref:`link_single_color_images`.
 
 .. _max_tile_limit:
 

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -168,15 +168,23 @@ class FileCache(TileCacheBase):
         if os.path.exists(tile_loc) or os.path.islink(tile_loc):
             os.unlink(tile_loc)
 
-        # Use relative path for the symlink
-        real_tile_loc = os.path.relpath(real_tile_loc, os.path.dirname(tile_loc))
+        if self.link_single_color_images == 'hardlink':
+            try:
+                os.link(real_tile_loc, tile_loc)
+            except OSError as e:
+                # ignore error if link was created by other process
+                if e.errno != errno.EEXIST:
+                    raise e
+        else:
+            # Use relative path for the symlink
+            real_tile_loc = os.path.relpath(real_tile_loc, os.path.dirname(tile_loc))
 
-        try:
-            os.symlink(real_tile_loc, tile_loc)
-        except OSError as e:
-            # ignore error if link was created by other process
-            if e.errno != errno.EEXIST:
-                raise e
+            try:
+                os.symlink(real_tile_loc, tile_loc)
+            except OSError as e:
+                # ignore error if link was created by other process
+                if e.errno != errno.EEXIST:
+                    raise e
 
         return
 

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -388,7 +388,7 @@ mapproxy_yaml_spec = {
             'max_tile_limit': number(),
             'minimize_meta_requests': bool(),
             'concurrent_tile_creators': int(),
-            'link_single_color_images': bool(),
+            'link_single_color_images': one_of(bool(), 'symlink', 'hardlink'),
             's3': {
                 'bucket_name': str(),
                 'profile_name': str(),
@@ -437,7 +437,7 @@ mapproxy_yaml_spec = {
             'request_format': str(),
             'use_direct_from_level': number(),
             'use_direct_from_res': number(),
-            'link_single_color_images': bool(),
+            'link_single_color_images': one_of(bool(), 'symlink', 'hardlink'),
             'cache_rescaled_tiles': bool(),
             'upscale_tiles': int(),
             'downscale_tiles': int(),

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -241,6 +241,30 @@ class TestFileTileCache(TileCacheTestBase):
         assert loc != loc2
         assert os.path.samefile(loc, loc2)
 
+        tile3 = Tile((0,0,2), ImageSource(img))
+        self.cache.link_single_color_images = 'hardlink'
+        self.cache.store_tile(tile3)
+        assert self.cache.is_cached(tile3)
+        loc3 = self.cache.tile_location(tile3)
+        assert is_png(open(loc3, 'rb'))
+
+        assert loc != loc3
+        assert os.path.samefile(loc, loc3)
+        loc3stat = os.stat(loc3)
+        assert loc3stat.st_nlink == 2
+
+        tile4 = Tile((0, 0, 1), ImageSource(img))
+        self.cache.link_single_color_images = 'symlink'
+        self.cache.store_tile(tile4)
+        assert self.cache.is_cached(tile4)
+        loc4 = self.cache.tile_location(tile4)
+        assert os.path.islink(loc4)
+        assert os.path.realpath(loc4).endswith('ff0105.png')
+        assert is_png(open(loc4, 'rb'))
+
+        assert loc != loc4
+        assert os.path.samefile(loc, loc4)
+
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='link_single_color_tiles not supported on windows')
     def test_single_color_tile_store_w_alpha(self):
@@ -253,6 +277,18 @@ class TestFileTileCache(TileCacheTestBase):
         assert os.path.islink(loc)
         assert os.path.realpath(loc).endswith('ff0105ff.png')
         assert is_png(open(loc, 'rb'))
+
+        tile2 = Tile((0,0,2), ImageSource(img))
+        self.cache.link_single_color_images = 'hardlink'
+        self.cache.store_tile(tile2)
+        assert self.cache.is_cached(tile2)
+        loc2 = self.cache.tile_location(tile2)
+        assert is_png(open(loc2, 'rb'))
+
+        assert loc != loc2
+        assert os.path.samefile(loc, loc2)
+        loc2stat = os.stat(loc2)
+        assert loc2stat.st_nlink == 2
 
     def test_load_metadata_missing_tile(self):
         tile = Tile((0, 0, 0))


### PR DESCRIPTION
This is a possible implementation to allow hardlinks to be used, rather than symlinks, with the `link_single_color_images` option for file caches, as mentionned in #410, to reduce inode usage.

Current behaviour is preserved, i.e. setting `link_single_color_images` to `true` will result in symbolic links being used.

Setting the value to 'hardlink', however, will use hardlinks. The 'symlink' keyword is also added.

Mixing types works here by virtue of non-empty strings testing True.