### PR TITLE
Fix TypeError when writing to stdout

### DIFF
--- a/mapproxy/script/conf/app.py
+++ b/mapproxy/script/conf/app.py
@@ -71,7 +71,7 @@ def write_header(f, capabilities):
 @contextmanager
 def file_or_stdout(name):
     if name == '-':
-        yield codecs.getwriter('utf-8')(sys.stdout)
+        yield codecs.getwriter('utf-8')(sys.stdout.buffer)
     else:
         with open(name, 'wb') as f:
             yield codecs.getwriter('utf-8')(f)

--- a/mapproxy/script/conf/app.py
+++ b/mapproxy/script/conf/app.py
@@ -71,7 +71,10 @@ def write_header(f, capabilities):
 @contextmanager
 def file_or_stdout(name):
     if name == '-':
-        yield codecs.getwriter('utf-8')(sys.stdout.buffer)
+        if hasattr(sys.stdout, 'buffer'):
+            yield codecs.getwriter('utf-8')(sys.stdout.buffer)
+        else:
+            yield codecs.getwriter('utf-8')(sys.stdout)
     else:
         with open(name, 'wb') as f:
             yield codecs.getwriter('utf-8')(f)


### PR DESCRIPTION
This PR fixes the following TypeError when running the command `mapproxy-util autoconfig     --capabilities https://api-proxy.auckland-cer.cloud.edu.au/cgi-bin/mapserv`:

```python
Traceback (most recent call last):
  File "/usr/local/bin/mapproxy-util", line 11, in <module>
    load_entry_point('MapProxy', 'console_scripts', 'mapproxy-util')()
  File "/home/ubuntu/mapproxy/mapproxy/script/util.py", line 387, in main
    commands[command]['func'](args)
  File "/home/ubuntu/mapproxy/mapproxy/script/conf/app.py", line 185, in config_command
    write_header(f, options.capabilities)
  File "/home/ubuntu/mapproxy/mapproxy/script/conf/app.py", line 59, in write_header
    print('# MapProxy configuration automatically generated from:', file=f)
  File "/usr/lib/python3.8/codecs.py", line 378, in write
    self.stream.write(data)
TypeError: write() argument must be str, not bytes
```

See https://stackoverflow.com/a/44447780 for an explanation