### PR TITLE
Add no-cache http headers to error responses.

### DIFF
--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -44,11 +44,13 @@ class RequestError(Exception):
         """
         if self.request is not None:
             handler = self.request.exception_handler
-            return handler.render(self)
+            resp = handler.render(self)
         elif self.status is not None:
-            return Response(self.msg, status=self.status)
+            resp = Response(self.msg, status=self.status)
         else:
-            return Response('internal error: %s' % self.msg, status=500)
+            resp = Response('internal error: %s' % self.msg, status=500)
+        resp.cache_headers(no_cache=True)
+        return resp
     
     def __str__(self):
         return 'RequestError("%s", code=%r, request=%r)' % (self.msg, self.code,

--- a/mapproxy/test/http.py
+++ b/mapproxy/test/http.py
@@ -480,3 +480,8 @@ def make_wsgi_env(query_string, extra_environ={}):
 
 def basic_auth_value(username, password):
     return base64.b64encode(('%s:%s' % (username, password)).encode('utf-8'))
+
+def assert_no_cache(resp):
+    assert resp.headers["Pragma"] == "no-cache"
+    assert resp.headers["Expires"] == "-1"
+    assert resp.cache_control.no_store == True

--- a/mapproxy/test/system/test_wmsc.py
+++ b/mapproxy/test/system/test_wmsc.py
@@ -26,6 +26,7 @@ from mapproxy.request.wms import (
 )
 from mapproxy.test.image import is_jpeg
 from mapproxy.test.helper import validate_with_dtd
+from mapproxy.test.http import assert_no_cache
 from mapproxy.test.system.test_wms import is_111_exception
 from mapproxy.test.system import SysTest
 
@@ -99,17 +100,17 @@ class TestWMSC(SysTest):
     def test_get_tile_wrong_bbox(self, app):
         self.common_map_req.params.bbox = "-20037508,0.0,200000.0,20037508"
         resp = app.get(str(self.common_map_req) + "&tiled=true")
-        assert "Cache-Control" not in resp.headers
+        assert_no_cache(resp)
         is_111_exception(resp.lxml, re_msg=".*invalid bbox")
 
     def test_get_tile_wrong_fromat(self, app):
         self.common_map_req.params.format = "image/png"
         resp = app.get(str(self.common_map_req) + "&tiled=true")
-        assert "Cache-Control" not in resp.headers
+        assert_no_cache(resp)
         is_111_exception(resp.lxml, re_msg="Invalid request: invalid.*format.*jpeg")
 
     def test_get_tile_wrong_size(self, app):
         self.common_map_req.params.size = (256, 255)
         resp = app.get(str(self.common_map_req) + "&tiled=true")
-        assert "Cache-Control" not in resp.headers
+        assert_no_cache(resp)
         is_111_exception(resp.lxml, re_msg="Invalid request: invalid.*size.*256x256")


### PR DESCRIPTION
Avoids caching in client and also allows upstream proxies etc. to better
handle WMS `application/vnd.ogc.se_inimage` and
`application/vnd.ogc.se_blank` error responses.