### PR TITLE
capabilities: Cache the capabilities document as static per config

### DIFF
--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -168,13 +168,12 @@ class TileServer(Server):
         :rtype: Response
         """
         key = "{}{}{}{}{}{}{}".format(
-                tms_request.mime_type,
                 tms_request.version,
-                request.http.environ.get('mapproxy.authorize', ''),
-                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
-                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
-                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
-                request.http.environ.get('HTTP_HOST', ''))
+                tms_request.http.environ.get('mapproxy.authorize', ''),
+                tms_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                tms_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                tms_request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                tms_request.http.environ.get('HTTP_HOST', ''))
 
         if not key in self.capabilities_cache:
             cached = False

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -167,7 +167,7 @@ class TileServer(Server):
         :return: the rendered tms capabilities
         :rtype: Response
         """
-        if self.capabilities_cache is None:
+        if self.capabilities_cache is None or 'mapproxy.authorize' in tms_request.http.environ:
             cached = False
             service = self._service_md(tms_request)
             if hasattr(tms_request, 'layer'):
@@ -176,7 +176,8 @@ class TileServer(Server):
             else:
                 layers = self.authorized_tile_layers(tms_request.http.environ)
                 result = self._render_template(layers, service)
-            self.capabilities_cache = result
+            if (not 'mapproxy.authorize' in tms_request.http.environ):
+                self.capabilities_cache = result
         else:
             cached = True
             result = self.capabilities_cache

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -170,11 +170,11 @@ class TileServer(Server):
         key = "{}{}{}{}{}{}{}".format(
                 tms_request.mime_type,
                 tms_request.version,
-                tms_request.http.environ['mapproxy.authorize'],
-                tms_request.http.environ['HTTP_X_FORWARDED_PROTO'],
-                tms_request.http.environ['HTTP_X_FORWARDED_HOST'],
-                tms_request.http.environ['HTTP_X_SCRIPT_NAME'],
-                tms_request.http.environ['HTTP_HOST'])
+                request.http.environ.get('mapproxy.authorize', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                request.http.environ.get('HTTP_HOST', ''))
 
         if not key in self.capabilities_cache:
             cached = False

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -168,7 +168,6 @@ class TileServer(Server):
         :rtype: Response
         """
         key = "{}{}{}{}{}{}{}".format(
-                tms_request.version,
                 tms_request.http.environ.get('mapproxy.authorize', ''),
                 tms_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 tms_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
@@ -188,7 +187,7 @@ class TileServer(Server):
                 self.capabilities_cache[key] = result
         else:
             cached = True
-            result = self.capabilities_cache
+            result = self.capabilities_cache[key]
         response = Response(result, mimetype='text/xml')
         response.headers['Cache-Status'] = 'HIT' if cached else 'MISS'
         return response

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -167,7 +167,7 @@ class TileServer(Server):
         :return: the rendered tms capabilities
         :rtype: Response
         """
