### PR TITLE
Allow reuse of Mapnik objects if enabled

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1063,6 +1063,18 @@ The complete path to the ``mapserv`` executable. Required if you use the ``mapse
 Path where the Mapserver should be executed from. It should be the directory where any relative paths in your mapfile are based on. Defaults to the directory of ``binary``.
 
 
+``mapnik``
+""""""""""
+
+Options for the :ref:`Mapnik source<mapnik_label>`.
+
+``reuse_map_objects``
+^^^^^^^^^^^^^^^^^^^^^
+
+Enable reuse of Mapnik map objects to avoid long startups for each tile to be rendered.
+If you enable this option, you cannot use multithreading (i.e. have to disable multithreading in your WSGI server).
+
+
 .. _image_options:
 
 Image Format Options

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -21,6 +21,7 @@ from __future__ import division
 import os
 import sys
 import hashlib
+import threading
 import warnings
 from copy import deepcopy, copy
 from functools import partial
@@ -346,6 +347,8 @@ class GlobalConfiguration(ConfigurationBase):
         self.preferred_srs = preferred_srs(self.conf.get('srs', {}))
         self.renderd_address = self.get_value('renderd.address')
         self.mapnik_reuse_map_objects = self.get_value('mapnik.reuse_map_objects') or False
+        if self.mapnik_reuse_map_objects and not (threading.current_thread() is threading.main_thread()):
+            raise ConfigurationError('mapnik.reuse_map_objects set to True althoug Mapproxy runs multi-threaded.')
 
     def _copy_conf_values(self, d, target):
         for k, v in iteritems(d):

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -345,6 +345,7 @@ class GlobalConfiguration(ConfigurationBase):
         self.image_options = ImageOptionsConfiguration(self.conf.get('image', {}), context)
         self.preferred_srs = preferred_srs(self.conf.get('srs', {}))
         self.renderd_address = self.get_value('renderd.address')
+        self.mapnik_reuse_map_objects = self.get_value('mapnik.reuse_map_objects') or False
 
     def _copy_conf_values(self, d, target):
         for k, v in iteritems(d):
@@ -939,7 +940,7 @@ class MapnikSourceConfiguration(SourceConfiguration):
         if mapnik_api is None:
             raise ConfigurationError('Could not import Mapnik, please verify it is installed!')
 
-        if self.context.renderd:
+        if self.context.renderd or self.context.globals.mapnik_reuse_map_objects:
             # only renderd guarantees that we have a single proc/thread
             # that accesses the same mapnik map object
             reuse_map_objects = True

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -392,7 +392,11 @@ mapproxy_yaml_spec = {
         'mapserver': mapserver_opts,
         'renderd': {
             'address': str(),
+        },
+        'mapnik': {
+            'reuse_map_objects': bool(),
         }
+
     },
     'grids': {
         anything(): grid_opts,


### PR DESCRIPTION
When Mapproxy uses Mapnik without using Renderd (by the way, that's not documented), a new Mapnik map object is initialised for any new rendering request. This harms performance – at least with some map styles – because Mapnik runs all the SQL queries of the layers of the style with an appended `LIMIT 0` to get the types of the returned columns. This pull request allows to reuse map objects.

For example, rendering a map style similar to OSM Carto requires 20 to 30 seconds without, and 6 to 8 seconds with reused Mapnik map objects. Without this patch, Mapproxy performance significantly slower with Mapnik sources compared to a Tirex+mod_tile setup.

Remarks: Multithreading is not supported. If a WSGI worker daemon is restarted, Mapnik is initialised when the first Mapnik rendering is requested.