### PR TITLE
capabilities: Cache the capabilities document as static per config/request/environment

### DIFF
--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -167,13 +167,10 @@ class TileServer(Server):
         :return: the rendered tms capabilities
         :rtype: Response
         """
-        key = "{}{}{}{}{}".format(
+        key = "{}|{}|{}".format(
+                '' if not hasattr(tms_request, 'layer') else tms_request.layer,
                 tms_request.http.environ.get('mapproxy.authorize', ''),
-                tms_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
-                tms_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
-                tms_request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
-                tms_request.http.environ.get('HTTP_HOST', ''))
-
+                tms_request.script_url)
         if not key in self.capabilities_cache:
             cached = False
             service = self._service_md(tms_request)

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -167,10 +167,12 @@ class TileServer(Server):
         :return: the rendered tms capabilities
         :rtype: Response
         """
-        key = "{}|{}|{}".format(
+        key = "{}|{}|{}|{}|{}".format(
                 '' if not hasattr(tms_request, 'layer') else tms_request.layer,
                 tms_request.http.environ.get('mapproxy.authorize', ''),
-                tms_request.script_url)
+                tms_request.http.environ.get('HTTP_X_FORWARDED_HOST') or tms_request.http.environ.get('HTTP_HOST') or (tms_request.http.environ.get('SERVER_NAME') + ':' + tms_request.http.environ.get('SERVER_PORT')),
+                tms_request.http.environ.get('HTTP_X_FORWARDED_PROTO') or tms_request.http.environ.get('wsgi.url_scheme'),
+                tms_request.http.environ.get('HTTP_X_SCRIPT_NAME') or tms_request.http.environ.get('SCRIPT_NAME'))
         if not key in self.capabilities_cache:
             cached = False
             service = self._service_md(tms_request)

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -78,6 +78,7 @@ class WMSServer(Server):
         self.max_output_pixels = max_output_pixels
         self.max_tile_age = max_tile_age
         self.inspire_md = inspire_md
+        self.capabilities_cache = {}
 
     def map(self, map_request):
         self.check_map_request(map_request)
@@ -179,25 +180,42 @@ class WMSServer(Server):
         #     layers = [layer for name, layer in iteritems(self.layers)
         #               if name != '__debug__']
 
-        if map_request.params.get('tiled', 'false').lower() == 'true':
-            tile_layers = self.tile_layers.values()
+        key = "{}{}{}{}{}{}{}".format(
+                map_request.mime_type or '',
+                '' if not 'version' in map_request.params else map_request.params.version,
+                map_request.http.environ.get('mapproxy.authorize', ''),
+                map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                map_request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                map_request.http.environ.get('HTTP_HOST', ''))
+        if not key in self.capabilities_cache:
+            cached = False
+            if map_request.params.get('tiled', 'false').lower() == 'true':
+                tile_layers = self.tile_layers.values()
+            else:
+                tile_layers = []
+
+            service = self._service_md(map_request)
+            root_layer = self.authorized_capability_layers(map_request.http.environ)
+
+            info_types = ['text', 'html', 'xml'] # defaults
+            if self.info_types:
+                info_types = self.info_types
+            elif self.fi_transformers:
+                info_types = self.fi_transformers.keys()
+            info_formats = [mimetype_from_infotype(map_request.version, info_type) for info_type in info_types]
+            result = Capabilities(service, root_layer, tile_layers,
+                self.image_formats, info_formats, srs=self.srs, srs_extents=self.srs_extents,
+                inspire_md=self.inspire_md, max_output_pixels=self.max_output_pixels
+                ).render(map_request)
+            if (not 'mapproxy.authorize' in map_request.http.environ):
+                self.capabilities_cache[key] = result
         else:
