### PR TITLE
fix capabilities documents and extend demo page

### DIFF
--- a/mapproxy/request/base.py
+++ b/mapproxy/request/base.py
@@ -196,7 +196,7 @@ class Request(object):
         if script_name:
             del environ['HTTP_X_SCRIPT_NAME']
             environ['SCRIPT_NAME'] = script_name
-            path_info = environ['PATH_INFO']
+            path_info = environ.get('PATH_INFO', '')
             if path_info.startswith(script_name):
                 environ['PATH_INFO'] = path_info[len(script_name):]
 
@@ -272,14 +272,11 @@ class Request(object):
         return (self.host_url.rstrip('/') +
                 quote(self.environ.get('SCRIPT_NAME', '/').rstrip('/'))
                )
-    
+
     @property
     def server_script_url(self):
         "Internal script URL"
-        return self.script_url.replace(
-            self.host_url.rstrip('/'),
-            self.server_url.rstrip('/')
-        )
+        return self.server_url.rstrip('/')
 
     @property
     def base_url(self):

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -132,35 +132,50 @@ class DemoServer(Server):
         elif 'wmts_layer' in req.args:
             demo = self._render_wmts_template('demo/wmts_demo.html', req)
         elif 'wms_capabilities' in req.args:
-            internal_url = '%s/service?REQUEST=GetCapabilities'%(req.server_script_url)
-            url = internal_url.replace(req.server_script_url, req.script_url)
-            capabilities = urllib2.urlopen(internal_url)
+            internal_url = '%s/service?REQUEST=GetCapabilities' % (req.server_script_url)
+            if 'type' in req.args and req.args['type'] == 'external':
+                url = internal_url.replace(req.server_script_url, req.script_url)
+            else:
+                url = internal_url
+            capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS', url)
         elif 'wmsc_capabilities' in req.args:
-            internal_url = '%s/service?REQUEST=GetCapabilities&tiled=true'%(req.server_script_url)
-            url = internal_url.replace(req.server_script_url, req.script_url)
-            capabilities = urllib2.urlopen(internal_url)
+            internal_url = '%s/service?REQUEST=GetCapabilities&tiled=true' % (req.server_script_url)
+            if 'type' in req.args and req.args['type'] == 'external':
+                url = internal_url.replace(req.server_script_url, req.script_url)
+            else:
+                url = internal_url
+            capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS-C', url)
         elif 'wmts_capabilities_kvp' in req.args:
             internal_url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMTS' % (req.server_script_url)
-            url = internal_url.replace(req.server_script_url, req.script_url)
-            capabilities = urllib2.urlopen(internal_url)
+            if 'type' in req.args and req.args['type'] == 'external':
+                url = internal_url.replace(req.server_script_url, req.script_url)
+            else:
+                url = internal_url
+            capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMTS', url)
         elif 'wmts_capabilities' in req.args:
             internal_url = '%s/wmts/1.0.0/WMTSCapabilities.xml' % (req.server_script_url)
-            url = internal_url.replace(req.server_script_url, req.script_url)
-            capabilities = urllib2.urlopen(internal_url)
+            if 'type' in req.args and req.args['type'] == 'external':
+                url = internal_url.replace(req.server_script_url, req.script_url)
+            else:
+                url = internal_url
+            capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMTS', url)
         elif 'tms_capabilities' in req.args:
             if 'layer' in req.args and 'srs' in req.args:
                 # prevent dir traversal (seems it's not possible with urllib2, but better safe then sorry)
                 layer = req.args['layer'].replace('..', '')
                 srs = req.args['srs'].replace('..', '')
-                internal_url = '%s/tms/1.0.0/%s/%s'%(req.server_script_url, layer, srs)
+                internal_url = '%s/tms/1.0.0/%s/%s' % (req.server_script_url, layer, srs)
             else:
-                internal_url = '%s/tms/1.0.0/'%(req.server_script_url)
-            capabilities = urllib2.urlopen(internal_url)
-            url = internal_url.replace(req.server_script_url, req.script_url)
+                internal_url = '%s/tms/1.0.0/' % (req.server_script_url)
+            if 'type' in req.args and req.args['type'] == 'external':
+                url = internal_url.replace(req.server_script_url, req.script_url)
+            else:
+                url = internal_url
+            capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'TMS', url)
         elif req.path == '/demo/':
             demo = self._render_template(req, 'demo/demo.html')