-        key = "{}{}{}{}{}{}{}".format(
+        key = "{}{}{}{}{}".format(
                 tms_request.http.environ.get('mapproxy.authorize', ''),
                 tms_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 tms_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -180,7 +180,15 @@ class WMSServer(Server):
         #     layers = [layer for name, layer in iteritems(self.layers)
         #               if name != '__debug__']
 
-        if not map_request.mime_type in self.capabilities_cache or 'mapproxy.authorize' in map_request.http.environ:
+        key = "{}{}{}{}{}{}{}".format(
+                map_request.mime_type,
+                map_request.version,
+                map_request.http.environ['mapproxy.authorize'],
+                map_request.http.environ['HTTP_X_FORWARDED_PROTO'],
+                map_request.http.environ['HTTP_X_FORWARDED_HOST'],
+                map_request.http.environ['HTTP_X_SCRIPT_NAME'],
+                map_request.http.environ['HTTP_HOST'])
+        if not key in self.capabilities_cache:
             cached = False
             if map_request.params.get('tiled', 'false').lower() == 'true':
                 tile_layers = self.tile_layers.values()
@@ -201,7 +209,7 @@ class WMSServer(Server):
                 inspire_md=self.inspire_md, max_output_pixels=self.max_output_pixels
                 ).render(map_request)
             if (not 'mapproxy.authorize' in map_request.http.environ):
-                self.capabilities_cache[map_request.mime_type] = result
+                self.capabilities_cache[key] = result
         else:
             cached = True
             result = self.capabilities_cache[map_request.mime_type]

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -181,8 +181,8 @@ class WMSServer(Server):
         #               if name != '__debug__']
 
         key = "{}{}{}{}{}{}{}".format(
-                '' if not 'mime_type' in map_request else map_request.mime_type,
-                '' if not 'version' in map_request else map_request.version,
+                map_request.mime_type or '',
+                '' if not 'version' in map_request.request_params else map_request.request_params.version,
                 map_request.http.environ.get('mapproxy.authorize', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -180,7 +180,7 @@ class WMSServer(Server):
         #     layers = [layer for name, layer in iteritems(self.layers)
         #               if name != '__debug__']
 
-        if not map_request.mime_type in self.capabilities_cache:
+        if not map_request.mime_type in self.capabilities_cache or 'mapproxy.authorize' in map_request.http.environ:
             cached = False
             if map_request.params.get('tiled', 'false').lower() == 'true':
                 tile_layers = self.tile_layers.values()
@@ -200,7 +200,8 @@ class WMSServer(Server):
                 self.image_formats, info_formats, srs=self.srs, srs_extents=self.srs_extents,
                 inspire_md=self.inspire_md, max_output_pixels=self.max_output_pixels
                 ).render(map_request)
-            self.capabilities_cache[map_request.mime_type] = result
+            if (not 'mapproxy.authorize' in map_request.http.environ):
+                self.capabilities_cache[map_request.mime_type] = result
         else:
             cached = True
             result = self.capabilities_cache[map_request.mime_type]

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -182,7 +182,7 @@ class WMSServer(Server):
 
         key = "{}{}{}{}{}{}{}".format(
                 map_request.mime_type or '',
-                '' if not 'version' in map_request.request_params else map_request.request_params.version,
+                '' if not 'version' in map_request.params else map_request.params.version,
                 map_request.http.environ.get('mapproxy.authorize', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -181,8 +181,8 @@ class WMSServer(Server):
         #               if name != '__debug__']
 
         key = "{}{}{}{}{}{}{}".format(
-                map_request.mime_type,
-                map_request.version,
+                map_request.get('mime_type', ''),
+                map_request.get('version', ''),
                 map_request.http.environ.get('mapproxy.authorize', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -183,11 +183,11 @@ class WMSServer(Server):
         key = "{}{}{}{}{}{}{}".format(
                 map_request.mime_type,
                 map_request.version,
-                request.http.environ.get('mapproxy.authorize', ''),
-                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
-                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
-                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
-                request.http.environ.get('HTTP_HOST', ''))
+                map_request.http.environ.get('mapproxy.authorize', ''),
+                map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                map_request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                map_request.http.environ.get('HTTP_HOST', ''))
         if not key in self.capabilities_cache:
             cached = False
             if map_request.params.get('tiled', 'false').lower() == 'true':

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -212,7 +212,7 @@ class WMSServer(Server):
                 self.capabilities_cache[key] = result
         else:
             cached = True
-            result = self.capabilities_cache[map_request.mime_type]
+            result = self.capabilities_cache[key]
         response = Response(result, mimetype=map_request.mime_type)
         response.headers['Cache-Status'] = 'HIT' if cached else 'MISS'
         return response

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -181,8 +181,8 @@ class WMSServer(Server):
         #               if name != '__debug__']
 
         key = "{}{}{}{}{}{}{}".format(
-                map_request.get('mime_type', ''),
-                map_request.get('version', ''),
+                '' if not 'mime_type' in map_request else map_request.mime_type,
+                '' if not 'version' in map_request else map_request.version,
                 map_request.http.environ.get('mapproxy.authorize', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -183,11 +183,11 @@ class WMSServer(Server):
         key = "{}{}{}{}{}{}{}".format(
                 map_request.mime_type,
                 map_request.version,
-                map_request.http.environ['mapproxy.authorize'],
-                map_request.http.environ['HTTP_X_FORWARDED_PROTO'],
-                map_request.http.environ['HTTP_X_FORWARDED_HOST'],
-                map_request.http.environ['HTTP_X_SCRIPT_NAME'],
-                map_request.http.environ['HTTP_HOST'])
+                request.http.environ.get('mapproxy.authorize', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                request.http.environ.get('HTTP_HOST', ''))
         if not key in self.capabilities_cache:
             cached = False
             if map_request.params.get('tiled', 'false').lower() == 'true':

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -78,7 +78,7 @@ class WMTSServer(Server):
         return wmts_layers, sets.values()
 
     def capabilities(self, request):
-        key = "{}{}{}{}{}{}{}".format(
+        key = "{}{}{}{}{}{}".format(
                 request.version,
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -79,7 +79,7 @@ class WMTSServer(Server):
 
     def capabilities(self, request):
         key = "{}{}{}{}{}{}".format(
-                request.mime_type,
+                '' if not 'mime_type' in request else request.mime_type,
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -81,11 +81,11 @@ class WMTSServer(Server):
         key = "{}{}{}{}{}{}{}".format(
                 request.mime_type,
                 request.version,
-                request.http.environ['mapproxy.authorize'],
-                request.http.environ['HTTP_X_FORWARDED_PROTO'],
-                request.http.environ['HTTP_X_FORWARDED_HOST'],
-                request.http.environ['HTTP_X_SCRIPT_NAME'],
-                request.http.environ['HTTP_HOST'])
+                request.http.environ.get('mapproxy.authorize', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                request.http.environ.get('HTTP_HOST', ''))
         if not key in self.capabilities_cache:
             cached = False
             service = self._service_md(request)

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -79,7 +79,6 @@ class WMTSServer(Server):
 
     def capabilities(self, request):
         key = "{}{}{}{}{}{}{}".format(
-                request.mime_type,
                 request.version,
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -79,7 +79,7 @@ class WMTSServer(Server):
 
     def capabilities(self, request):
         key = "{}{}{}{}{}{}".format(
-                request.get('version', ''),
+                '' if not 'version' in request else request.version,
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -79,7 +79,7 @@ class WMTSServer(Server):
 
     def capabilities(self, request):
         key = "{}{}{}{}{}{}".format(
-                request.version,
+                request.get('version', ''),
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -94,7 +94,7 @@ class WMTSServer(Server):
                 self.capabilities_cache[key] = result
         else:
             cached = True
-            result = self.capabilities_cache
+            result = self.capabilities_cache[key]
         response = Response(result, mimetype='application/xml')
         response.headers['Cache-Status'] = 'HIT' if cached else 'MISS'
         return response

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -79,7 +79,7 @@ class WMTSServer(Server):
 
     def capabilities(self, request):
         key = "{}{}{}{}{}{}".format(
-                '' if not 'version' in request else request.version,
+                request.mime_type,
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -78,12 +78,13 @@ class WMTSServer(Server):
         return wmts_layers, sets.values()
 
     def capabilities(self, request):
-        if self.capabilities_cache is None:
+        if self.capabilities_cache is None or 'mapproxy.authorize' in request.http.environ:
             cached = False
             service = self._service_md(request)
             layers = self.authorized_tile_layers(request.http.environ)
             result = self.capabilities_class(service, layers, self.matrix_sets, info_formats=self.info_formats).render(request)
-            self.capabilities_cache = result
+            if (not 'mapproxy.authorize' in request.http.environ):
+                self.capabilities_cache = result
         else:
             cached = True
             result = self.capabilities_cache


### PR DESCRIPTION
Each time the config file gets loaded (or reloaded), all server objects
are recreated. So it is safe do store the capabilities document, once
generated, as a static document. The first request to getCapabilities
will render de document and store it as static. All other requests will
get the static document until the configuration is reloaded, when a new
document will be rendered and stored again.
The Cache-Status non-standard HTTP header will inform if the capabilities document
was rendered or was retrieved from cache (static variable).