### PR TITLE
URL Prefix configuration

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1047,6 +1047,16 @@ Configuration options for the TMS/Tile service.
   was not changed.
 
 
+``prefix``
+"""""""""""""
+
+Prefix to root level of URLs. This allows the application to be hosted at a non root location, e.g. https://myapp.com/maps/
+::
+
+  http:
+    prefix: '/maps/'
+
+
 ``mapserver``
 """""""""""""
 

--- a/mapproxy/config/defaults.py
+++ b/mapproxy/config/defaults.py
@@ -94,4 +94,5 @@ http = dict(
     method = 'AUTO',
     access_control_allow_origin = '*',
     hide_error_details = True,
+    prefix = ''
 )

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -75,6 +75,7 @@ http_opts = {
     'headers': {
         anything(): str()
     },
+    'prefix': str(),
 }
 
 mapserver_opts = {


### PR DESCRIPTION
Added an option to add a prefix so that the app can be hosted at non root locations (e.g. at a route defined by a load balancer).