### PR TITLE
Concurrent instances for mapnik rebased

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -602,6 +602,8 @@ Other options
 
 The Mapnik source also supports the ``min_res``/``max_res``/``min_scale``/``max_scale``, ``concurrent_requests``, ``seed_only`` and ``coverage`` options. See :ref:`wms_label`.
 
+Mapnik can be used in multithreading and multiprocessing operation by setting ``multithreaded: True``. This is only tested and safe *for seeding*.
+
 
 Example configuration
 ^^^^^^^^^^^^^^^^^^^^^

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -952,9 +952,13 @@ class MapnikSourceConfiguration(SourceConfiguration):
         else:
             reuse_map_objects = False
 
+        concurrent_tile_creators = self.context.globals.get_value('concurrent_tile_creators', self.conf,
+            global_key='cache.concurrent_tile_creators')
+
         return MapnikSource(mapfile, layers=layers, image_opts=image_opts,
-            coverage=coverage, res_range=res_range, lock=lock,
-            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor)
+                            coverage=coverage, res_range=res_range, lock=lock,
+                            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor,
+                            concurrent_tile_creators=concurrent_tile_creators)
 
 class TileSourceConfiguration(SourceConfiguration):
     supports_meta_tiles = False

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -952,13 +952,9 @@ class MapnikSourceConfiguration(SourceConfiguration):
         else:
             reuse_map_objects = False
 
-        concurrent_tile_creators = self.context.globals.get_value('concurrent_tile_creators', self.conf,
-            global_key='cache.concurrent_tile_creators')
-
         return MapnikSource(mapfile, layers=layers, image_opts=image_opts,
                             coverage=coverage, res_range=res_range, lock=lock,
-                            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor,
-                            concurrent_tile_creators=concurrent_tile_creators)
+                            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor)
 
 class TileSourceConfiguration(SourceConfiguration):
     supports_meta_tiles = False

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -930,6 +930,7 @@ class MapnikSourceConfiguration(SourceConfiguration):
         res_range = resolution_range(self.conf)
 
         scale_factor = self.conf.get('scale_factor', None)
+        multithreaded = self.conf.get('multithreaded', False)
 
         layers = self.conf.get('layers', None)
         if isinstance(layers, string_type):
