### PR TITLE
Add flake8 for linting on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,4 +60,5 @@ install:
     - "pip freeze"
 
 script:
+    - flake8 mapproxy
     - pytest mapproxy

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -23,6 +23,7 @@ docker==4.3.0
 docutils==0.15.2
 ecdsa==0.14.1
 future==0.18.2
+flake8==3.8.4
 idna==2.8
 importlib-metadata==1.7.0
 iniconfig==1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,69 @@ doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE 
 norecursedirs = fixture .git .tox
 testpaths = mapproxy
 
+[flake8]
+ignore = E111
+         E117
+         E121
+         E122
+         E123
+         E124
+         E125
+         E126
+         E127
+         E128
+         E129
+         E131
+         E201
+         E202
+         E203
+         E221
+         E222
+         E223
+         E225
+         E226
+         E228
+         E231
+         E241
+         E251
+         E261
+         E262
+         E265
+         E266
+         E271
+         E272
+         E301
+         E302
+         E303
+         E305
+         E306
+         E402
+         E501
+         E502
+         E701
+         E702
+         E703
+         E711
+         E712
+         E713
+         E721
+         E722
+         E731
+         E741
+         F401
+         F523
+         F812
+         F821
+         F841
+         F901
+         W503
+         W504
+         W191
+         W291
+         W292
+         W293
+         W391
+
 [egg_info]
 #tag_build = .dev
 tag_date = true


### PR DESCRIPTION
This is a first step towards introducing linting (#478) using flake8. The strategy is to start by ignoring all errors and un-ignore them step by step to break this into multiple commits.

For now, I'm using this PR to make sure it works with the CI. I will undraft once I get it to work.
