### PR TITLE
Fix find_library() throws OSError FileNotFoundError

### DIFF
--- a/mapproxy/util/lib.py
+++ b/mapproxy/util/lib.py
@@ -90,7 +90,13 @@ def find_library(lib_name, paths=None, exts=None):
     If nothing is found None is returned.
     """
     if not paths or not exts:
-        return _find_library(lib_name if not lib_name.startswith("lib") else lib_name[3:])
+        try:
+            lib = _find_library(lib_name)
+        except OSError:
+            lib = None
+        if lib is None and lib_name.startswith('lib'):
+            lib = _find_library(lib_name[3:])
+        return lib
 
     for lib_name in [lib_name] + ([lib_name[3:]] if lib_name.startswith('lib') else []):
         for path in paths:

--- a/mapproxy/util/lib.py
+++ b/mapproxy/util/lib.py
@@ -90,12 +90,7 @@ def find_library(lib_name, paths=None, exts=None):
     If nothing is found None is returned.
     """
     if not paths or not exts:
-        try:
-            lib = _find_library(lib_name)
-        except OSError:
-            if lib_name.startswith('lib'):
-                lib = _find_library(lib_name[3:])
-        return lib
+        return _find_library(lib_name if not lib_name.startswith("lib") else lib_name[3:])
 
     for lib_name in [lib_name] + ([lib_name[3:]] if lib_name.startswith('lib') else []):
         for path in paths:

--- a/mapproxy/util/lib.py
+++ b/mapproxy/util/lib.py
@@ -90,9 +90,11 @@ def find_library(lib_name, paths=None, exts=None):
     If nothing is found None is returned.
     """
     if not paths or not exts:
-        lib = _find_library(lib_name)
-        if lib is None and lib_name.startswith('lib'):
-            lib = _find_library(lib_name[3:])
+        try:
+            lib = _find_library(lib_name)
+        except OSError:
+            if lib_name.startswith('lib'):
+                lib = _find_library(lib_name[3:])
         return lib
 
     for lib_name in [lib_name] + ([lib_name[3:]] if lib_name.startswith('lib') else []):


### PR DESCRIPTION
According to this WONTFIX, adding lib prefix to any library has always been wrong and rises an exception: https://bugs.python.org/issue42580

Fixes #558