### PR TITLE
Add a mechanism to define plugins

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ MapProxy Documentation
    auth
    decorate_img
    development
+   plugins
    mapproxy_2
 
 .. todolist::

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -8,14 +8,14 @@ Example
 -------
 
 The mapproxy_hips plugin at https://github.com/rouault/mapproxy_hips is an
-example of a plugin, which adds a new source, service and customize the demo
+example of a plugin, which adds a new source, service and customizes the demo
 service, demonstrating all the below points.
 
 How to add a plugin ?
 ---------------------
 
-A plugin should be written as a Python package whose setuptools setup()
-method has a entry_points keywords with a group ``mapproxy`` pointing to
+A plugin should be written as a Python package whose setuptools ``setup()``
+method has a ``entry_points`` keyword with a group ``mapproxy`` pointing to
 a module with a ``plugin_entrypoint`` method.
 
 .. code-block:: python
@@ -23,7 +23,7 @@ a module with a ``plugin_entrypoint`` method.
     entry_points={"mapproxy": ["hips = mapproxy_hips.pluginmodule"]},
 
 
-In this example, the mapproxy_hips/pluginmodule.py file should have
+In this example, the ``mapproxy_hips/pluginmodule.py`` file should have
 a ``plugin_entrypoint`` method taking no argument and returning nothing.
 
 .. code-block:: python
@@ -186,7 +186,7 @@ Customizing the demo service
 
 The :ref:`demo_service_label` can be customized in two ways:
 
-- Customizing the output of the /demo HTML output, by typically adding entries
+- Customizing the output of the ``/demo`` HTML output, typically by adding entries
   for new services. This is done with the ``register_extra_demo_substitution_handler()``
   method of the ``mapproxy.service.demo`` module.
 
@@ -205,7 +205,7 @@ The :ref:`demo_service_label` can be customized in two ways:
                 :type handler: function that takes 3 arguments(DemoServer instance, req and a substitutions dictionary argument).
             """
 
-- Handling new request paths under the /demo/ hierarchy, typically to implement a new
+- Handling new request paths under the ``/demo/`` hierarchy, typically to implement a new
   service. This is done with the ``register_extra_demo_server_handler()``
   method of the ``mapproxy.service.demo`` module.
 
@@ -214,8 +214,8 @@ The :ref:`demo_service_label` can be customized in two ways:
         def register_extra_demo_server_handler(handler):
             """ Method used by plugins to register a new handler for the demo service.
                 The handler passed to this method is invoked by the DemoServer.handle()
