### PR TITLE
Update configuration.rst

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -127,7 +127,7 @@ The old syntax to configure each layer as a dictionary with the key as the name 
   layers:
     mylayer:
       title: My Layer
-      source: [mysource]
+      sources: [mysource]
 
 should become
 
@@ -138,7 +138,7 @@ should become
       title: My Layer
       source: [mysource]
 
-The mixed format where the layers are a list (``-``) but each layer is still a dictionary is no longer supported (e.g. ``- mylayer:`` becomes ``- name: mylayer``).
+The mixed format where the layers are a list (``-``) but each layer is still a dictionary is no longer supported (e.g. ``- mylayer:`` becomes ``- name: mylayer``). Note that the deprecated format is still currently required if you are using the base: option due to  `issue #490 <https://github.com/mapproxy/mapproxy/issues/490>`.
 
 .. _layers_name:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -136,7 +136,7 @@ should become
   layers:
     - name: mylayer
       title: My Layer
-      source: [mysource]
+      sources: [mysource]
 
 The mixed format where the layers are a list (``-``) but each layer is still a dictionary is no longer supported (e.g. ``- mylayer:`` becomes ``- name: mylayer``). Note that the deprecated format is still currently required if you are using the base: option due to  `issue #490 <https://github.com/mapproxy/mapproxy/issues/490>`.
 


### PR DESCRIPTION
I really bumped my head hard on this issue https://github.com/mapproxy/mapproxy/issues/490 which requires to use the older layer syntax. Further the deprecated example uses source: (singular) for sources key which further makes even trying to use the deprecated syntax by following the example given hard. This PR tries to make things a little clearer for those who are following the same trail through the docs as I did.
