### PR TITLE
Fix demo "view as html" pages

### DIFF
--- a/mapproxy/request/base.py
+++ b/mapproxy/request/base.py
@@ -259,12 +259,27 @@ class Request(object):
     def host_url(self):
         return '%s://%s/' % (self.url_scheme, self.host)
 
+    @cached_property
+    def server_url(self):
+        return 'http://%s:%s/' % (
+            self.environ['SERVER_NAME'],
+            self.environ['SERVER_PORT']
+        )
+
     @property
     def script_url(self):
         "Full script URL without trailing /"
         return (self.host_url.rstrip('/') +
                 quote(self.environ.get('SCRIPT_NAME', '/').rstrip('/'))
                )
+    
+    @property
+    def server_script_url(self):
+        "Internal script URL"
+        return self.script_url.replace(
+            self.host_url.rstrip('/'),
+            self.server_url.rstrip('/')
+        )
 
     @property
     def base_url(self):

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -91,30 +91,35 @@ class DemoServer(Server):
         elif 'wmts_layer' in req.args:
             demo = self._render_wmts_template('demo/wmts_demo.html', req)
         elif 'wms_capabilities' in req.args:
-            url = '%s/service?REQUEST=GetCapabilities'%(req.server_script_url)
-            capabilities = urllib2.urlopen(url)
+            internal_url = '%s/service?REQUEST=GetCapabilities'%(req.server_script_url)
+            url = internal_url.replace(req.server_script_url, req.script_url)
+            capabilities = urllib2.urlopen(internal_url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS', url)
         elif 'wmsc_capabilities' in req.args:
-            url = '%s/service?REQUEST=GetCapabilities&tiled=true'%(req.server_script_url)
-            capabilities = urllib2.urlopen(url)
+            internal_url = '%s/service?REQUEST=GetCapabilities&tiled=true'%(req.server_script_url)
+            url = internal_url.replace(req.server_script_url, req.script_url)
+            capabilities = urllib2.urlopen(internal_url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS-C', url)
         elif 'wmts_capabilities_kvp' in req.args:
-            url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMTS' % (req.server_script_url)
-            capabilities = urllib2.urlopen(url)
+            internal_url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMTS' % (req.server_script_url)
+            url = internal_url.replace(req.server_script_url, req.script_url)
+            capabilities = urllib2.urlopen(internal_url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMTS', url)
         elif 'wmts_capabilities' in req.args:
-            url = '%s/wmts/1.0.0/WMTSCapabilities.xml' % (req.server_script_url)
-            capabilities = urllib2.urlopen(url)
+            internal_url = '%s/wmts/1.0.0/WMTSCapabilities.xml' % (req.server_script_url)
+            url = internal_url.replace(req.server_script_url, req.script_url)
+            capabilities = urllib2.urlopen(internal_url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMTS', url)
         elif 'tms_capabilities' in req.args:
             if 'layer' in req.args and 'srs' in req.args:
                 # prevent dir traversal (seems it's not possible with urllib2, but better safe then sorry)
                 layer = req.args['layer'].replace('..', '')
                 srs = req.args['srs'].replace('..', '')
-                url = '%s/tms/1.0.0/%s/%s'%(req.server_script_url, layer, srs)
+                internal_url = '%s/tms/1.0.0/%s/%s'%(req.server_script_url, layer, srs)
             else:
-                url = '%s/tms/1.0.0/'%(req.server_script_url)
-            capabilities = urllib2.urlopen(url)
+                internal_url = '%s/tms/1.0.0/'%(req.server_script_url)
+            capabilities = urllib2.urlopen(internal_url)
+            url = internal_url.replace(req.server_script_url, req.script_url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'TMS', url)
         elif req.path == '/demo/':
             demo = self._render_template('demo/demo.html')

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -91,19 +91,19 @@ class DemoServer(Server):
         elif 'wmts_layer' in req.args:
             demo = self._render_wmts_template('demo/wmts_demo.html', req)
         elif 'wms_capabilities' in req.args:
-            url = '%s/service?REQUEST=GetCapabilities'%(req.script_url)
+            url = '%s/service?REQUEST=GetCapabilities'%(req.server_script_url)
             capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS', url)
         elif 'wmsc_capabilities' in req.args:
-            url = '%s/service?REQUEST=GetCapabilities&tiled=true'%(req.script_url)
+            url = '%s/service?REQUEST=GetCapabilities&tiled=true'%(req.server_script_url)
             capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS-C', url)
         elif 'wmts_capabilities_kvp' in req.args:
-            url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMTS' % (req.script_url)
+            url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMTS' % (req.server_script_url)
             capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMTS', url)
         elif 'wmts_capabilities' in req.args:
-            url = '%s/wmts/1.0.0/WMTSCapabilities.xml' % (req.script_url)
+            url = '%s/wmts/1.0.0/WMTSCapabilities.xml' % (req.server_script_url)
             capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMTS', url)
         elif 'tms_capabilities' in req.args:
@@ -111,9 +111,9 @@ class DemoServer(Server):
                 # prevent dir traversal (seems it's not possible with urllib2, but better safe then sorry)
                 layer = req.args['layer'].replace('..', '')
                 srs = req.args['srs'].replace('..', '')
-                url = '%s/tms/1.0.0/%s/%s'%(req.script_url, layer, srs)
+                url = '%s/tms/1.0.0/%s/%s'%(req.server_script_url, layer, srs)
             else:
-                url = '%s/tms/1.0.0/'%(req.script_url)
+                url = '%s/tms/1.0.0/'%(req.server_script_url)
             capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'TMS', url)
         elif req.path == '/demo/':


### PR DESCRIPTION
Hi,

I was encountering issues with the `view as html` pages of the `demo` service running mapproxy in a docker container with port forwarding (9000:8000).

The demo service is making internal calls to retrieve the capabilities (`capabilities = urllib2.urlopen(url)`), so I changed the target hostname and port to be the server's.