### PR TITLE
S3 Performance: s3 http get

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,17 +6,6 @@ include CHANGES.txt
 include COPYING.txt
 include requirements-tests.txt
 
-include doc/GM.txt
-include doc/*.yaml
-include doc/yaml/*.yaml
-include doc/Makefile
-include doc/*.rst
-include doc/conf.py
-include doc/imgs/*.png
-include doc/_static/*.png
-include doc/_static/*.css
-include doc/_templates/*.html
-
 recursive-include mapproxy/config_template *.ini *.wsgi *.yaml
 recursive-include mapproxy/image/fonts *.ttf LICENSE
 recursive-include mapproxy/service/templates *.css *.cfg *.gif *.png *.xml *.html *.js
@@ -24,3 +13,6 @@ recursive-include mapproxy/test/schemas *.xml *.xsd *.dtd *.wsdl *.txt
 recursive-include mapproxy/test/system/fixture *.yaml *.mbtiles *.geojson *.xml *.jpeg *.png *.py
 recursive-include mapproxy/test/unit epsg *.dbf *.shp *.shx
 recursive-include mapproxy/util/ext/wmsparse/test *.xml
+
+prune mapproxy/test
+prune doc/

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -18,13 +18,20 @@ import calendar
 import hashlib
 import sys
 import threading
-import urllib2
 
 from mapproxy.image import ImageSource
 from mapproxy.cache import path
 from mapproxy.cache.base import tile_buffer, TileCacheBase
+from mapproxy.compat import PY2
 from mapproxy.util import async_
 from mapproxy.util.py import reraise_exception
+
+if PY2:
+    import urllib2
+    from urllib2 import HTTPError
+else:
+    from urllib import request as urllib2
+    from urllib.error import HTTPError
 
 try:
     import boto3

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -18,6 +18,7 @@ import calendar
 import hashlib
 import sys
 import threading
+import urllib2
 
 from mapproxy.image import ImageSource
 from mapproxy.cache import path
@@ -51,7 +52,7 @@ class S3Cache(TileCacheBase):
 
     def __init__(self, base_path, file_ext, directory_layout='tms',
                  bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
-                 _concurrent_writer=4, access_control_list=None):
+                 _concurrent_writer=4, access_control_list=None, use_http_get=False):
         super(S3Cache, self).__init__()
         self.lock_cache_id = hashlib.md5(base_path.encode('utf-8') + bucket_name.encode('utf-8')).hexdigest()
         self.bucket_name = bucket_name
@@ -59,6 +60,7 @@ class S3Cache(TileCacheBase):
         self.region_name = region_name
         self.endpoint_url = endpoint_url
         self.access_control_list = access_control_list
+        self.use_http_get = use_http_get
 
         try:
             self.bucket = self.conn().head_bucket(Bucket=bucket_name)
@@ -78,6 +80,9 @@ class S3Cache(TileCacheBase):
         self._concurrent_writer = _concurrent_writer
 
         self._tile_location, _ = path.location_funcs(layout=directory_layout)
+
+    def get_bucket_url(self, tile):
+        return "https://{bucket}.s3.{region}.amazonaws.com/{key}".format(bucket=self.bucket_name, region=self.region_name, key=self.tile_key(tile))
 
     def tile_key(self, tile):
         return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
@@ -104,14 +109,24 @@ class S3Cache(TileCacheBase):
 
     def is_cached(self, tile):
         if tile.is_missing():
-            key = self.tile_key(tile)
-            try:
-                r = self.conn().head_object(Bucket=self.bucket_name, Key=key)
-                self._set_metadata(r, tile)
-            except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] in ('404', 'NoSuchKey'):
-                    return False
-                raise
+            if self.use_http_get:
+                try:
+                    req = urllib2.Request(self.get_bucket_url(tile))
+                    response = urllib2.urlopen(req)
+                    self._set_metadata(response.info(), tile)
+                except urllib2.HTTPError as e:
+                    if e.code == 403:
+                        return False
+                    raise
+            else:
+                key = self.tile_key(tile)
+                try:
+                    r = self.conn().head_object(Bucket=self.bucket_name, Key=key)
+                    self._set_metadata(r, tile)
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] in ('404', 'NoSuchKey'):
+                        return False
+                    raise
 
         return True
 
@@ -126,15 +141,24 @@ class S3Cache(TileCacheBase):
         key = self.tile_key(tile)
         log.debug('S3:load_tile, key: %s' % key)
 
-        try:
-            r  = self.conn().get_object(Bucket=self.bucket_name, Key=key)
-            self._set_metadata(r, tile)
-            tile.source = ImageSource(r['Body'])
-        except botocore.exceptions.ClientError as e:
-            error = e.response.get('Errors', e.response)['Error'] # moto get_object can return Error wrapped in Errors...
-            if error['Code'] in ('404', 'NoSuchKey'):
-                return False
-            raise
+        if self.use_http_get:
+            try:
+                req = urllib2.Request(self.get_bucket_url(tile))
+                tile.source = ImageSource(urllib2.urlopen(req))
+            except urllib2.HTTPError as e:
+                if e.code == 403:
+                    return False
+                raise
+        else:
+            try:
+                r  = self.conn().get_object(Bucket=self.bucket_name, Key=key)
+                self._set_metadata(r, tile)
+                tile.source = ImageSource(r['Body'])
+            except botocore.exceptions.ClientError as e:
+                error = e.response.get('Errors', e.response)['Error'] # moto get_object can return Error wrapped in Errors...
+                if error['Code'] in ('404', 'NoSuchKey'):
+                    return False
+                raise
 
         return True
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1153,6 +1153,10 @@ class CacheConfiguration(ConfigurationBase):
         access_control_list = self.context.globals.get_value('cache.access_control_list', self.conf,
             global_key='cache.s3.access_control_list')
 
+        use_http_get = self.context.globals.get_value('cache.use_http_get', self.conf,
+            global_key='cache.s3.use_http_get'
+        )
+
         directory_layout = self.conf['cache'].get('directory_layout', 'tms')
 
         base_path = self.conf['cache'].get('directory', None)
@@ -1167,7 +1171,8 @@ class CacheConfiguration(ConfigurationBase):
             profile_name=profile_name,
             region_name=region_name,
             endpoint_url=endpoint_url,
-            access_control_list=access_control_list
+            access_control_list=access_control_list,
+            use_http_get=use_http_get
         )
 
     def _sqlite_cache(self, grid_conf, file_ext):

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -149,6 +149,7 @@ cache_types = {
         'endpoint_url': str(),
         'access_control_list': str(),
         'tile_lock_dir': str(),
+        'use_http_get': bool(),
      },
     'riak': {
         'nodes': [riak_node],
@@ -592,4 +593,3 @@ mapproxy_yaml_spec = {
      # from other sections (e.g. coverages, dimensions, etc.)
     'parts': anything(),
 }
-


### PR DESCRIPTION
### Background
Using `Mapproxy` on an AWS hosted EC2 to provide cached data using **S3** storage.

### Issue
When using the S3 cache, the response times can be high (~300-500ms for a _cached_ tile when requesting from localhost). One of the reasons for this is the underlying AWS API which is used to `GetObject`. Checking the debug log, a couple hundred ms are used just to assume the required AWS role.

### Proposal
By configuring the `Bucket Policy` to allow any principal from a specific VPC S3 endpoint (eg. from the VPC the EC2 is runngin in)  to `GetObject`, the bucket can be accessed over `http` instead of the AWS SDK, bypassing the need for `boto` to do its thing. This has brought down the request time on localhost to ~40ms.

### Solution
The S3 cache can now be configured with `use_http_get`. If specified, requests to `GetObject` are requested using `urllib2` instead of `boto`