### PR TITLE
Change deprecated imports for Python 3.8 compat

### DIFF
--- a/mapproxy/compat/modules.py
+++ b/mapproxy/compat/modules.py
@@ -5,5 +5,9 @@ __all__ = ['urlparse']
 
 if PY2:
     import urlparse; urlparse
+    from cgi import parse_qsl, escape
+    from urllib import quote
 else:
+    from html import escape
     from urllib import parse as urlparse
+    from urllib.parse import parse_qsl, quote

--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -16,8 +16,8 @@
 """
 Service exception handling (WMS exceptions, XML, in_image, etc.).
 """
-import cgi
 from mapproxy.response import Response
+from mapproxy.compat.modules import escape
 
 class RequestError(Exception):
     """
@@ -116,7 +116,7 @@ class XMLExceptionHandler(ExceptionHandler):
         """
         status_code = self.status_codes.get(request_error.code, self.status_code)
         # escape &<> in error message (e.g. URL params)
-        msg = cgi.escape(request_error.msg)
+        msg = escape(request_error.msg)
         result = self.template.substitute(exception=msg,
                                           code=request_error.code)
         return Response(result, mimetype=self.mimetype, content_type=self.content_type,

--- a/mapproxy/request/base.py
+++ b/mapproxy/request/base.py
@@ -16,15 +16,9 @@
 """
 Service requests (parsing, handling, etc).
 """
-import cgi
-
+from mapproxy.compat import PY2, iteritems, text_type
+from mapproxy.compat.modules import parse_qsl, urlparse, quote
 from mapproxy.util.py import cached_property
-from mapproxy.compat import iteritems, PY2, text_type
-
-if PY2:
-    from urllib import quote
-else:
-    from urllib.parse import quote
 
 class NoCaseMultiDict(dict):
     """
@@ -178,7 +172,7 @@ def url_decode(qs, charset='utf-8', decode_keys=False, include_empty=True,
     Parse query string `qs` and return a `NoCaseMultiDict`.
     """
     tmp = []
-    for key, value in cgi.parse_qsl(qs, include_empty):
+    for key, value in parse_qsl(qs, include_empty):
         if PY2:
             if decode_keys:
                 key = key.decode(charset, errors)

--- a/mapproxy/service/template_helper.py
+++ b/mapproxy/service/template_helper.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cgi import escape
 from mapproxy.template import bunch
+from mapproxy.compat.modules import escape
 
 __all__ = ['escape', 'indent', 'bunch', 'wms100format', 'wms100info_format',
     'wms111metadatatype']

--- a/mapproxy/test/http.py
+++ b/mapproxy/test/http.py
@@ -15,10 +15,10 @@
 
 from __future__ import print_function
 
+
 import re
 import threading
 import sys
-import cgi
 import socket
 import errno
 import time
@@ -26,7 +26,7 @@ import base64
 from contextlib import contextmanager
 from mapproxy.util.py import reraise
 from mapproxy.compat import iteritems, PY2
-from mapproxy.compat.modules import urlparse
+from mapproxy.compat.modules import urlparse, parse_qsl
 if PY2:
     from cStringIO import StringIO
 else:
@@ -418,7 +418,7 @@ def query_to_dict(query):
     d = {}
     if '?' in query:
         query = query.split('?', 1)[-1]
-    for key, value in cgi.parse_qsl(query):
+    for key, value in parse_qsl(query):
         d[key.lower()] = value
     return d
 


### PR DESCRIPTION
This changes a number of imports so that mapproxy can be used with Python 3.8.

Amongst others, this handles the removal of deprecated `cgi` methods: https://bugs.python.org/issue33843