-            tile_layers = []
-
-        service = self._service_md(map_request)
-        root_layer = self.authorized_capability_layers(map_request.http.environ)
-
-        info_types = ['text', 'html', 'xml'] # defaults
-        if self.info_types:
-            info_types = self.info_types
-        elif self.fi_transformers:
-            info_types = self.fi_transformers.keys()
-        info_formats = [mimetype_from_infotype(map_request.version, info_type) for info_type in info_types]
-        result = Capabilities(service, root_layer, tile_layers,
-            self.image_formats, info_formats, srs=self.srs, srs_extents=self.srs_extents,
-            inspire_md=self.inspire_md, max_output_pixels=self.max_output_pixels
-            ).render(map_request)
-        return Response(result, mimetype=map_request.mime_type)
+            cached = True
+            result = self.capabilities_cache[key]
+        response = Response(result, mimetype=map_request.mime_type)
+        response.headers['Cache-Status'] = 'HIT' if cached else 'MISS'
+        return response
 
     def featureinfo(self, request):
         infos = []

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -180,14 +180,11 @@ class WMSServer(Server):
         #     layers = [layer for name, layer in iteritems(self.layers)
         #               if name != '__debug__']
 
-        key = "{}{}{}{}{}{}{}".format(
+        key = "{}|{}|{}|{}".format(
                 map_request.mime_type or '',
                 '' if not 'version' in map_request.params else map_request.params.version,
                 map_request.http.environ.get('mapproxy.authorize', ''),
-                map_request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
-                map_request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
-                map_request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
-                map_request.http.environ.get('HTTP_HOST', ''))
+                map_request.script_url)
         if not key in self.capabilities_cache:
             cached = False
             if map_request.params.get('tiled', 'false').lower() == 'true':

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -180,11 +180,13 @@ class WMSServer(Server):
         #     layers = [layer for name, layer in iteritems(self.layers)
         #               if name != '__debug__']
 
-        key = "{}|{}|{}|{}".format(
-                map_request.mime_type or '',
-                '' if not 'version' in map_request.params else map_request.params.version,
+        key = "{}|{}|{}|{}|{}|{}".format(
+                map_request.version,
+                map_request.mime_type,
                 map_request.http.environ.get('mapproxy.authorize', ''),
-                map_request.script_url)
+                map_request.http.environ.get('HTTP_X_FORWARDED_HOST') or map_request.http.environ.get('HTTP_HOST') or (map_request.http.environ.get('SERVER_NAME') + ':' + map_request.http.environ.get('SERVER_PORT')),
+                map_request.http.environ.get('HTTP_X_FORWARDED_PROTO') or map_request.http.environ.get('wsgi.url_scheme'),
+                map_request.http.environ.get('HTTP_X_SCRIPT_NAME') or map_request.http.environ.get('SCRIPT_NAME'))
         if not key in self.capabilities_cache:
             cached = False
             if map_request.params.get('tiled', 'false').lower() == 'true':

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -78,10 +78,12 @@ class WMTSServer(Server):
         return wmts_layers, sets.values()
 
     def capabilities(self, request):
-        key = "{}|{}|{}".format(
-                '' if not hasattr(request, 'mime_type') else request.mime_type,
+        key = "{}|{}|{}|{}|{}".format(
+                request.mime_type,
                 request.http.environ.get('mapproxy.authorize', ''),
-                request.script_url)
+                request.http.environ.get('HTTP_X_FORWARDED_HOST') or request.http.environ.get('HTTP_HOST') or (request.http.environ.get('SERVER_NAME') + ':' + request.http.environ.get('SERVER_PORT')),
+                request.http.environ.get('HTTP_X_FORWARDED_PROTO') or request.http.environ.get('wsgi.url_scheme'),
+                request.http.environ.get('HTTP_X_SCRIPT_NAME') or request.http.environ.get('SCRIPT_NAME'))
         if not key in self.capabilities_cache:
             cached = False
             service = self._service_md(request)

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -78,13 +78,10 @@ class WMTSServer(Server):
         return wmts_layers, sets.values()
 
     def capabilities(self, request):
