### PR TITLE
Fix SyntaxWarning issues with Python 3.8.

### DIFF
--- a/mapproxy/test/unit/test_conf_loader.py
+++ b/mapproxy/test/unit/test_conf_loader.py
@@ -903,7 +903,7 @@ class TestImageOptions(object):
         except ConfigurationError:
             pass
         else:
-            raise False('expected ConfigurationError')
+            raise Exception('expected ConfigurationError')
 
 
         conf_dict['globals']['image']['formats']['image/jpeg']['encoding_options'] = {
@@ -914,7 +914,7 @@ class TestImageOptions(object):
         except ConfigurationError:
             pass
         else:
-            raise False('expected ConfigurationError')
+            raise Exception('expected ConfigurationError')
 
 
         conf_dict['globals']['image']['formats']['image/jpeg']['encoding_options'] = {}
@@ -924,7 +924,7 @@ class TestImageOptions(object):
         except ConfigurationError:
             pass
         else:
-            raise False('expected ConfigurationError')
+            raise Exception('expected ConfigurationError')
 
 
         conf_dict['globals']['image']['formats']['image/jpeg']['encoding_options'] = {

--- a/mapproxy/util/ext/wmsparse/parse.py
+++ b/mapproxy/util/ext/wmsparse/parse.py
@@ -53,7 +53,7 @@ class WMSCapabilities(object):
 
     def parse_contact(self):
         elem = self.find(self.tree, 'Service/ContactInformation')
-        if elem is None or len(elem) is 0:
+        if elem is None or len(elem) == 0:
             elem = etree.Element(None)
         md = dict(
             person = self.findtext(elem, 'ContactPersonPrimary/ContactPerson'),


### PR DESCRIPTION
A few SyntaxWarning issues are reported when installing the Debian packages with python3.8:

 * SyntaxWarning: 'bool' object is not callable; perhaps you missed a comma?
 * SyntaxWarning: "is" with a literal. Did you mean "=="?