### PR TITLE
Fixup layer preview

### DIFF
--- a/mapproxy/test/system/test_demo.py
+++ b/mapproxy/test/system/test_demo.py
@@ -32,3 +32,8 @@ class TestDemo(SysTest):
         assert 'href="../service?REQUEST=GetCapabilities&tiled=true"' in resp
         assert 'href="../demo/?wmts_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
         assert 'href="../demo/?tms_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
+
+    def test_previewmap(self, app):
+        resp = app.get("/demo/?srs=EPSG%3A3857&format=image%2Fpng&wms_layer=wms_cache", status=200)
+        assert resp.content_type == "text/html"
+        assert '<h2>Openlayers Client - Layer wms_cache</h2>' in resp

--- a/mapproxy/util/ext/tempita/__init__.py
+++ b/mapproxy/util/ext/tempita/__init__.py
@@ -250,6 +250,8 @@ class Template(object):
 
     def _interpret_for(self, vars, expr, content, ns, out, defs):
         __traceback_hide__ = True
+        if expr is None:
+            return
         for item in expr:
             if len(vars) == 1:
                 ns[vars[0]] = item


### PR DESCRIPTION
This fixes the wms layer preview which failed with following stacktrace after merging https://github.com/mapproxy/mapproxy/pull/449

I am not really sure what the intended behaviour was in the mentioned PR (maybe @ingenieroariel @tomkralidis or @drnextgis can help), but this keeps the preview running at least

```
Traceback (most recent call last):
  File "/home/johnny/workspace/mapproxy/mapproxy/wsgiapp.py", line 141, in __call__
    resp = self.handlers[handler_name].handle(req)
  File "/home/johnny/workspace/mapproxy/mapproxy/service/demo.py", line 90, in handle
    demo = self._render_wms_template('demo/wms_demo.html', req)
  File "/home/johnny/workspace/mapproxy/mapproxy/service/demo.py", line 193, in _render_wms_template
    return template.substitute(layer=layer,
  File "/home/johnny/workspace/mapproxy/mapproxy/util/ext/tempita/__init__.py", line 167, in substitute
    result, defs, inherit = self._interpret(ns)
  File "/home/johnny/workspace/mapproxy/mapproxy/util/ext/tempita/__init__.py", line 178, in _interpret
    self._interpret_codes(self._parsed, ns, out=parts, defs=defs)
  File "/home/johnny/workspace/mapproxy/mapproxy/util/ext/tempita/__init__.py", line 206, in _interpret_codes
    self._interpret_code(item, ns, out, defs)
  File "/home/johnny/workspace/mapproxy/mapproxy/util/ext/tempita/__init__.py", line 220, in _interpret_code
    self._interpret_for(vars, expr, content, ns, out, defs)
  File "/home/johnny/workspace/mapproxy/mapproxy/util/ext/tempita/__init__.py", line 253, in _interpret_for
    for item in expr if expr is not None:
TypeError: 'NoneType' object is not iterable
```
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