@@ -954,7 +955,8 @@ class MapnikSourceConfiguration(SourceConfiguration):
 
         return MapnikSource(mapfile, layers=layers, image_opts=image_opts,
                             coverage=coverage, res_range=res_range, lock=lock,
-                            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor)
+                            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor,
+                            multithreaded=multithreaded)
 
 class TileSourceConfiguration(SourceConfiguration):
     supports_meta_tiles = False

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -552,6 +552,7 @@ mapproxy_yaml_spec = {
                 'layers': one_of(str(), [str()]),
                 'use_mapnik2': bool(),
                 'scale_factor': number(),
+                'multithreaded': bool(),
             }),
             'arcgis': combined(source_commons, {
                required('req'): {

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -128,7 +128,7 @@ class MapnikSource(MapLayer):
         process_id = multiprocessing.current_process()._identity
         queue_cachekey = (process_id, mapfile)
         if not queue_cachekey in self._map_objs_queues:
-            self._map_objs_queues[queue_cachekey] = new Queue(MAX_UNUSED_MAPS)
+            self._map_objs_queues[queue_cachekey] = Queue(MAX_UNUSED_MAPS)
         try:
             self._map_objs_queues[queue_cachekey].put_nowait(m)
         except Full:

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -49,8 +49,8 @@ try:
     Full = queue.Full
 except ImportError: # in python2 it is called Queue
     import Queue
-    import Queue.Empty as Empty
-    import Queue.Full as Full
+    Empty = Queue.Empty
+    Full = Queue.Full
 MAX_UNUSED_MAPS=10
 
 # fake 2.0 API for older versions

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -125,7 +125,7 @@ class MapnikSource(MapLayer):
                 return _map_objs_queues[queue_cachekey].get_nowait()
             except Empty:
                 pass
-        return self._create_map_obj(self, mapfile)
+        return self._create_map_obj(mapfile)
 
     def _put_unused_map_obj(self, mapfile, m):
         process_id = multiprocessing.current_process()._identity

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -120,9 +120,9 @@ class MapnikSource(MapLayer):
     def _get_map_obj(self, mapfile):
         process_id = multiprocessing.current_process()._identity
         queue_cachekey = (process_id, mapfile)
-        if queue_cachekey in self._map_objs_queues:
+        if queue_cachekey in _map_objs_queues:
             try:
-                return self._map_objs_queues[queue_cachekey].get_nowait()
+                return _map_objs_queues[queue_cachekey].get_nowait()
             except Empty:
                 pass
         return _create_map_obj(self, mapfile)
@@ -130,10 +130,10 @@ class MapnikSource(MapLayer):
     def _put_unused_map_obj(self, mapfile, m):
         process_id = multiprocessing.current_process()._identity
         queue_cachekey = (process_id, mapfile)
-        if not queue_cachekey in self._map_objs_queues:
-            self._map_objs_queues[queue_cachekey] = Queue(MAX_UNUSED_MAPS)
+        if not queue_cachekey in _map_objs_queues:
+            _map_objs_queues[queue_cachekey] = Queue(MAX_UNUSED_MAPS)
         try:
-            self._map_objs_queues[queue_cachekey].put_nowait(m)
+            _map_objs_queues[queue_cachekey].put_nowait(m)
         except Full:
             # cleanup the data and drop the map, so it can be garbage collected
             m.remove_all()

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import sys
 import time
 import threading
+import multiprocessing
 
 from mapproxy.grid import tile_grid
 from mapproxy.image import ImageSource
@@ -49,7 +50,8 @@ log = logging.getLogger(__name__)
 class MapnikSource(MapLayer):
     supports_meta_tiles = True
     def __init__(self, mapfile, layers=None, image_opts=None, coverage=None,
-        res_range=None, lock=None, reuse_map_objects=False, scale_factor=None):
+                 res_range=None, lock=None, reuse_map_objects=False, scale_factor=None,
+                 concurrent_tile_creators=None):
         MapLayer.__init__(self, image_opts=image_opts)
         self.mapfile = mapfile
         self.coverage = coverage
@@ -57,8 +59,9 @@ class MapnikSource(MapLayer):
         self.layers = set(layers) if layers else None
         self.scale_factor = scale_factor
         self.lock = lock
-        self._map_objs = {}
-        self._map_objs_lock = threading.Lock()
+        # global objects to support multiprocessing
+        global _map_objs
+        _map_objs = {}
         self._cache_map_obj = reuse_map_objects
         if self.coverage:
             self.extent = MapExtent(self.coverage.bbox, self.coverage.srs)
@@ -93,24 +96,42 @@ class MapnikSource(MapLayer):
         else:
             return self.render_mapfile(mapfile, query)
 
-    def map_obj(self, mapfile):
-        if not self._cache_map_obj:
-            m = mapnik.Map(0, 0)
-            mapnik.load_map(m, str(mapfile))
-            return m
+    def _create_map_obj(self, mapfile):
+        m = mapnik.Map(0, 0)
+        mapnik.load_map(m, str(mapfile))
+        return m
 
+    def map_obj(self, mapfile):
         # cache loaded map objects
-        # only works when a single proc/thread accesses this object
+        # only works when a single proc/thread accesses the map
         # (forking the render process doesn't work because of open database
         #  file handles that gets passed to the child)
-        if mapfile not in self._map_objs:
-            with self._map_objs_lock:
-                if mapfile not in self._map_objs:
-                    m = mapnik.Map(0, 0)
-                    mapnik.load_map(m, str(mapfile))
-                    self._map_objs[mapfile] = m
+        # segment the cache by process and thread to avoid interference
+        if self._cache_map_obj:
+            cachekey = None # renderd guarantees that there are no concurrency issues
+        else:
+            thread_id = threading.current_thread().ident
+            process_id = multiprocessing.current_process()._identity
+            cachekey = (process_id, thread_id, mapfile)
+        if cachekey not in _map_objs:
+            _map_objs[cachekey] = self._create_map_obj(mapfile)
 
-        return self._map_objs[mapfile]
+        # clean up no longer used cached maps
+        process_cache_keys = [k for k in _map_objs.keys()
+                              if k[0] == process_id]
+        if len(process_cache_keys) > (5 + threading.active_count()):
+            active_thread_ids = set(i.ident for i in threading.enumerate())
+            for k in process_cache_keys:
+                if not k[1] in active_thread_ids and k in _map_objs:
+                    try:
+                        m = _map_objs[k]
+                        del _map_objs[k]
+                    except KeyError:
+                        continue
+                    m.remove_all() # cleanup
+                    mapnik.clear_cache()
+
+        return _map_objs[cachekey]
 
     def render_mapfile(self, mapfile, query):
         return run_non_blocking(self._render_mapfile, (mapfile, query))

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -17,8 +17,6 @@ from __future__ import absolute_import
 
 import sys
 import time
-import queue
-import random
 import threading
 import multiprocessing
 
@@ -64,46 +62,11 @@ class MapnikSource(MapLayer):
         # global objects to support multiprocessing
         global _map_objs
         _map_objs = {}
-        global _last_activity
-        _last_activity = time.time()
         self._cache_map_obj = reuse_map_objects
         if self.coverage:
             self.extent = MapExtent(self.coverage.bbox, self.coverage.srs)
         else:
             self.extent = DefaultMapExtent()
-        # pre-created mapfiles for higher reactivity
-        global _last_mapfile
-        _last_mapfile = None
-        # pre-create more maps than the typical number of threads to allow for fast start
-        global _map_objs_precreated
-        if self._cache_map_obj:
-            _precreate_count = 1
-        else:
-            _precreate_count = (2 * concurrent_tile_creators if concurrent_tile_creators else 4) # 4 is the default for async_.ThreadPool
-        _map_objs_precreated = queue.Queue(_precreate_count)
-        self.map_obj_pre_creating_thread = threading.Thread(target=self._precreate_maps)
-        self.map_obj_pre_creating_thread.daemon = True
-        self.map_obj_pre_creating_thread.start()
-
-    def _idle(self):
-        return time.time() > _last_activity + 30
-
-    def _restart_idle_timer(self):
-        global _last_activity
-        _last_activity = time.time()
-
-    def _precreate_maps(self):
-        while True:
-            mapfile = _last_mapfile
-            if mapfile is None or _map_objs_precreated.full():
-                time.sleep(60 * random.random()) # randomized wait to avoid multiprocessing issues
-                continue
-            if not self._idle():
-                time.sleep(10 * random.random())
-                continue
-            _map_objs_precreated.put((mapfile, self._create_map_obj(mapfile)))
-            # prefer creating currently needed maps to filling the cache
-            time.sleep(5 + (10 * random.random()))
 
     def get_map(self, query):
         if self.res_range and not self.res_range.contains(query.bbox, query.size,
@@ -136,23 +99,9 @@ class MapnikSource(MapLayer):
     def _create_map_obj(self, mapfile):
         m = mapnik.Map(0, 0)
         mapnik.load_map(m, str(mapfile))
-        global _last_mapfile
-        _last_mapfile = mapfile
         return m
 
-    def _get_map_obj(self, mapfile):
-        while not _map_objs_precreated.empty():
-            try:
-                mf, m = _map_objs_precreated.get()
-            except queue.Empty:
-                break
-            if mf == mapfile:
-                return m
-        return self._create_map_obj(mapfile)
-
     def map_obj(self, mapfile):
-        # avoid concurrent cache filling
-        self._restart_idle_timer()
         # cache loaded map objects
         # only works when a single proc/thread accesses the map
         # (forking the render process doesn't work because of open database
@@ -165,7 +114,7 @@ class MapnikSource(MapLayer):
             process_id = multiprocessing.current_process()._identity
             cachekey = (process_id, thread_id, mapfile)
         if cachekey not in _map_objs:
-            _map_objs[cachekey] = self._get_map_obj(mapfile)
+            _map_objs[cachekey] = self._create_map_obj(mapfile)
 
         # clean up no longer used cached maps
         process_cache_keys = [k for k in _map_objs.keys()
@@ -182,7 +131,6 @@ class MapnikSource(MapLayer):
                     m.remove_all() # cleanup
                     mapnik.clear_cache()
 
-        self._restart_idle_timer()
         return _map_objs[cachekey]
 
     def render_mapfile(self, mapfile, query):

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -41,9 +41,12 @@ except ImportError:
         mapnik = None
 
 try:
-    import queue.Queue as Queue
-    import queue.Empty as Empty
-    import queue.Full as Full
+    import queue
+    import queue
+    import queue
+    Queue = queue.Queue
+    Empty = queue.Empty
+    Full = queue.Full
 except ImportError: # in python2 it is called Queue
     import Queue
     import Queue.Empty as Empty

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -50,8 +50,7 @@ log = logging.getLogger(__name__)
 class MapnikSource(MapLayer):
     supports_meta_tiles = True
     def __init__(self, mapfile, layers=None, image_opts=None, coverage=None,
-                 res_range=None, lock=None, reuse_map_objects=False, scale_factor=None,
-                 concurrent_tile_creators=None):
+                 res_range=None, lock=None, reuse_map_objects=False, scale_factor=None):
         MapLayer.__init__(self, image_opts=image_opts)
         self.mapfile = mapfile
         self.coverage = coverage

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -125,7 +125,7 @@ class MapnikSource(MapLayer):
                 return _map_objs_queues[queue_cachekey].get_nowait()
             except Empty:
                 pass
-        return _create_map_obj(self, mapfile)
+        return self._create_map_obj(self, mapfile)
 
     def _put_unused_map_obj(self, mapfile, m):
         process_id = multiprocessing.current_process()._identity

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -42,8 +42,6 @@ except ImportError:
 
 try:
     import queue
-    import queue
-    import queue
     Queue = queue.Queue
     Empty = queue.Empty
     Full = queue.Full

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -61,7 +61,8 @@ log = logging.getLogger(__name__)
 class MapnikSource(MapLayer):
     supports_meta_tiles = True
     def __init__(self, mapfile, layers=None, image_opts=None, coverage=None,
-                 res_range=None, lock=None, reuse_map_objects=False, scale_factor=None):
+                 res_range=None, lock=None, reuse_map_objects=False,
+                 scale_factor=None, multithreaded=False):
         MapLayer.__init__(self, image_opts=image_opts)
         self.mapfile = mapfile
         self.coverage = coverage
@@ -69,18 +70,43 @@ class MapnikSource(MapLayer):
         self.layers = set(layers) if layers else None
         self.scale_factor = scale_factor
         self.lock = lock
-        # global objects allow caching over multiple instances within the same worker process
-        global _map_objs # mapnik map objects by cachekey
-        _map_objs = {}
-        global _map_objs_lock
-        _map_objs_lock = threading.Lock()
-        global _map_objs_queues # queues of unused mapnik map objects by PID and mapfile
-        _map_objs_queues = {}
+        self.multithreaded = multithreaded
         self._cache_map_obj = reuse_map_objects
         if self.coverage:
             self.extent = MapExtent(self.coverage.bbox, self.coverage.srs)
         else:
             self.extent = DefaultMapExtent()
+        if multithreaded:
+            # global objects allow caching over multiple instances within the same worker process
+            global _map_objs # mapnik map objects by cachekey
+            _map_objs = {}
+            global _map_objs_lock
+            _map_objs_lock = threading.Lock()
+            global _map_objs_queues # queues of unused mapnik map objects by PID and mapfile
+            _map_objs_queues = {}
+        else:
+            # instance variables guarantee separation of caches
+            self._map_objs = {}
+            self._map_objs_lock = threading.Lock()
+
+    def _map_cache(self):
+        """Get the cache for map objects.
+
+        Uses an instance variable for containment when multithreaded
+        operation is disabled.
+        """
+        if self.multithreaded:
+            return _map_objs
+        return self._map_objs
+    def _map_cache_lock(self):
+        """Get the cache-locks for map objects.
+
+        Uses an instance variable for containment when multithreaded
+        operation is disabled.
+        """
+        if self.multithreaded:
+            return _map_objs_lock
+        return self._map_objs_lock
 
     def get_map(self, query):
         if self.res_range and not self.res_range.contains(query.bbox, query.size,
@@ -117,6 +143,9 @@ class MapnikSource(MapLayer):
         return m
 
     def _get_map_obj(self, mapfile):
+        if not self.multithreaded:
+            return self._create_map_obj(mapfile, None)
+
         process_id = multiprocessing.current_process()._identity
         queue_cachekey = (process_id, mapfile)
         if queue_cachekey in _map_objs_queues:
@@ -142,26 +171,20 @@ class MapnikSource(MapLayer):
             m.remove_all()
             mapnik.clear_cache()
 
-    def map_obj(self, mapfile):
-        # cache loaded map objects
-        # only works when a single proc/thread accesses the map
-        # (forking the render process doesn't work because of open database
-        #  file handles that gets passed to the child)
-        # segment the cache by process and thread to avoid interference
-        if self._cache_map_obj:
+    def _get_cachekey(self, mapfile):
+        if not self.multithreaded or self._cache_map_obj:
             # all MapnikSources with the same mapfile share the same Mapnik Map.
-            cachekey = (None, None, mapfile)
-        else:
-            thread_id = threading.current_thread().ident
-            process_id = multiprocessing.current_process()._identity
-            cachekey = (process_id, thread_id, mapfile)
-        with _map_objs_lock:
-            if cachekey not in _map_objs:
-                _map_objs[cachekey] = self._get_map_obj(mapfile)
-            mapnik_map = _map_objs[cachekey]
+            return (None, None, mapfile)
+        thread_id = threading.current_thread().ident
+        process_id = multiprocessing.current_process()._identity
+        return (process_id, thread_id, mapfile)
 
+    def _cleanup_unused_cached_maps(self, mapfile):
+        if not self.multithreaded:
+            return
         # clean up no longer used cached maps
-        process_cache_keys = [k for k in _map_objs.keys()
+        process_id = multiprocessing.current_process()._identity
+        process_cache_keys = [k for k in self._map_cache().keys()
                               if k[0] == process_id]
         # To avoid time-consuming cleanup whenever one thread in the
         # threadpool finishes, allow ignoring up to 5 dead mapnik
@@ -169,17 +192,31 @@ class MapnikSource(MapLayer):
         if len(process_cache_keys) > (5 + threading.active_count()):
             active_thread_ids = set(i.ident for i in threading.enumerate())
             for k in process_cache_keys:
-                with _map_objs_lock:
-                    if not k[1] in active_thread_ids and k in _map_objs:
+                with self._map_cache_lock():
+                    if not k[1] in active_thread_ids and k in self._map_cache():
                         try:
-                            m = _map_objs[k]
-                            del _map_objs[k]
+                            m = self._map_cache()[k]
+                            del self._map_cache()[k]
                             # put the map into the queue of unused
                             # maps so it can be re-used from another
                             # thread.
                             self._put_unused_map_obj(mapfile, m)
                         except KeyError:
                             continue
+
+    def map_obj(self, mapfile):
+        # cache loaded map objects
+        # only works when a single proc/thread accesses the map
+        # (forking the render process doesn't work because of open database
+        #  file handles that gets passed to the child)
+        # segment the cache by process and thread to avoid interference
+        cachekey = self._get_cachekey(mapfile)
+        with self._map_cache_lock():
+            if cachekey not in self._map_cache():
+                self._map_cache()[cachekey] = self._get_map_obj(mapfile)
+            mapnik_map = self._map_cache()[cachekey]
+
+        self._cleanup_unused_cached_maps(mapfile)
 
         return mapnik_map
 
@@ -200,7 +237,7 @@ class MapnikSource(MapLayer):
             if self.layers:
                 i = 0
                 for layer in m.layers[:]:
-                    if layer.name != 'Unkown' and layer.name not in self.layers:
+                    if layer.name != 'Unknown' and layer.name not in self.layers:
                         del m.layers[i]
                     else:
                         i += 1

--- a/mapproxy/test/system/fixture/mapnik_source.yaml
+++ b/mapproxy/test/system/fixture/mapnik_source.yaml
@@ -5,6 +5,9 @@ layers:
   - name: mapnik
     title: Mapnik Source
     sources: [mapnik]
+  - name: mapnik_seed
+    title: Mapnik Seed
+    sources: [mapnik_seed]
   - name: mapnik_hq
     title: Mapnik Source with scale-factor 2
     sources: [mapnik_hq]
@@ -26,6 +29,14 @@ sources:
     coverage:
       bbox: [-170, -80, 180, 90]
       bbox_srs: 'EPSG:4326'
+
+  mapnik_seed:
+    type: mapnik
+    mapfile: ./mapnik.xml
+    coverage:
+      bbox: [-170, -80, 180, 90]
+      bbox_srs: 'EPSG:4326'
+    multithreaded: True
 
   mapnik_hq:
     type: mapnik


### PR DESCRIPTION
This pull-request recovers caching of the mapnik object by segmenting the cache by process_id and thread_id, both for seeding and for serving. To avoid delays in serving after threads are reaped, mapnik.Map(…) objects are pregenerated for the least recently used mapfile.

The segmented cache speeds up the seeding process in our setup by at least factor 4 and pregeneration of the maps reduces the delay for serving not-yet-cached map tiles is reduced from ~5 seconds to ~1 second.

Licensing under Apache license is OK.

I’d be glad if you could merge these changes and hope they prove useful!

rebase of https://github.com/mapproxy/mapproxy/pull/401 on top of current master.