### PR TITLE
fix passing dimensions by changing from positional to keyword argument

### DIFF
--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -344,7 +344,7 @@ class MBTilesLevelCache(TileCacheBase):
 
         return self._get_level(tile.coord[2]).store_tile(tile, dimensions=dimensions)
 
-    def store_tiles(self, tiles, dimensions):
+    def store_tiles(self, tiles, dimensions=None):
         failed = False
         for level, tiles in itertools.groupby(tiles, key=lambda t: t.coord[2]):
             tiles = [t for t in tiles if not t.stored]
@@ -352,11 +352,11 @@ class MBTilesLevelCache(TileCacheBase):
             if not res: failed = True
         return failed
 
-    def load_tile(self, tile, with_metadata=False):
+    def load_tile(self, tile, with_metadata=False, dimensions=None):
         if tile.source or tile.coord is None:
             return True
 
-        return self._get_level(tile.coord[2]).load_tile(tile, with_metadata=with_metadata)
+        return self._get_level(tile.coord[2]).load_tile(tile, with_metadata=with_metadata, dimensions=dimensions)
 
     def load_tiles(self, tiles, with_metadata=False, dimensions=None):
         level = None
@@ -377,7 +377,7 @@ class MBTilesLevelCache(TileCacheBase):
 
         return self._get_level(tile.coord[2]).remove_tile(tile)
 
-    def load_tile_metadata(self, tile, dimensions):
+    def load_tile_metadata(self, tile, dimensions=None):
         self.load_tile(tile, dimensions=dimensions)
 
     def remove_level_tiles_before(self, level, timestamp):


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

This (hopefully) fixes the bug mentioned in https://github.com/mapproxy/mapproxy/issues/597.

A few methods were expecting a positional argument `dimensions`, which was not used in any call. In order to fix this problem, I changed the method signatures that now expect a keyword argument `dimensions=`.

I am unsure, why a few methods were expecting `dimensions` as a positional argument, while the majority is expecting a keyword argument (see https://github.com/mapproxy/mapproxy/commit/6f4753a9008b858bccd7fbd0dff12f3087f83288#diff-ec8c90017656b594aa66aedaf8bffaa27734b0d1b9f867d5547b3cd6702e73b7R380 for comparison). There probably has been a reason for this, which surpasses my very limited understanding of mapproxy. However, since I could not find any calls that actually provided the positional argument, this code could never have worked.

Running test locally succeeds.

@traviskirstine could you please verify that this fixes the bug you described in https://github.com/mapproxy/mapproxy/issues/597?