### PR TITLE
Add vary header to textual responses

### DIFF
--- a/mapproxy/response.py
+++ b/mapproxy/response.py
@@ -42,6 +42,12 @@ class Response(object):
             content_type = self.default_content_type
         self.headers['Content-type'] = content_type
 
+        if content_type.startswith(('text/', 'application/')):
+            # Capability documents can be dependent on the value of a few X-headers.
+            # Tell this caching proxies via the Vary HTTP header. This also prevents
+            # malicious cache poisoning.
+            self.headers['Vary'] = 'X-Script-Name, X-Forwarded-Host, X-Forwarded-Proto'
+
     def _status_set(self, status):
         if isinstance(status, int):
             status = status_code(status)

--- a/mapproxy/test/system/test_response_headers.py
+++ b/mapproxy/test/system/test_response_headers.py
@@ -1,0 +1,54 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2011 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import pytest
+
+from mapproxy.test.system import SysTest
+
+
+class TestResponseHeaders(SysTest):
+    """
+    Check if the vary header is set for text / xml content like capabilities 
+    """
+    @pytest.fixture(scope='class')
+    def config_file(self):
+        return 'auth.yaml'
+
+    def test_tms(self, app):
+        resp = app.get('http://localhost/tms')
+        assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
+
+    def test_wms(self, app):
+        resp = app.get('http://localhost/service?SERVICE=WMS&REQUEST=GetCapabilities'
+                            '&VERSION=1.1.0')
+        assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
+
+    def test_wmts(self, app):
+        resp = app.get('http://localhost/service?SERVICE=WMTS&REQUEST=GetCapabilities')
+        assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
+
+    def test_restful_wmts(self, app):
+        resp = app.get('http://localhost/wmts/1.0.0/WMTSCapabilities.xml')
+        assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
+
+    def test_no_endpoint(self, app):
+        resp = app.get('http://localhost/service?')
+        assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
+
+    def test_image_response(self, app):
+        resp = app.get('http://localhost/tms/1.0.0/layer1a/EPSG900913/0/0/0.png')
+        assert resp.vary == None


### PR DESCRIPTION
This adds the `Vary` Header to text like responses in order to prevent potential web cache poisoning.