--- a/mapproxy/service/templates/demo/demo.html
+++ b/mapproxy/service/templates/demo/demo.html
@@ -41,7 +41,8 @@ jscript_openlayers=None
             <div class="capabilities">
                 <span>Capabilities document</span>
                 <span><a href="../service?REQUEST=GetCapabilities">(download as xml)</a></span>
-                <span><a href="../demo/?wms_capabilities">(view as html)</a></span>
+                <span><a href="../demo/?wms_capabilities">(view as html, internal)</a></span>
+                <span><a href="../demo/?wms_capabilities&type=external">(view as html, external)</a></span>
             </div>
             {{if 'wms_111' in services }}
                 <table class="code">
@@ -88,7 +89,8 @@ jscript_openlayers=None
             <div class="capabilities">
                 <span>Capabilities document</span>
                 <span><a href="../service?REQUEST=GetCapabilities&tiled=true">(download as xml)</a></span>
-                <span><a href="../demo/?wmsc_capabilities">(view as html)</a></span>
+                <span><a href="../demo/?wmsc_capabilities">(view as html, internal)</a></span>
+                <span><a href="../demo/?wmsc_capabilities&type=external">(view as html, external)</a></span>
             </div>
             {{else}}
             <div class="capabilities">
@@ -101,14 +103,16 @@ jscript_openlayers=None
                 <div class="capabilities">
                     <span>KVP capabilities document</span>
                     <span><a href="../service?REQUEST=GetCapabilities&SERVICE=WMTS">(download as xml)</a></span>
-                    <span><a href="../demo/?wmts_capabilities_kvp">(view as html)</a></span>
+                    <span><a href="../demo/?wmts_capabilities_kvp">(view as html, internal)</a></span>
+                    <span><a href="../demo/?wmts_capabilities_kvp&type=external">(view as html, external)</a></span>
                 </div>
                 {{endif}}
                 {{if 'wmts_restful' in services}}
                 <div class="capabilities">
                     <span>RESTFul capabilities document</span>
                     <span><a href="../wmts/1.0.0/WMTSCapabilities.xml">(download as xml)</a></span>
-                    <span><a href="../demo/?wmts_capabilities">(view as html)</a></span>
+                    <span><a href="../demo/?wmts_capabilities">(view as html, internal)</a></span>
+                    <span><a href="../demo/?wmts_capabilities&type=external">(view as html, external)</a></span>
                 </div>
                 {{endif}}
             <table class="code">
@@ -145,7 +149,8 @@ jscript_openlayers=None
             <div class="capabilities">
                 <span>Capabilities document</span>
                 <span><a href="../tms/1.0.0/">(download as xml)</a></span>
-                <span><a href="../demo/?tms_capabilities">(view as html)</a></span>
+                <span><a href="../demo/?tms_capabilities">(view as html, internal)</a></span>
+                <span><a href="../demo/?tms_capabilities&type=external">(view as html, external)</a></span>
             </div>
             <table class="code">
                 <tr>


### PR DESCRIPTION
#Fixes #495 and extends the functionality of the demo page.

## summary
The user can now choose to view the capabilities documents either for the internal address (e.g. 10.0.13.37) or the external address (e.g. example.org). This makes debugging easier when the service is running behind a reverse proxy and doesn't throw an "internal error" as before.

## backward compatibility
This patch is backward compatible. There's a new URL parameter `type=external`, which controls which _flavor_ to show. Dropping the key `type` or setting it to another value, like `type=internal`, shows the original one.

## example calls
- internal: `https://10.0.13.37:8000/demo/?wms_capabilities`
- internal: `https://10.0.13.37:8000/demo/?wms_capabilities&type=internal`
- external: `https://10.0.13.37:8000/demo/?wms_capabilities&type=external`

## screenshot
![image](https://user-images.githubusercontent.com/1864057/146301534-eb3f8505-c584-4756-929f-9ffcb9909e7b.png)
