### PR TITLE
improve support for configurations splat in multiple files

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -2123,10 +2123,15 @@ def merge_dict(conf, base):
             base[k] = v
         else:
             if isinstance(base[k], dict):
-                merge_dict(v, base[k])
+                if v != None:
+                    base[k] = merge_dict(v, base[k])
+            elif isinstance(base[k], list):
+                if v != None:
+                    base[k] = base[k] + v
             else:
                 base[k] = v
-    return base
+    return base     
+
 
 def parse_color(color):
     """


### PR DESCRIPTION
I bring a fix to improve the support of splat configurations (via `base`). 

This fix allows to have heterogeneous yaml files (one with only services, another with one layer definition, another with common configuration parts). It improves the support for `None` sub dictionaries and can merge lists (like `layers`). 

Ref #293 

