### PR TITLE
Use compat imports for `cgi.escape` and `cgi.parse_qsl` Fix #462

### DIFF
--- a/mapproxy/service/templates/demo/capabilities_demo.html
+++ b/mapproxy/service/templates/demo/capabilities_demo.html
@@ -1,5 +1,5 @@
 {{py:
-import cgi
+from mapproxy.compat.modules import escape
 import textwrap
 
 wrapper = textwrap.TextWrapper(replace_whitespace=False, width=90,
@@ -12,7 +12,7 @@ jscript_functions = None
             <a href="{{url}}">{{url}}</a>
             <pre>
 {{for line in capabilities}}
-{{cgi.escape(wrapper.fill(line.decode('utf8')))}}
+{{escape(wrapper.fill(line.decode('utf8')))}}
 {{endfor}}
             </pre>
 

--- a/mapproxy/service/templates/demo/tms_demo.html
+++ b/mapproxy/service/templates/demo/tms_demo.html
@@ -1,5 +1,5 @@
 {{py:
-import cgi
+from mapproxy.compat.modules import escape
 import textwrap
 
 wrapper = textwrap.TextWrapper(replace_whitespace=False, width=90,
@@ -76,6 +76,6 @@ function init(){
             <h3>JavaScript code</h3>
             <pre>
 {{for line in jscript_openlayers().split('\n')}}
-{{cgi.escape(wrapper.fill(line))}}
+{{escape(wrapper.fill(line))}}
 {{endfor}}
             </pre>

--- a/mapproxy/service/templates/demo/wms_demo.html
+++ b/mapproxy/service/templates/demo/wms_demo.html
@@ -1,5 +1,5 @@
 {{py:
-import cgi
+from mapproxy.compat.modules import escape
 import textwrap
 
 wrapper = textwrap.TextWrapper(replace_whitespace=False, width=90,
@@ -72,6 +72,6 @@ jscript_functions=None
             <h3>JavaScript code</h3>
             <pre>
 {{for line in jscript_openlayers().split('\n')}}
-{{cgi.escape(wrapper.fill(line))}}
+{{escape(wrapper.fill(line))}}
 {{endfor}}
             </pre>

--- a/mapproxy/service/templates/demo/wmts_demo.html
+++ b/mapproxy/service/templates/demo/wmts_demo.html
@@ -1,5 +1,5 @@
 {{py:
-import cgi
+from mapproxy.compat.modules import escape
 import textwrap
 
 wrapper = textwrap.TextWrapper(replace_whitespace=False, width=90,
@@ -70,6 +70,6 @@ function init(){
             <h3>JavaScript code</h3>
             <pre>
 {{for line in jscript_openlayers().split('\n')}}
-{{cgi.escape(wrapper.fill(line))}}
+{{escape(wrapper.fill(line))}}
 {{endfor}}
             </pre>

--- a/mapproxy/util/ext/tempita/__init__.py
+++ b/mapproxy/util/ext/tempita/__init__.py
@@ -33,6 +33,7 @@ from __future__ import print_function
 import re
 import sys
 import cgi
+from mapproxy.compat.modules import escape
 import os
 import tokenize
 from io import StringIO, BytesIO
@@ -437,10 +438,10 @@ def html_quote(value, force=True):
     if not isinstance(value, basestring_):
         value = coerce_text(value)
     if sys.version >= "3" and isinstance(value, bytes):
-        value = cgi.escape(value.decode('latin1'), 1)
+        value = escape(value.decode('latin1'), 1)
         value = value.encode('latin1')
     else:
-        value = cgi.escape(value, 1)
+        value = escape(value, 1)
     if sys.version < "3":
         if is_unicode(value):
             value = value.encode('ascii', 'xmlcharrefreplace')

--- a/mapproxy/util/ext/tempita/__init__.py
+++ b/mapproxy/util/ext/tempita/__init__.py
@@ -32,12 +32,11 @@ from __future__ import print_function
 
 import re
 import sys
-import cgi
-from mapproxy.compat.modules import escape
 import os
 import tokenize
 from io import StringIO, BytesIO
 from mapproxy.compat import iteritems, PY2, text_type
+from mapproxy.compat.modules import escape
 from mapproxy.util.py import reraise
 from mapproxy.util.ext.tempita._looper import looper
 from mapproxy.util.ext.tempita.compat3 import bytes, basestring_, next, is_unicode, coerce_text


### PR DESCRIPTION
As required for Python 3.8 or later
This should fix #462

As of yet still totally untested, but I think it should work.
Anyone is free to test, I'll try it myself as well, when I have the time, but that might be some time later.