-                method when receiving an incoming request, and let a chance to the
-                handler to process it, if it is relevant to it.
+                method when receiving an incoming request. This enables handlers to
+                process it, in case it is relevant to it.
 
                 :param handler: New handler for incoming requests
                 :type handler: function that takes 2 arguments (DemoServer instance and req) and

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -1,0 +1,303 @@
+Writing plugins
+===============
+
+Since MapProxy 1.15, it is possible to write plugins for MapProxy that can
+add new sources, services or commands. This requires Python >= 3.7
+
+Example
+-------
+
+The mapproxy_hips plugin at https://github.com/rouault/mapproxy_hips is an
+example of a plugin, which adds a new source, service and customize the demo
+service, demonstrating all the below points.
+
+How to add a plugin ?
+---------------------
+
+A plugin should be written as a Python package whose setuptools setup()
+method has a entry_points keywords with a group ``mapproxy`` pointing to
+a module with a ``plugin_entrypoint`` method.
+
+.. code-block:: python
+
+    entry_points={"mapproxy": ["hips = mapproxy_hips.pluginmodule"]},
+
+
+In this example, the mapproxy_hips/pluginmodule.py file should have
+a ``plugin_entrypoint`` method taking no argument and returning nothing.
+
+.. code-block:: python
+
+    def plugin_entrypoint():
+        # call different registration methods, like register_service_configuration(),
+        # register_source_configuration()
+        pass
+
+That method is in charge of registering the various registration methods
+detailed hereafter.
+
+Plugins will often by dependent on MapProxy internal classes. It is their
+responsibility to check the MapProxy version, in case the MapProxy internal
+API or behavior would change and make them incompatible.
+
+Adding a new service
+--------------------
+
+The ``mapproxy.config.loader`` module has a ``register_service_configuration()``
+method to register a new service and specify the allowed keywords for it in
+the YAML configuration file.
+
+.. code-block:: python
+
+    def register_service_configuration(service_name, service_creator,
+                                       yaml_spec_service_name = None, yaml_spec_service_def = None):
+        """ Method used by plugins to register a new service.
+
+            :param config_name: Name of the service
+            :type config_name: str
+            :param service_creator: Creator method of the service
+            :type service_creator: method of type (serviceConfiguration: ServiceConfiguration, conf: dict) -> Server
+            :param yaml_spec_service_name: Name of the service in the YAML configuration file
+            :type yaml_spec_service_name: str
+            :param yaml_spec_service_def: Definition of the service in the YAML configuration file
+            :type yaml_spec_service_def: dict
+        """
+
+
+This can for example by used like the following snippet:
+
+.. code-block:: python
+
+    from mapproxy.config.loader import register_service_configuration
+    from mapproxy.service.base import Server
+
+    class MyExtraServiceServer(Server):
+        # Look at classes at https://github.com/mapproxy/mapproxy/tree/master/mapproxy/service
+        # for a real implementation
+        names = ('my_extra_service',)
+        def __init__(self):
+            pass
+
+    def my_extra_service_method(serviceConfiguration, conf):
+        return MyExtraServiceServer()
+
+    register_service_configuration('my_extra_service', my_extra_service_method,
+                                   'my_extra_service', {'foo': str()})
+
+
+This allows the following declaration in the YAML mapproxy configuration file:
+
+.. code-block:: yaml
+
+    services:
+        my_extra_service:
+            foo: bar
+
+A real-world implementation can be found at https://github.com/rouault/mapproxy_hips/blob/master/mapproxy_hips/service/hips.py
+
+
+Customizing layer metadata in YAML configuration file
+-----------------------------------------------------
+
+When implementing a new service, it might be useful to add per-layer metadata
+for it. The YAML validator needs to be updated to recognize the new keywords.
+The ``add_subcategory_to_layer_md()`` method of the ``mapproxy.config.spec`` module
+can be used to do that.
+
+.. code-block:: python
+
+
+    def add_subcategory_to_layer_md(category_name, category_def):
+        """ Add a new category to wms_130_layer_md.
+            Used by plugins
+        """
+
+This can for example by used like the following snippet:
+
+.. code-block:: python
+
+    from mapproxy.config.spec import add_subcategory_to_layer_md
+
+    # Add a 'hips' subcategory to layer spec to be able to define hips service
+    # specific layer metadata
+    add_subcategory_to_layer_md('hips', anything())
+
+
+Adding a new source
+-------------------
+
+The ``mapproxy.config.loader`` module has a ``register_source_configuration()``
+method to register a new source and specify the allowed keywords for it in
+the YAML configuration file.
+
+.. code-block:: python
+
+
+    def register_source_configuration(config_name, config_class,
+                                      yaml_spec_source_name = None, yaml_spec_source_def = None):
+        """ Method used by plugins to register a new source configuration.
+
+            :param config_name: Name of the source configuration
+            :type config_name: str
+            :param config_class: Class of the source configuration
+            :type config_name: SourceConfiguration
+            :param yaml_spec_source_name: Name of the source in the YAML configuration file
+            :type yaml_spec_source_name: str
+            :param yaml_spec_source_def: Definition of the source in the YAML configuration file
+            :type yaml_spec_source_def: dict
+        """
+
+
+This can for example by used like the following snippet:
+
+.. code-block:: python
+
+    from mapproxy.config.loader import register_source_configuration
+    from mapproxy.config.loader import SourceConfiguration
+
+    class my_source_configuration(SourceConfiguration):
+        source_type = ('my_extra_source',)
+
+        def source(self, params=None):
+            # Look at classes at https://github.com/mapproxy/mapproxy/tree/master/mapproxy/source
+            # for a real implementation
+            class MySource(object):
+                def __init__(self):
+                    self.extent = None
+            return MySource()
+
+    register_source_configuration('my_extra_source', my_source_configuration,
+                                  'my_extra_source', {'foo': str()})
+
+
+This allows the following declaration in the YAML mapproxy configuration file:
+
+.. code-block:: yaml
+
+    sources:
+        some_source_name:
+            type: my_extra_source
+            foo: bar
+
+A real-world implementation can be found at https://github.com/rouault/mapproxy_hips/blob/master/mapproxy_hips/source/hips.py
+
+Customizing the demo service
+----------------------------
+
+The :ref:`demo_service_label` can be customized in two ways:
+
+- Customizing the output of the /demo HTML output, by typically adding entries
+  for new services. This is done with the ``register_extra_demo_substitution_handler()``
+  method of the ``mapproxy.service.demo`` module.
+
+  .. code-block:: python
+
+        def register_extra_demo_substitution_handler(handler):
+            """ Method used by plugins to register a new handler for doing substitutions
+                to the HTML template used by the demo service.
+                The handler passed to this method is invoked by the DemoServer._render_template()
+                method. The handler may modify the passed substitutions dictionary
+                argument. Keys of particular interest are 'extra_services_html_beginning'
+                and 'extra_services_html_end' to add HTML content before/after built-in
+                services.
+
+                :param handler: New handler for incoming requests
+                :type handler: function that takes 3 arguments(DemoServer instance, req and a substitutions dictionary argument).
+            """
+
+- Handling new request paths under the /demo/ hierarchy, typically to implement a new
+  service. This is done with the ``register_extra_demo_server_handler()``
+  method of the ``mapproxy.service.demo`` module.
+
+  .. code-block:: python
+
+        def register_extra_demo_server_handler(handler):
+            """ Method used by plugins to register a new handler for the demo service.
+                The handler passed to this method is invoked by the DemoServer.handle()
+                method when receiving an incoming request, and let a chance to the
+                handler to process it, if it is relevant to it.
+
+                :param handler: New handler for incoming requests
+                :type handler: function that takes 2 arguments (DemoServer instance and req) and
+                               returns a string with HTML content or None
+            """
+
+This can for example by used like the following snippet:
+
+.. code-block:: python
+
+    from mapproxy.service.demo import register_extra_demo_server_handler, register_extra_demo_substitution_handler
+
+    def demo_server_handler(demo_server, req):
+        if 'my_service' in req.args:
+            return 'my_return'
+        return None
+
+    def demo_substitution_handler(demo_server, req, substitutions):
+        html = '<h2>My extra service</h2>'
+        html += '<a href="/demo?my_service">My service</a>'
+        substitutions['extra_services_html_beginning'] += html
+
+    register_extra_demo_server_handler(demo_server_handler)
+    register_extra_demo_substitution_handler(demo_substitution_handler)
+
+
+A real-world example can be found at https://github.com/rouault/mapproxy_hips/blob/master/mapproxy_hips/service/demo_extra.py
+
+
+Adding new commands to mapproxy-util
+------------------------------------
+
+New commands can be added to :ref:`mapproxy-util` by using the
+``register_command()`` method of the ``mapproxy.script.util`` module
+
+.. code-block:: python
+
+    def register_command(command_name, command_spec):
+        """ Method used by plugins to register a command.
+
+            :param command_name: Name of the service
+            :type command_name: str
+            :param command_spec: Definition of the command. Dictionary with a 'func' and 'help' member
+            :type command_spec: dict
+        """
+
+This can for example by used like the following snippet:
+
+.. code-block:: python
+
+    import optparse
+    from mapproxy.script.util import register_command
+
+    def my_command(args=None):
+        parser = optparse.OptionParser("%prog my_command [options] -f mapproxy_conf -l layer")
+        parser.add_option("-f", "--mapproxy-conf", dest="mapproxy_conf",
+            help="MapProxy configuration.")
+        parser.add_option("-l", "--layer", dest="layer", help="Layer")
+
+        if args:
+            args = args[1:] # remove script name
+
+        (options, args) = parser.parse_args(args)
+        if not options.mapproxy_conf or not options.layer:
+            parser.print_help()
+            sys.exit(1)
+
+        # Do something
+
+
+    register_command('my_command', {
+        'func': my_command,
+        'help': 'Do something.'
+    })
+
+
+A real-world example can be found at
+https://github.com/rouault/mapproxy_hips/blob/master/mapproxy_hips/script/hipsallsky.py
+`
+
+Credits
+-------
+
+The development of the plugin mechanism has been funded by
+Centre National d'Etudes Spatiales (CNES): https://cnes.fr

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -112,7 +112,7 @@ can be used to do that.
             Used by plugins
         """
 
-This can for example by used like the following snippet:
+This can for example be used like in the following snippet:
 
 .. code-block:: python
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -222,7 +222,7 @@ The :ref:`demo_service_label` can be customized in two ways:
                                returns a string with HTML content or None
             """
 
-This can for example by used like the following snippet:
+This can for example be used like in the following snippet:
 
 .. code-block:: python
 
@@ -256,13 +256,13 @@ New commands can be added to :ref:`mapproxy-util` by using the
     def register_command(command_name, command_spec):
         """ Method used by plugins to register a command.
 
-            :param command_name: Name of the service
+            :param command_name: Name of the command
             :type command_name: str
             :param command_spec: Definition of the command. Dictionary with a 'func' and 'help' member
             :type command_spec: dict
         """
 
-This can for example by used like the following snippet:
+This can for example be used like in the following snippet:
 
 .. code-block:: python
 

--- a/mapproxy/client/http.py
+++ b/mapproxy/client/http.py
@@ -181,7 +181,7 @@ class HTTPClient(object):
         self.header_list = headers.items() if headers else []
         self.hide_error_details = hide_error_details
 
-    def open(self, url, data=None):
+    def open(self, url, data=None, method=None):
         code = None
         result = None
         try:
@@ -191,6 +191,8 @@ class HTTPClient(object):
             reraise_exception(err, sys.exc_info())
         for key, value in self.header_list:
             req.add_header(key, value)
+        if method:
+            req.method=method
         try:
             start_time = time.time()
             if self._timeout is not None:

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1040,6 +1040,7 @@ def register_source_configuration(config_name, config_class,
                                                     'image': image_opts,
                                                   })
     """
+    log.info('Registering configuration for plugin source %s' % config_name)
     source_configuration_types[config_name] = config_class
     if yaml_spec_source_name is not None and yaml_spec_source_def is not None:
         add_source_to_mapproxy_yaml_spec(yaml_spec_source_name, yaml_spec_source_def)
@@ -1882,6 +1883,7 @@ def register_service_configuration(service_name, service_creator,
         :type yaml_spec_service_def: dict
     """
 
+    log.info('Registering configuration for plugin service %s' % service_name)
     plugin_services[service_name] = service_creator
     if yaml_spec_service_name is not None and yaml_spec_service_def is not None:
         add_service_to_mapproxy_yaml_spec(yaml_spec_service_name, yaml_spec_service_def)
@@ -2126,6 +2128,7 @@ def load_plugins():
     for dist in importlib_metadata.distributions():
         for ep in dist.entry_points:
             if ep.group == 'mapproxy':
+                log.info('Loading plugin from package %s' % dist.metadata['name'])
                 ep.load().plugin_entrypoint()
 
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1873,8 +1873,8 @@ def register_service_configuration(service_name, service_creator,
                                    yaml_spec_service_name = None, yaml_spec_service_def = None):
     """ Method used by plugins to register a new service.
 
-        :param config_name: Name of the service
-        :type config_name: str
+        :param service_name: Name of the service
+        :type service_name: str
         :param service_creator: Creator method of the service
         :type service_creator: method of type (serviceConfiguration: ServiceConfiguration, conf: dict) -> Server
         :param yaml_spec_service_name: Name of the service in the YAML configuration file

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -604,3 +604,29 @@ mapproxy_yaml_spec = {
     # from other sections (e.g. coverages, dimensions, etc.)
     'parts': anything(),
 }
+
+
+def add_source_to_mapproxy_yaml_spec(source_name, source_spec):
+    """ Add a new source type to mapproxy_yaml_spec.
+        Used by plugins.
+    """
+
+    # sources has a single anything() : {} member
+    values = list(mapproxy_yaml_spec['sources'].values())
+    assert len(values) == 1
+    values[0].add_subspec(source_name, source_spec)
+
+
+def add_service_to_mapproxy_yaml_spec(service_name, service_spec):
+    """ Add a new service type to mapproxy_yaml_spec.
+        Used by plugins.
+    """
+
+    mapproxy_yaml_spec['services'][service_name] = service_spec
+
+
+def add_subcategory_to_layer_md(category_name, category_def):
+    """ Add a new category to wms_130_layer_md.
+        Used by plugins
+    """
+    wms_130_layer_md[category_name] = category_def

--- a/mapproxy/script/util.py
+++ b/mapproxy/script/util.py
@@ -25,6 +25,7 @@ import textwrap
 import logging
 
 from mapproxy.compat import iteritems
+from mapproxy.config.loader import load_plugins
 from mapproxy.script.conf.app import config_command
 from mapproxy.script.defrag import defrag_command
 from mapproxy.script.export import export_command
@@ -321,6 +322,18 @@ commands = {
 }
 
 
+def register_command(command_name, command_spec):
+    """ Method used by plugins to register a command.
+
+        :param command_name: Name of the service
+        :type command_name: str
+        :param command_spec: Definition of the command. Dictionary with a 'func' and 'help' member
+        :type command_spec: dict
+    """
+
+    commands[command_name] = command_spec
+
+
 class NonStrictOptionParser(optparse.OptionParser):
     def _process_args(self, largs, rargs, values):
         while rargs:
@@ -361,6 +374,9 @@ def print_items(data, title='Commands'):
         print('  %s%s' % (name, help), file=sys.stdout)
 
 def main():
+
+    load_plugins()
+
     parser = NonStrictOptionParser("usage: %prog COMMAND [options]",
         add_help_option=False)
     options, args = parser.parse_args()

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -157,8 +157,12 @@ class DemoServer(Server):
             if srs_code not in cached_srs:
                 uncached_srs.append(srs_code)
 
-        sorted_cached_srs = sorted(cached_srs, key=lambda srs: get_epsg_num(srs))
-        sorted_uncached_srs = sorted(uncached_srs, key=lambda srs: get_epsg_num(srs))
+        def get_srs_key(srs):
+            epsg_num = get_epsg_num(srs)
+            return str(epsg_num if epsg_num else srs)
+
+        sorted_cached_srs = sorted(cached_srs, key=lambda srs: get_srs_key(srs))
+        sorted_uncached_srs = sorted(uncached_srs, key=lambda srs: get_srs_key(srs))
         sorted_cached_srs = [(s + '*', s) for s in sorted_cached_srs]
         sorted_uncached_srs = [(s, s) for s in sorted_uncached_srs]
         return sorted_cached_srs + sorted_uncached_srs

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -41,6 +41,40 @@ from mapproxy.template import template_loader, bunch
 env = {'bunch': bunch}
 get_template = template_loader(__name__, 'templates', namespace=env)
 
+# Used by plugins
+extra_demo_server_handlers = set()
+
+def register_extra_demo_server_handler(handler):
+    """ Method used by plugins to register a new handler for the demo service.
+        The handler passed to this method is invoked by the DemoServer.handle()
+        method when receiving an incoming request, and let a chance to the
+        handler to process it, if it is relevant to it.
+
+        :param handler: New handler for incoming requests
+        :type handler: function that takes 2 arguments (DemoServer instance and req) and
+                       returns a string with HTML content or None
+    """
+
+    extra_demo_server_handlers.add(handler)
+
+
+extra_substitution_handlers = set()
+
+def register_extra_demo_substitution_handler(handler):
+    """ Method used by plugins to register a new handler for doing substitutions
+        to the HTML template used by the demo service.
+        The handler passed to this method is invoked by the DemoServer._render_template()
+        method. The handler may modify the passed substitutions dictionary
+        argument. Keys of particular interest are 'extra_services_html_beginning'
+        and 'extra_services_html_end' to add HTML content before/after built-in
+        services.
+
+        :param handler: New handler for incoming requests
+        :type handler: function that takes 3 arguments(DemoServer instance, req and a substitutions dictionary argument).
+    """
+
+    extra_substitution_handlers.add(handler)
+
 
 def static_filename(name):
     if base_config().template_dir:
@@ -86,6 +120,11 @@ class DemoServer(Server):
         if not authorized:
             return Response('forbidden', content_type='text/plain', status=403)
 
+        for handler in extra_demo_server_handlers:
+            demo = handler(self, req)
+            if demo is not None:
+                return Response(demo, content_type='text/html')
+
         if 'wms_layer' in req.args:
             demo = self._render_wms_template('demo/wms_demo.html', req)
         elif 'tms_layer' in req.args:
@@ -124,7 +163,7 @@ class DemoServer(Server):
             url = internal_url.replace(req.server_script_url, req.script_url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'TMS', url)
         elif req.path == '/demo/':
-            demo = self._render_template('demo/demo.html')
+            demo = self._render_template(req, 'demo/demo.html')
         else:
             resp = Response('', status=301)
             resp.headers['Location'] = req.script_url.rstrip('/') + '/demo/'
@@ -167,20 +206,30 @@ class DemoServer(Server):
         sorted_uncached_srs = [(s, s) for s in sorted_uncached_srs]
         return sorted_cached_srs + sorted_uncached_srs
 
-    def _render_template(self, template):
+    def _render_template(self, req, template):
         template = get_template(template, default_inherit="demo/static.html")
         tms_tile_layers = defaultdict(list)
         for layer in self.tile_layers:
             name = self.tile_layers[layer].md.get('name')
             tms_tile_layers[name].append(self.tile_layers[layer])
         wmts_layers = tms_tile_layers.copy()
-        return template.substitute(layers=self.layers,
-                                   formats=self.image_formats,
-                                   srs=self.srs,
-                                   layer_srs=self.layer_srs,
-                                   tms_layers=tms_tile_layers,
-                                   wmts_layers=wmts_layers,
-                                   services=self.services)
+
+        substitutions = dict(
+            extra_services_html_beginning='',
+            extra_services_html_end='',
+            layers=self.layers,
+            formats=self.image_formats,
+            srs=self.srs,
+            layer_srs=self.layer_srs,
+            tms_layers=tms_tile_layers,
+            wmts_layers=wmts_layers,
+            services=self.services
+        )
+
+        for add_substitution in extra_substitution_handlers:
+            add_substitution(self, req, substitutions)
+
+        return template.substitute(substitutions)
 
     def _render_wms_template(self, template, req):
         template = get_template(template, default_inherit="demo/static.html")

--- a/mapproxy/service/templates/demo/demo.html
+++ b/mapproxy/service/templates/demo/demo.html
@@ -35,6 +35,7 @@ jscript_openlayers=None
 {{enddef}}
             <h2>About</h2>
             <p>MapProxy Version {{version}}</p>
+            {{ extra_services_html_beginning }}
             <h2>WMS</h2>
             {{if 'wms' in services}}
             <div class="capabilities">
@@ -177,3 +178,4 @@ jscript_openlayers=None
                 <span>This service is not available with the current configuration.</span>
             </div>
             {{endif}}
+            {{ extra_services_html_end }}

--- a/mapproxy/template.py
+++ b/mapproxy/template.py
@@ -28,7 +28,9 @@ def template_loader(module_name, location='templates', namespace={}):
 
     class loader(object):
         def __call__(self, name, from_template=None, default_inherit=None):
-            if base_config().template_dir:
+            if os.path.isabs(name):
+                template_file = name
+            elif base_config().template_dir:
                 template_file = os.path.join(base_config().template_dir, name)
             else:
                 template_file = pkg_resources.resource_filename(module_name, location + '/' + name)

--- a/mapproxy/test/http.py
+++ b/mapproxy/test/http.py
@@ -131,6 +131,10 @@ def mock_http_handler(requests_responses, unordered=False, query_comparator=None
     if query_comparator is None:
         query_comparator = query_eq
     class MockHTTPHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.query_data = self.path
+            return self.do_mock_request('HEAD')
+
         def do_GET(self):
             self.query_data = self.path
             return self.do_mock_request('GET')
@@ -207,7 +211,10 @@ def mock_http_handler(requests_responses, unordered=False, query_comparator=None
                 with open(resp['body_file'], 'rb') as f:
                     self.wfile.write(f.read())
             else:
-                self.wfile.write(resp['body'])
+                if 'body' in resp:
+                    self.wfile.write(resp['body'])
+                else:
+                    self.wfile.write(b'')
             if not requests_responses:
                 self.server.shutdown = True
             return

--- a/mapproxy/test/system/__init__.py
+++ b/mapproxy/test/system/__init__.py
@@ -34,6 +34,9 @@ class WSGITestApp(_TestApp):
     def get(self, url, *args, **kw):
         return _TestApp.get(self, str(url), *args, **kw)
 
+    def head(self, url, *args, **kw):
+        return _TestApp.head(self, str(url), *args, **kw)
+
 
 @pytest.mark.usefixtures("cache_dir")
 class SysTest(object):

--- a/mapproxy/test/system/fixture/demo.yaml
+++ b/mapproxy/test/system/fixture/demo.yaml
@@ -1,0 +1,135 @@
+globals:
+  cache:
+    base_dir: cache_data/
+    meta_size: [1, 1]
+    meta_buffer: 0
+  image:
+    # resampling: 'bicubic'
+    paletted: False
+services:
+  demo:
+  tms:
+  kml:
+  wmts:
+    md:
+      keyword_list:
+        - keywords: [wmtskey1, wmtskey2, wmtskey3]
+    featureinfo_formats:
+      - mimetype: application/gml+xml; version=3.1
+        suffix: gml
+      - mimetype: application/json
+        suffix: geojson
+
+    restful_template: '/myrest/{Layer}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}'
+    restful_featureinfo_template: '/myrest/{Layer}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}/{I}/{J}.{InfoFormat}'
+  wms:
+    md:
+      title: MapProxy test fixture
+      abstract: This is MapProxy.
+      keyword_list:
+        - keywords: [wmskey1,wmskey2,wmskey3]
+      online_resource: http://mapproxy.org/
+      contact:
+        person: Oliver Tonnhofer
+        position: Technical Director
+        organization: Omniscale
+        address: Nadorster Str. 60
+        city: Oldenburg
+        postcode: 26123
+        country: Germany
+        phone: +49(0)441-9392774-0
+        fax: +49(0)441-9392774-9
+        email: info@omniscale.de
+      access_constraints:
+        Here be dragons.
+
+layers:
+  - name: wms_cache
+    title: WMS Cache Layer
+    sources: [wms_cache]
+  - name: wms_cache_multi
+    title: WMS Cache Multi Layer
+    sources: [wms_cache_multi]
+  - name: tms_cache
+    title: TMS Cache Layer
+    sources: [tms_cache, wms_fi_only]
+  - name: tms_cache_ul
+    title: TMS Cache Layer
+    sources: [tms_cache_ul]
+  - name: gk3_cache
+    title: GK3 Cache Layer
+    sources: [gk3_cache]
+caches:
+  wms_cache:
+    format: image/jpeg
+    grids: [GLOBAL_MERCATOR]
+    sources: [wms_cache]
+  wms_cache_multi:
+    format: image/jpeg
+    grids: [CustomGridSet, GoogleMapsCompatible]
+    sources: [wms_cache_130]
+  tms_cache:
+    grids: [GLOBAL_MERCATOR]
+    sources: [tms_cache]
+  tms_cache_ul:
+    grids: [ulgrid]
+    sources: [tms_cache]
+  gk3_cache:
+    grids: [gk3]
+    sources: [wms_cache]
+
+sources:
+  wms_cache:
+    type: wms
+    supported_srs: ['EPSG:3857', 'EPSG:4326']
+    wms_opts:
+      featureinfo: True
+    req:
+      url: http://localhost:42423/service
+      layers: foo,bar
+  wms_cache_100:
+    type: wms
+    wms_opts:
+      version: '1.0.0'
+      featureinfo: True
+    req:
+      url: http://localhost:42423/service
+      layers: foo,bar
+  wms_cache_130:
+    type: wms
+    min_res: 250000000
+    max_res: 1
+    wms_opts:
+      version: '1.3.0'
+      featureinfo: True
+    req:
+      url: http://localhost:42423/service
+      layers: foo,bar
+  tms_cache:
+    type: tile
+    url: http://localhost:42423/tiles/%(tc_path)s.png
+  wms_fi_only:
+    type: wms
+    wms_opts:
+      featureinfo: True
+      map: False
+    req:
+      url: http://localhost:42423/service
+      layers: fi
+    coverage:
+      bbox: [-180,-90,170,80]
+      srs: 'EPSG:4326'
+
+grids:
+  gk3:
+    srs: 'EPSG:31467'
+    bbox: [3000000, 5000000, 4000000, 6000000]
+    origin: 'ul'
+  GoogleMapsCompatible:
+    base: GLOBAL_MERCATOR
+  CustomGridSet:
+    base: GLOBAL_GEODETIC
+    min_res: 0.703125
+  ulgrid:
+    base: GLOBAL_MERCATOR
+    origin: ul

--- a/mapproxy/test/system/test_demo.py
+++ b/mapproxy/test/system/test_demo.py
@@ -1,0 +1,34 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2022 Even Rouault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from mapproxy.test.system import SysTest
+
+
+@pytest.fixture(scope="module")
+def config_file():
+    return "demo.yaml"
+
+
+class TestDemo(SysTest):
+
+    def test_basic(self, app):
+        resp = app.get("/demo/", status=200)
+        assert resp.content_type == "text/html"
+        assert 'href="../service?REQUEST=GetCapabilities"' in resp
+        assert 'href="../service?REQUEST=GetCapabilities&tiled=true"' in resp
+        assert 'href="../demo/?wmts_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
+        assert 'href="../demo/?tms_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp

--- a/mapproxy/test/system/test_demo_with_extra_service.py
+++ b/mapproxy/test/system/test_demo_with_extra_service.py
@@ -1,0 +1,53 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2022 Even Rouault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from mapproxy.service.demo import extra_demo_server_handlers, extra_substitution_handlers, register_extra_demo_server_handler, register_extra_demo_substitution_handler
+from mapproxy.test.system import SysTest
+
+def demo_server_handler(demo_server, req):
+    if 'my_service' in req.args:
+        return 'my_return'
+    return None
+
+
+def demo_substitution_handler(demo_server, req, substitutions):
+    substitutions['extra_services_html_beginning'] += '<h2>My extra service</h2>'
+
+@pytest.fixture(scope="module")
+def config_file():
+    register_extra_demo_server_handler(demo_server_handler)
+    register_extra_demo_substitution_handler(demo_substitution_handler)
+    yield "demo.yaml"
+    extra_demo_server_handlers.clear()
+    extra_substitution_handlers.clear()
+
+
+class TestDemoWithExtraService(SysTest):
+
+    def test_basic(self, app):
+        resp = app.get("/demo/", status=200)
+        assert resp.content_type == "text/html"
+        assert 'href="../service?REQUEST=GetCapabilities"' in resp
+        assert 'href="../service?REQUEST=GetCapabilities&tiled=true"' in resp
+        assert 'href="../demo/?wmts_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
+        assert 'href="../demo/?tms_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
+        assert '<h2>My extra service</h2>' in resp
+
+    def test_my_service(self, app):
+        resp = app.get("/demo/?my_service=bar", status=200)
+        assert resp.content_type == "text/html"
+        assert 'my_return' in resp

--- a/mapproxy/test/unit/test_client.py
+++ b/mapproxy/test/unit/test_client.py
@@ -15,6 +15,7 @@
 
 
 import os
+import sys
 import time
 
 import pytest
@@ -49,6 +50,12 @@ class TestHTTPClient(object):
         with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/service?foo=bar', 'method': 'POST'},
                                               {'status': '200', 'body': b''})]):
             self.client.open(TESTSERVER_URL + '/service', data=b"foo=bar")
+
+    @pytest.mark.skipif(sys.version_info < (3,), reason='HEAD request not supported by BaseHTTPRequestHandler in Py 2')
+    def test_head(self):
+        with mock_httpd(TESTSERVER_ADDRESS, [({'path': '/service', 'method': 'HEAD'},
+                                              {'status': '200'})]):
+            self.client.open(TESTSERVER_URL + '/service', method = 'HEAD')
 
     def test_internal_error_response(self):
         try:

--- a/mapproxy/util/ext/dictspec/spec.py
+++ b/mapproxy/util/ext/dictspec/spec.py
@@ -99,13 +99,10 @@ class number(object):
 class type_spec(object):
     def __init__(self, type_key, specs):
         self.type_key = type_key
-        self.specs = specs
+        self.specs = {}
 
-        for v in itervalues(specs):
-            if not isinstance(v, dict):
-                raise ValueError('%s requires dict subspecs', self.__class__)
-            if self.type_key not in v:
-                v[self.type_key] = str()
+        for key in specs:
+            self.add_subspec(key, specs[key])
 
     def subspec(self, data, context):
         if not data:
@@ -118,3 +115,10 @@ class type_spec(object):
         if key not in self.specs:
             raise ValueError("unknown %s value '%s' in %s" % (self.type_key, key, context.current_pos))
         return self.specs[key]
+
+    def add_subspec(self, key, subspec):
+        if not isinstance(subspec, dict):
+            raise ValueError('%s requires dict subspecs', self.__class__)
+        if self.type_key not in subspec:
+            subspec[self.type_key] = str()
+        self.specs[key] = subspec


### PR DESCRIPTION
This PR builds upon the bugfix of https://github.com/mapproxy/mapproxy/pull/577 (first commit)

The scope of this PR is best explained by the new documentation page: https://github.com/rouault/mapproxy/blob/plugins/doc/plugins.rst

It can also be quickly demo'ed with:

```shell
python3 -m venv myvenv
source myvenv/bin/activate
pip install git+https://github.com/rouault/mapproxy@plugins
pip install git+https://github.com/rouault/mapproxy_hips

git clone https://github.com/rouault/mapproxy_hips
mapproxy-util serve-develop mapproxy_hips/hips_examples/ogc_as_hips/mapproxy.yaml &
curl http://localhost:8080/hips/mars_tiled_geodetic/properties
```