### PR TITLE
mapproxy seed - CL Option skip uncached

### DIFF
--- a/doc/seed.rst
+++ b/doc/seed.rst
@@ -69,6 +69,16 @@ Options
 
   This will simulate the seed/cleanup process without requesting, creating or removing any tiles.
 
+.. option:: -l N, --skip-geoms-for-last-levels N
+
+  This will skip checking the intersections between tiles and seed geometries on the last N levels.
+
+.. option:: --skip-uncached
+
+  This will seed only tiles which are already in the cache. This option is interesting in combination with
+  the configuration entry `refresh_before`_ to refresh regularly the existing tiles and to avoid loading
+  all available tiles.
+
 .. option:: --summary
 
   Print a summary of all seeding and cleanup tasks and exit.

--- a/mapproxy/seed/script.py
+++ b/mapproxy/seed/script.py
@@ -105,6 +105,11 @@ class SeedScript(object):
                       metavar="N",
                       help="do not check for intersections between tiles"
                            " and seed geometries on the last N levels")
+    parser.add_option("--skip-uncached",
+                      action="store_true", dest="skip_uncached", default=False,
+                      help="only treat tiles which are already present in the cache."
+                           " This can be used with the configuration entry `refresh_before`"
+                           " to refresh only the existing cache.")
     parser.add_option("--summary",
                       action="store_true", dest="summary", default=False,
                       help="print summary with all seeding tasks and exit."
@@ -243,7 +248,8 @@ class SeedScript(object):
                         progress_store=progress)
                     seed(seed_tasks, progress_logger=logger, dry_run=options.dry_run,
                          concurrency=options.concurrency, cache_locker=cache_locker,
-                         skip_geoms_for_last_levels=options.geom_levels)
+                         skip_geoms_for_last_levels=options.geom_levels,
+                         skip_uncached=options.skip_uncached)
                 if cleanup_tasks:
                     print('========== Cleanup tasks ==========')
                     print('Start cleanup process (%d task%s)' % (

--- a/mapproxy/seed/seeder.py
+++ b/mapproxy/seed/seeder.py
@@ -477,7 +477,7 @@ class CleanupTask(object):
         return NONE
 
 def seed(tasks, concurrency=2, dry_run=False, skip_geoms_for_last_levels=0,
-    progress_logger=None, cache_locker=None):
+    progress_logger=None, cache_locker=None, skip_uncached=False):
     if cache_locker is None:
         cache_locker = DummyCacheLocker()
 
@@ -496,7 +496,7 @@ def seed(tasks, concurrency=2, dry_run=False, skip_geoms_for_last_levels=0,
                     start_progress = None
                 seed_progress = SeedProgress(old_progress_identifier=start_progress)
                 seed_task(task, concurrency, dry_run, skip_geoms_for_last_levels, progress_logger,
-                    seed_progress=seed_progress)
+                    seed_progress=seed_progress, skip_uncached=skip_uncached)
         except CacheLockedError:
             print('    ...cache is locked, skipping')
             active_tasks = [task] + active_tasks[:-1]
@@ -505,7 +505,7 @@ def seed(tasks, concurrency=2, dry_run=False, skip_geoms_for_last_levels=0,
 
 
 def seed_task(task, concurrency=2, dry_run=False, skip_geoms_for_last_levels=0,
-    progress_logger=None, seed_progress=None):
+    progress_logger=None, seed_progress=None, skip_uncached=False):
     if task.coverage is False:
         return
     if task.refresh_timestamp is not None:
@@ -518,7 +518,11 @@ def seed_task(task, concurrency=2, dry_run=False, skip_geoms_for_last_levels=0,
 
     tile_worker_pool = TileWorkerPool(task, TileSeedWorker, dry_run=dry_run,
         size=concurrency, progress_logger=progress_logger)
-    tile_walker = TileWalker(task, tile_worker_pool, handle_uncached=True,
+    # If the configuration requests to only refresh tiles which are already in cache,
+    # tile walker parameters shall be adapted
+    handle_stale = skip_uncached
+    handle_uncached = not skip_uncached
+    tile_walker = TileWalker(task, tile_worker_pool, handle_uncached=handle_uncached, handle_stale=handle_stale,
         skip_geoms_for_last_levels=skip_geoms_for_last_levels, progress_logger=progress_logger,
         seed_progress=seed_progress,
         work_on_metatiles=work_on_metatiles,

--- a/mapproxy/test/system/test_seed.py
+++ b/mapproxy/test/system/test_seed.py
@@ -86,10 +86,41 @@ class SeedTestBase(SeedTestEnvironment):
                             {'body': img_data, 'headers': {'content-type': 'image/png'}})
             with mock_httpd(('localhost', 42423), [expected_req]):
                 with local_base_config(self.mapproxy_conf.base_config):
-                    seed_conf  = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+                    seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
                     tasks, cleanup_tasks = seed_conf.seeds(['one']), seed_conf.cleanups()
                     seed(tasks, dry_run=False)
                     cleanup(cleanup_tasks, verbose=False, dry_run=False)
+
+    def test_seed_skip_uncached(self):
+        with tmp_image((256, 256), format='png') as img:
+            img_data = img.read()
+            with local_base_config(self.mapproxy_conf.base_config):
+                expected_req = ({'path': r'/service?LAYERS=foo&SERVICE=WMS&FORMAT=image%2Fpng'
+                                 '&REQUEST=GetMap&VERSION=1.1.1&bbox=-180.0,-90.0,180.0,90.0'
+                                 '&width=256&height=128&srs=EPSG:4326'},
+                                {'body': img_data, 'headers': {'content-type': 'image/png'}})
+                seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+                tasks, cleanup_tasks = seed_conf.seeds(['one']), seed_conf.cleanups()
+
+                # tile not in cache => skipped by seeder
+                seed(tasks, dry_run=False, skip_uncached=True)
+                assert not self.tile_exists((0, 0, 0))
+
+                with mock_httpd(('localhost', 42423), [expected_req]):
+                    # force tile generation in cache (via skip_uncached=False)
+                    seed(tasks, dry_run=False, skip_uncached=False)
+                assert self.tile_exists((0, 0, 0))
+
+                # no refresh since tile is not older than 1 day (cf. config seed.yaml)
+                seed(tasks, dry_run=False, skip_uncached=True)
+
+                # create stale tile (older than 1 day)
+                self.make_tile((0, 0, 0), timestamp=time.time() - (60*60*25))
+                with mock_httpd(('localhost', 42423), [expected_req]):
+                    # check that old tile in cache is refreshed
+                    seed(tasks, dry_run=False, skip_uncached=True)
+                assert self.tile_exists((0, 0, 0))
+                cleanup(cleanup_tasks, verbose=False, dry_run=False)
 
     def test_reseed_uptodate(self):
         # tile already there.


### PR DESCRIPTION
This feature covers a use case where mapproxy-seed is run to update stale tiles in the cache.
All code is already present, the feature is just made available via command-line options.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
