### PR TITLE
re-enable riak cache tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 services:
   - couchdb
   - redis-server
+  - docker
 
 addons:
   apt:
@@ -31,6 +32,8 @@ env:
   global:
     - MAPPROXY_TEST_COUCHDB=http://127.0.0.1:5984
     - MAPPROXY_TEST_REDIS=127.0.0.1:6379
+    - MAPPROXY_TEST_RIAK_HTTP=http://localhost:8098
+    - MAPPROXY_TEST_RIAK_PBC=pbc://localhost:8087
 
     # do not load /etc/boto.cfg with Python 3 incompatible plugin
     # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
@@ -47,6 +50,9 @@ matrix:
 cache:
   directories:
     - $HOME/.cache/pip
+
+before_install:
+    - docker run --detach --rm --publish 8087:8087 --publish 8098:8098 basho/riak-kv
 
 install:
     - "pip install -r requirements-tests.txt"


### PR DESCRIPTION
Use docker based riak instance to perform caching tests.

Fix #479