### PR TITLE
srs: Make SupportedSRS iterable

### DIFF
--- a/mapproxy/srs.py
+++ b/mapproxy/srs.py
@@ -444,6 +444,9 @@ class SupportedSRS(object):
         self.supported_srs = supported_srs
         self.preferred_srs = preferred_srs or PreferredSrcSRS()
 
+    def __iter__(self):
+        return iter(self.supported_srs)
+
     def __contains__(self, srs):
         return srs in self.supported_srs
 

--- a/mapproxy/test/unit/test_srs.py
+++ b/mapproxy/test/unit/test_srs.py
@@ -154,6 +154,10 @@ class TestSupportedSRS(object):
         assert SRS(4258) not in supported
         assert SRS(25832) in supported
 
+    def test_iter(self, preferred):
+        supported = SupportedSRS([SRS(4326), SRS(25832)], preferred)
+        assert [SRS(4326), SRS(25832)] == [srs for srs in supported]
+
     def test_best_srs(self, preferred):
         supported = SupportedSRS([SRS(4326), SRS(25832)], preferred)
         assert supported.best_srs(SRS(4326)) == SRS(4326)


### PR DESCRIPTION
This resolves an issue with the demo service, which expects an iterable list of SRSs: https://github.com/mapproxy/mapproxy/blob/bc9e7dbcf3900e29066c927c04273da14e584fcc/mapproxy/service/demo.py#L142-L145

from WMS Source:
https://github.com/mapproxy/mapproxy/blob/bc9e7dbcf3900e29066c927c04273da14e584fcc/mapproxy/config/loader.py#L574-L580