### PR TITLE
MapExtent: remove hardcoded EPSG:4326

### DIFF
--- a/mapproxy/layer.py
+++ b/mapproxy/layer.py
@@ -200,7 +200,7 @@ class MapExtent(object):
     @property
     def llbbox(self):
         if not self._llbbox:
-            self._llbbox = self.srs.transform_bbox_to(SRS(4326), self.bbox)
+            self._llbbox = self.srs.transform_bbox_to(self.srs.get_geographic_srs(), self.bbox)
         return self._llbbox
 
     def bbox_for(self, srs):
@@ -236,7 +236,7 @@ class MapExtent(object):
             return self
         if self.is_default:
             return other
-        return MapExtent(merge_bbox(self.llbbox, other.llbbox), SRS(4326))
+        return MapExtent(merge_bbox(self.llbbox, other.llbbox), self.srs.get_geographic_srs())
 
     def contains(self, other):
         if not isinstance(other, MapExtent):

--- a/mapproxy/srs.py
+++ b/mapproxy/srs.py
@@ -238,6 +238,13 @@ class _SRS_Proj4_API(object):
         """
         return self.proj.is_latlong()
 
+
+    def get_geographic_srs(self):
+        """ Return the "canonical" geographic CRS corresponding to this CRS.
+            Always EPSG:4326 for Proj4 implementation """
+        return SRS(4326)
+
+
     @property
     def is_axis_order_ne(self):
         """
@@ -431,6 +438,17 @@ class _SRS(object):
         False
         """
         return self.proj.is_geographic
+
+
+    def get_geographic_srs(self):
+        """ Return the "canonical" geographic CRS corresponding to this CRS.
+            EPSG:4326 for Earth CRS, or another one from other celestial bodies """
+        auth = self.proj.to_authority()
+        if auth is None or not auth[0].startswith('IAU'):
+            ret = SRS(4326)
+        else:
+            return _SRS(':'.join(self.proj.geodetic_crs.to_authority()))
+        return ret
 
     @property
     def is_axis_order_ne(self):

--- a/mapproxy/test/unit/test_srs.py
+++ b/mapproxy/test/unit/test_srs.py
@@ -31,6 +31,8 @@ class TestSRS(object):
         assert not srs.is_axis_order_en
         assert srs.is_axis_order_ne
 
+        assert srs.get_geographic_srs() == srs
+
     def test_crs84(self):
         srs = SRS("CRS:84")
 
@@ -47,6 +49,8 @@ class TestSRS(object):
         assert not srs.is_axis_order_en
         assert srs.is_axis_order_ne
 
+        assert srs.get_geographic_srs() == SRS(4326)
+
     def test_epsg900913(self):
         srs = SRS("epsg:900913")
 
@@ -60,6 +64,29 @@ class TestSRS(object):
         assert not srs.is_latlong
         assert srs.is_axis_order_en
         assert not srs.is_axis_order_ne
+
+        assert srs.get_geographic_srs() == SRS(4326)
+
+
+    def test_iau_crs(self):
+        try:
+            srs = SRS("IAU:49900") # "Mars (2015) - Sphere / Ocentric"
+        except:
+            pytest.skip('Requires recent pyproj version')
+
+        assert srs.is_latlong
+        assert '49900' in str(srs.get_geographic_srs())
+
+
+    def test_iau_crs_projected(self):
+        try:
+            srs = SRS("IAU:49910") # "Mars (2015) - Sphere / Ocentric / Equirectangular, clon = 0"
+        except:
+            pytest.skip('Requires recent pyproj version')
+
+        assert not srs.is_latlong
+        assert '49900' in str(srs.get_geographic_srs())
+
 
     def test_from_srs(self):
         srs1 = SRS("epsg:4326")


### PR DESCRIPTION
Fix for non-Earth usages

* SRS class: add a get_geographic_srs() method

Return the "canonical" geographic CRS corresponding to this CRS.
EPSG:4326 for Earth CRS, or another one from other celestial bodies.

* MapExtent: do not hardcode EPSG:4326 in llbox()/bbox_for() methods, but use SRS.get_geographic_srs()