### PR TITLE
Add detail to RequestErrors caused by MapBBOXError

### DIFF
--- a/mapproxy/layer.py
+++ b/mapproxy/layer.py
@@ -429,7 +429,7 @@ class CacheMapLayer(MapLayer):
         num_tiles = tile_grid[0] * tile_grid[1]
 
         if self.max_tile_limit and num_tiles >= self.max_tile_limit:
-            raise MapBBOXError("too many tiles")
+            raise MapBBOXError("too many tiles, max_tile_limit: %s, num_tiles: %s" % (self.max_tile_limit, num_tiles))
 
         if query.tiled_only:
             if num_tiles > 1:

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -640,8 +640,8 @@ class LayerRenderer(object):
             return layer, layer_img
         except SourceError:
             raise
-        except MapBBOXError:
-            raise RequestError('Request too large or invalid BBOX.', request=self.request)
+        except MapBBOXError as e:
+            raise RequestError('Request too large or invalid BBOX. (%s)' % e, request=self.request)
         except MapError as e:
             raise RequestError('Invalid request: %s' % e.args[0], request=self.request)
         except TransformationError:


### PR DESCRIPTION
Enable users to more easily determine the cause of a `MapBBOXError` caused by a large request by providing details of the reason.

I spent a while a few weeks ago trying to determine the cause of service exceptions related to WMS requests that where either `num_tiles > max_tile_limit` or dimensions > `max_output_pixels`.