### PR TITLE
test.yml: avoid test failures with Python 3.8 and Pillow 9.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies ⏬
       run: |
         pip install -r requirements-tests.txt
-        if [[ ${{ matrix.python-version }} = 2.7 || ${{ matrix.python-version }} = 3.8 ]]; then pip install -U "Pillow!=8.3.0,!=8.3.1"; fi
+        if [[ ${{ matrix.python-version }} = 2.7 || ${{ matrix.python-version }} = 3.8 ]]; then pip install -U "Pillow!=8.3.0,!=8.3.1,!=9.0.0"; fi
         pip freeze
 
     - name: Run tests 🏗️


### PR DESCRIPTION
Pillow 9.0 with Python 3.8 causes test failures in
mapproxy/test/unit/test_image.py::TestImageSource::test_output_formats_greyscale_png
mapproxy/test/unit/test_image.py::TestImageSource::test_output_formats_png8

See https://github.com/rouault/mapproxy/runs/4692398962
