### PR TITLE
tileservices: add Cache-Status HTTP header to inform HIT or MISS on cached tiles

### DIFF
--- a/mapproxy/config/defaults.py
+++ b/mapproxy/config/defaults.py
@@ -64,6 +64,7 @@ cache = dict(
     minimize_meta_requests = False,
     link_single_color_images = False,
     sqlite_timeout = 30,
+    show_cache_status = False
 )
 
 grid = dict(

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1473,6 +1473,11 @@ class CacheConfiguration(ConfigurationBase):
         concurrent_tile_creators = self.context.globals.get_value('concurrent_tile_creators', self.conf,
             global_key='cache.concurrent_tile_creators')
 
+        show_cache_status = self.context.globals.get_value('show_cache_status', self.conf,
+            global_key='cache.show_cache_status')
+        show_cache_status = bool(str(show_cache_status).lower() == 'true') if show_cache_status is not None else False
+
+
         cache_rescaled_tiles = self.conf.get('cache_rescaled_tiles')
         upscale_tiles = self.conf.get('upscale_tiles', 0)
         if upscale_tiles < 0:
@@ -1559,6 +1564,7 @@ class CacheConfiguration(ConfigurationBase):
                         lock_timeout=self.context.globals.get_value('http.client_timeout', {}),
                         lock_cache_id=cache.lock_cache_id,
                 )
+
             mgr = TileManager(tile_grid, cache, sources, image_opts.format.ext,
                 locker=locker,
                 image_opts=image_opts, identifier=identifier,
@@ -1571,6 +1577,7 @@ class CacheConfiguration(ConfigurationBase):
                 bulk_meta_tiles=bulk_meta_tiles,
                 cache_rescaled_tiles=cache_rescaled_tiles,
                 rescale_tiles=rescale_tiles,
+                show_cache_status=show_cache_status
             )
             extent = merge_layer_extents(sources)
             if extent.is_default:
@@ -2150,5 +2157,3 @@ def parse_color(color):
         return r, g, b, a
 
     return r, g, b
-
-

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1477,7 +1477,6 @@ class CacheConfiguration(ConfigurationBase):
             global_key='cache.show_cache_status')
         show_cache_status = bool(str(show_cache_status).lower() == 'true') if show_cache_status is not None else False
 
-
         cache_rescaled_tiles = self.conf.get('cache_rescaled_tiles')
         upscale_tiles = self.conf.get('upscale_tiles', 0)
         if upscale_tiles < 0:

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -376,6 +376,7 @@ mapproxy_yaml_spec = {
                 'region_name': str(),
                 'endpoint_url': str(),
             },
+            'show_cache_status': bool(),
         },
         'grid': {
             'tile_size': [int()],
@@ -425,7 +426,8 @@ mapproxy_yaml_spec = {
                 'opacity': number(),
                 'spacing': str(),
             },
-            'cache': type_spec('type', cache_types)
+            'cache': type_spec('type', cache_types),
+            'show_cache_status': bool()
         }
     },
     'services': {
@@ -591,4 +593,3 @@ mapproxy_yaml_spec = {
      # from other sections (e.g. coverages, dimensions, etc.)
     'parts': anything(),
 }
-

--- a/mapproxy/response.py
+++ b/mapproxy/response.py
@@ -69,7 +69,7 @@ class Response(object):
 
     etag = property(_etag_get, _etag_set)
 
-    def cache_headers(self, timestamp=None, etag_data=None, max_age=None, no_cache=False):
+    def cache_headers(self, timestamp=None, etag_data=None, max_age=None, no_cache=False, cache_hit=None):
         """
         Set cache-related headers.
 
@@ -92,6 +92,9 @@ class Response(object):
         self.last_modified = timestamp
         if (timestamp or etag_data) and max_age is not None:
             self.headers['Cache-control'] = 'public, max-age=%d, s-maxage=%d' % (max_age, max_age)
+
+        if cache_hit is not None:
+            self.headers['Cache-Status'] = 'HIT' if cache_hit == True else 'MISS'
 
     def make_conditional(self, req):
         """

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -399,6 +399,7 @@ class ImageResponse(object):
         self.format = format
         self.size = 0
         self.cacheable = True
+        self.cache_hit = False
 
     def as_buffer(self):
         return self.img
@@ -415,6 +416,7 @@ class TileResponse(object):
         self.cacheable = tile.cacheable
         self._buf = self.tile.source_buffer(format=format, image_opts=image_opts)
         self.format = format or self._format_from_magic_bytes()
+        self.cache_hit = tile.cache_hit
 
     def as_buffer(self):
         return self._buf

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -104,7 +104,7 @@ class WMTSServer(Server):
         # set the content_type to tile.format and not to request.format ( to support mixed_mode)
         resp = Response(tile.as_buffer(), content_type='image/' + tile.format)
         resp.cache_headers(tile.timestamp, etag_data=(tile.timestamp, tile.size),
-                           max_age=self.max_tile_age)
+                           max_age=self.max_tile_age, cache_hit=tile.cache_hit)
         resp.make_conditional(request.http)
         return resp
 
@@ -115,12 +115,12 @@ class WMTSServer(Server):
         tile_layer = self.layers[request.layer][request.tilematrixset]
         if not request.format:
             request.format = tile_layer.format
-        
+
         feature_count = None
         # WMTS REST style request do not have request params
         if hasattr(request, 'params'):
             feature_count = request.params.get('feature_count', None)
-        
+
         bbox = tile_layer.grid.tile_bbox(request.tile)
         query = InfoQuery(bbox, tile_layer.grid.tile_size, tile_layer.grid.srs, request.pos,
                           request.infoformat, feature_count=feature_count)


### PR DESCRIPTION
Once enabled by the config directive show_cache_status, the non-standard
HTTP header Cache-Status will provide information whether the response data
origin is cached data (HIT) or not (MISS).
Also, on each thousand requests made to the tile services, it will be logged the
ratio (%) of hits and misses.