### PR TITLE
fixes Shapely >= 1.8 deprecation messages

### DIFF
--- a/mapproxy/util/geom.py
+++ b/mapproxy/util/geom.py
@@ -94,7 +94,7 @@ def load_ogr_datasource(datasource, where=None):
                 if geom.type == 'Polygon':
                     polygons.append(geom)
                 elif geom.type == 'MultiPolygon':
-                    for p in geom:
+                    for p in geom.geoms:
                         polygons.append(p)
                 else:
                     log_config.warning('skipping %s geometry from %s: not a Polygon/MultiPolygon',
@@ -148,7 +148,7 @@ def load_geojson(datasource):
         if geom.type == 'Polygon':
             polygons.append(geom)
         elif geom.type == 'MultiPolygon':
-            for p in geom:
+            for p in geom.geoms:
                 polygons.append(p)
         else:
             log_config.warning('ignoring non-polygon geometry (%s) from %s',
@@ -165,7 +165,7 @@ def load_polygon_lines(line_iter, source='<string>'):
         if geom.type == 'Polygon':
             polygons.append(geom)
         elif geom.type == 'MultiPolygon':
-            for p in geom:
+            for p in geom.geoms:
                 polygons.append(p)
         else:
             log_config.warning('ignoring non-polygon geometry (%s) from %s',
@@ -187,7 +187,7 @@ def build_multipolygon(polygons, simplify=False):
         polygons = [simplify_geom(g) for g in polygons]
 
     # eliminate any self-overlaps
-    mp = shapely.ops.cascaded_union(polygons)
+    mp = shapely.ops.unary_union(polygons)
 
     return mp.bounds, mp
 
@@ -249,7 +249,7 @@ def flatten_to_polygons(geometry):
         return [geometry]
 
     if geometry.type == 'MultiPolygon':
-        return list(geometry)
+       return list(geometry.geoms)
 
     if hasattr(geometry, 'geoms'):
         # GeometryCollection or MultiLineString? return list of all polygons


### PR DESCRIPTION
Fixes #554

Due to the roadmap for Shapely 2.0, some stuff throws deprecation messages starting with Shapely 1.8, see: https://github.com/shapely/shapely/issues/932