### PR TITLE
Use 'shape()' function instead of 'asShape()'

### DIFF
--- a/mapproxy/util/geom.py
+++ b/mapproxy/util/geom.py
@@ -144,7 +144,7 @@ def load_geojson(datasource):
 
     polygons = []
     for geom in geometries:
-        geom = shapely.geometry.asShape(geom)
+        geom = shapely.geometry.shape(geom)
         if geom.type == 'Polygon':
             polygons.append(geom)
         elif geom.type == 'MultiPolygon':


### PR DESCRIPTION
This PR fixes the following issue:

```
$ mapproxy-seed --continue -f mapproxy.yaml -c 4 --seed myseed1 seed.yaml
[2022-08-04 13:49:33,456] mapproxy.config - WARNING - Missing layers section
[2022-08-04 13:49:33,456] mapproxy.config - WARNING - Missing services section
/tmp/tile-cache/env/lib/python3.8/site-packages/mapproxy/util/geom.py:147: ShapelyDeprecationWarning: The proxy geometries (through the 'asShape()', 'asMultiPolygon()' or 'MultiPolygonAdapter()' constructors) are deprecated and will be removed in Shapely 2.0. Use the 'shape()' function or the standard 'MultiPolygon()' constructor instead.
  geom = shapely.geometry.asShape(geom)
Exception ignored in: <function BaseGeometry.__del__ at 0x7f1e8a07d700>
Traceback (most recent call last):
  File "/tmp/tile-cache/env/lib/python3.8/site-packages/shapely/geometry/base.py", line 209, in __del__
    self._empty(val=None)
  File "/tmp/tile-cache/env/lib/python3.8/site-packages/shapely/geometry/base.py", line 199, in _empty
    self._is_empty = True
  File "/tmp/tile-cache/env/lib/python3.8/site-packages/shapely/geometry/proxy.py", line 44, in __setattr__
    object.__setattr__(self, name, value)
AttributeError: can't set attribute
```