-        key = "{}{}{}{}{}{}".format(
+        key = "{}|{}|{}".format(
                 '' if not hasattr(request, 'mime_type') else request.mime_type,
                 request.http.environ.get('mapproxy.authorize', ''),
-                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
-                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
-                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
-                request.http.environ.get('HTTP_HOST', ''))
+                request.script_url)
         if not key in self.capabilities_cache:
             cached = False
             service = self._service_md(request)

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -79,7 +79,7 @@ class WMTSServer(Server):
 
     def capabilities(self, request):
         key = "{}|{}|{}|{}|{}".format(
-                request.mime_type,
+                'text/xml' if not hasattr(request, 'mime_type') else request.mime_type,
                 request.http.environ.get('mapproxy.authorize', ''),
                 request.http.environ.get('HTTP_X_FORWARDED_HOST') or request.http.environ.get('HTTP_HOST') or (request.http.environ.get('SERVER_NAME') + ':' + request.http.environ.get('SERVER_PORT')),
                 request.http.environ.get('HTTP_X_FORWARDED_PROTO') or request.http.environ.get('wsgi.url_scheme'),

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -55,6 +55,7 @@ class WMTSServer(Server):
         self.capabilities_class = Capabilities
         self.fi_transformers = None
         self.info_formats = info_formats
+        self.capabilities_cache = {}
 
     def _matrix_sets(self, layers):
         sets = {}
@@ -77,12 +78,26 @@ class WMTSServer(Server):
         return wmts_layers, sets.values()
 
     def capabilities(self, request):
-        service = self._service_md(request)
-        layers = self.authorized_tile_layers(request.http.environ)
-
-
-        result = self.capabilities_class(service, layers, self.matrix_sets, info_formats=self.info_formats).render(request)
-        return Response(result, mimetype='application/xml')
+        key = "{}{}{}{}{}{}".format(
+                '' if not hasattr(request, 'mime_type') else request.mime_type,
+                request.http.environ.get('mapproxy.authorize', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_PROTO', ''),
+                request.http.environ.get('HTTP_X_FORWARDED_HOST', ''),
+                request.http.environ.get('HTTP_X_SCRIPT_NAME', ''),
+                request.http.environ.get('HTTP_HOST', ''))
+        if not key in self.capabilities_cache:
+            cached = False
+            service = self._service_md(request)
+            layers = self.authorized_tile_layers(request.http.environ)
+            result = self.capabilities_class(service, layers, self.matrix_sets, info_formats=self.info_formats).render(request)
+            if (not 'mapproxy.authorize' in request.http.environ):
+                self.capabilities_cache[key] = result
+        else:
+            cached = True
+            result = self.capabilities_cache[key]
+        response = Response(result, mimetype='application/xml')
+        response.headers['Cache-Status'] = 'HIT' if cached else 'MISS'
+        return response
 
     def tile(self, request):
         self.check_request(request)
@@ -115,12 +130,12 @@ class WMTSServer(Server):
         tile_layer = self.layers[request.layer][request.tilematrixset]
         if not request.format:
             request.format = tile_layer.format
-        
+
         feature_count = None
         # WMTS REST style request do not have request params
         if hasattr(request, 'params'):
             feature_count = request.params.get('feature_count', None)
-        
+
         bbox = tile_layer.grid.tile_bbox(request.tile)
         query = InfoQuery(bbox, tile_layer.grid.tile_size, tile_layer.grid.srs, request.pos,
                           request.infoformat, feature_count=feature_count)


### PR DESCRIPTION
Each time the config file gets loaded (or reloaded), all server objects
are recreated. So it should be safe to store the capabilities document, once
generated, as a static document if we generate one document for different
request version and/or mime_type, and also consider the mapproxy.authorization 
and host/url-related environmental variables.
The first request to getCapabilities will render de document and store it as static.
All other requests will get the static document until the configuration is reloaded,
there are diferent values in version or mime_type, differente environment variables
like HTTP_HOST, or the request is using mapproxy.authorize, when a new
document will be rendered and stored again.
The Cache-Status non-standard HTTP header will inform if the capabilities document
was rendered or was retrieved from cache (static variable).