### PR TITLE
Fix caching

### DIFF
--- a/mapproxy/response.py
+++ b/mapproxy/response.py
@@ -112,7 +112,7 @@ class Response(object):
         elif self._timestamp is not None:
             date = environ.get('HTTP_IF_MODIFIED_SINCE', None)
             timestamp = parse_httpdate(date)
-            if timestamp is not None and self._timestamp <= timestamp:
+            if timestamp is not None and int(self._timestamp) <= timestamp:
                 not_modified = True
 
         if not_modified:

--- a/mapproxy/test/system/test_tms.py
+++ b/mapproxy/test/system/test_tms.py
@@ -176,7 +176,8 @@ class TestTileService(SysTest):
         assert is_jpeg(data)
 
     def _update_timestamp(self, cache_dir, base_config):
-        timestamp = 1234567890.0
+        # real files in the filesystem may have non integer timestamps
+        timestamp = 1234567890.2735
         size = 10214
         base_dir = base_config.cache.base_dir
         os.utime(

--- a/mapproxy/util/ext/serving.py
+++ b/mapproxy/util/ext/serving.py
@@ -123,7 +123,6 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
 
         def write(data):
             assert headers_set, 'write() before start_response'
-            import pdb; pdb.set_trace()
             if not headers_sent:
                 if self.request_version == "HTTP/1.0":
                     headers_sent[:] = headers_set

--- a/mapproxy/util/ext/serving.py
+++ b/mapproxy/util/ext/serving.py
@@ -62,6 +62,8 @@ def _log(type, message, *args):
 class WSGIRequestHandler(BaseHTTPRequestHandler, object):
     """A request handler that implements WSGI dispatching."""
 
+    protocol_version = 'HTTP/1.1'
+
     @property
     def server_version(self):
         return 'MapProxy/' + mapproxy.version.__version__ + ' (Werkzeug based)'

--- a/mapproxy/util/ext/serving.py
+++ b/mapproxy/util/ext/serving.py
@@ -127,15 +127,15 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                 if self.request_version == "HTTP/1.0":
                     headers_sent[:] = headers_set
                     status = headers_set[0]
-                    # remove non-HTTP1.0 headers
+                    # only keep HTTP/1.0 headers
                     response_headers = (
                         header_tuple
                         for header_tuple in headers_set[1]
                         if header_tuple[0].lower() in [
-                                "date", "pragma",
-                                "location", "server", "www-authenticate",
-                                "allow", "content-Encoding", "content-length",
-                                "content-type", "expires", "last-modified"
+                            "date", "pragma",
+                            "location", "server", "www-authenticate",
+                            "allow", "content-encoding", "content-length",
+                            "content-type", "expires", "last-modified"
                         ]
                     )
                 else:
@@ -252,7 +252,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         self.log_request(code)
         if message is None:
             message = code in self.responses and self.responses[code][0] or ''
-        if self.request_version == 'HTTP/0.9':
+        if self.request_version != 'HTTP/0.9':
             if self.request_version == 'HTTP/1.0':
                 hdr = "%s %d %s\r\n" % (self.request_version, code, message)
             else:


### PR DESCRIPTION
Cache handling in the Navigator is confusing since the cache headers are not correctly recognized if not using HTTP1.1

This PR fixes cache problems in the Navigator and fixes another roundoff error observed in caching with NOT-MODIFIED-SINCE header

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
