### PR TITLE
New cache: Azure Blob storage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,11 @@ jobs:
         ports:
           - 8087:8087
           - 8098:8098
-      
+      azure-blob:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+
     strategy:
       matrix:
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
@@ -36,6 +40,7 @@ jobs:
       MAPPROXY_TEST_REDIS: '127.0.0.1:6379'
       MAPPROXY_TEST_RIAK_HTTP: 'http://localhost:8098'
       MAPPROXY_TEST_RIAK_PBC: 'pbc://localhost:8087'
+      MAPPROXY_TEST_AZURE_BLOB: 'http://localhost:10000'
       # do not load /etc/boto.cfg with Python 3 incompatible plugin
       # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
       BOTO_CONFIG: '/doesnotexist'

--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -35,6 +35,7 @@ The following backend types are available.
 - :ref:`cache_riak`
 - :ref:`cache_redis`
 - :ref:`cache_s3`
+- :ref:`cache_azureblob`
 - :ref:`cache_compact`
 
 .. _cache_file:
@@ -494,7 +495,7 @@ Example
         profile_name: default
 
 
-Example usage with DigitalOcean Spaces 
+Example usage with DigitalOcean Spaces
 --------------------------------------
 
 ::
@@ -515,6 +516,75 @@ Example usage with DigitalOcean Spaces
         endpoint_url: https://nyc3.digitaloceanspaces.com
         access_control_list: public-read
 
+.. _cache_azureblob:
+
+``azureblob``
+======
+
+.. versionadded:: to be released
+
+Store tiles in `Azure Blob Storage <https://azure.microsoft.com/en-us/products/storage/blobs/>`_, Microsoft's object storage solution for the cloud.
+
+
+Requirements
+------------
+
+You will need the `azure-storage-blob <https://pypi.org/project/azure-storage-blob/>`_ package. You can install it in the usual way, for example with ``pip install azure-storage-blob``.
+
+Configuration
+-------------
+
+Available options:
+
+``container_name``:
+  The blob container used for this cache. You can set the default container with ``globals.cache.azureblob.container_name``.
+
+``connection_string``:
+  Credentials/url to connect and authenticate against Azure Blob storage. You can set the default connection_string with ``globals.cache.azureblob.connection_string`` or
+  using the ``AZURE_STORAGE_CONNECTION_STRING`` environment variable. There are several ways to
+  `authenticate against Azure Blob storage <https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string>`_:
+
+- Using the storage account key. This connection string can also found in the Azure Portal under the "Access Keys" section. For example:
+
+::
+
+    "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key"
+
+- Using a SAS token. For example:
+
+::
+
+    "BlobEndpoint=https://my-storage-account.blob.core.windows.net;SharedAccessSignature=sv=2015-04-05&sr=b&si=tutorial-policy-635959936145100803&sig=9aCzs76n0E7y5BpEi2GvsSv433BZa22leDOZXX%2BXXIU%3D"
+
+- Using a local Azurite emulator, this is for TESTING purposes only. For example, using the default Azurite account:
+
+::
+
+    "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1"
+
+``directory``:
+  Base directory (path) where all tiles are stored.
+
+``directory_layout``:
+  Defines the directory layout for the tiles (``12/12345/67890.png``, ``L12/R00010932/C00003039.png``, etc.).  See :ref:`cache_file` for available options. Defaults to ``tms`` (e.g. ``12/12345/67890.png``). This cache cache also supports ``reverse_tms`` where tiles are stored as ``y/x/z.format``.
+
+Example
+-------
+
+::
+
+  cache:
+    my_layer_20110501_epsg_4326_cache_out:
+      sources: [my_layer_20110501_cache]
+      cache:
+        type: azureblob
+        directory: /1.0.0/my_layer/default/20110501/4326/
+        container_name: my-azureblob-tiles-cache
+
+  globals:
+    cache:
+      azureblob:
+        connection_string: "DefaultEndpointsProtocol=https;AccountName=xxxx;AccountKey=xxxx"
 
 .. _cache_compact:
 

--- a/mapproxy/cache/azureblob.py
+++ b/mapproxy/cache/azureblob.py
@@ -1,0 +1,140 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2022 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import calendar
+import hashlib
+from io import BytesIO
+
+from mapproxy.cache import path
+from mapproxy.cache.base import tile_buffer, TileCacheBase
+from mapproxy.image import ImageSource
+from mapproxy.util import async_
+
+try:
+    from azure.storage.blob import BlobServiceClient, ContentSettings
+    from azure.core.exceptions import AzureError
+except ImportError:
+    BlobServiceClient = None
+    ContentSettings = None
+    AzureError = None
+
+import logging
+log = logging.getLogger('mapproxy.cache.azureblob')
+
+
+def azure_container_client(connection_string, container_name):
+    client = BlobServiceClient.from_connection_string(connection_string)
+    return client.get_container_client(container_name)
+
+
+class AzureBlobConnectionError(Exception):
+    pass
+
+
+class AzureBlobCache(TileCacheBase):
+
+    def __init__(self, base_path, file_ext, directory_layout='tms', container_name='mapproxy',
+                 _concurrent_writer=4, _concurrent_reader=4, connection_string=None):
+        super(AzureBlobCache, self).__init__()
+        if BlobServiceClient is None:
+            raise ImportError("Azure Blob Cache requires 'azure-storage-blob' package")
+
+        self.lock_cache_id = 'azureblob-' + hashlib.md5(base_path.encode('utf-8')
+                                                        + container_name.encode('utf-8')).hexdigest()
+
+        self.container_client = azure_container_client(connection_string, container_name)
+        if not self.container_client.exists():
+            raise AzureBlobConnectionError('Blob container %s does not exist' % container_name)
+
+        self.base_path = base_path
+        self.file_ext = file_ext
+        self._concurrent_writer = _concurrent_writer
+        self._concurrent_reader = _concurrent_reader
+        self._tile_location, _ = path.location_funcs(layout=directory_layout)
+
+    def tile_key(self, tile):
+        return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
+
+    def load_tile_metadata(self, tile, dimensions=None):
+        if tile.timestamp:
+            return
+        self.is_cached(tile, dimensions=dimensions)
+
+    @staticmethod
+    def _set_metadata(properties, tile):
+        tile.timestamp = calendar.timegm(properties.last_modified.timetuple())
+        tile.size = properties.size
+
+    def is_cached(self, tile, dimensions=None):
+        if tile.is_missing():
+            key = self.tile_key(tile)
+            blob = self.container_client.get_blob_client(key)
+            if not blob.exists():
+                return False
+            else:
+                self._set_metadata(blob.get_blob_properties(), tile)
+
+        return True
+
+    def load_tiles(self, tiles, with_metadata=True, dimensions=None):
+        p = async_.Pool(min(self._concurrent_reader, len(tiles)))
+        return all(p.map(self.load_tile, tiles))
+
+    def load_tile(self, tile, with_metadata=True, dimensions=None):
+        if not tile.cacheable:
+            return False
+
+        if not tile.is_missing():
+            return True
+
+        key = self.tile_key(tile)
+        log.debug('AzureBlob:load_tile, loading key: %s' % key)
+
+        try:
+            r = self.container_client.download_blob(key)
+            self._set_metadata(r.properties, tile)
+            tile.source = ImageSource(BytesIO(r.readall()))
+        except AzureError as e:
+            log.debug("AzureBlob:load_tile unable to load key: %s" % key, e)
+            tile.source = None
+            return False
+
+        log.debug("AzureBlob:load_tile loaded key: %s" % key)
+        return True
+
+    def remove_tile(self, tile, dimensions=None):
+        key = self.tile_key(tile)
+        log.debug('remove_tile, key: %s' % key)
+        self.container_client.delete_blob(key)
+
+    def store_tiles(self, tiles, dimensions=None):
+        p = async_.Pool(min(self._concurrent_writer, len(tiles)))
+        p.map(self.store_tile, tiles)
+
+    def store_tile(self, tile, dimensions=None):
+        if tile.stored:
+            return
+
+        key = self.tile_key(tile)
+        log.debug('AzureBlob: store_tile, key: %s' % key)
+
+        with tile_buffer(tile) as buf:
+            content_settings = ContentSettings(content_type='image/' + self.file_ext)
+            self.container_client.upload_blob(
+                name=key,
+                data=buf,
+                overwrite=True,
+                content_settings=content_settings)

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -183,6 +183,13 @@ cache_types = {
         required('version'): number(),
         'tile_lock_dir': str(),
     },
+    'azureblob': {
+        'connection_string': str(),
+        'container_name': str(),
+        'directory_layout': str(),
+        'directory': str(),
+        'tile_lock_dir': str(),
+    },
 }
 
 on_error = {
@@ -387,6 +394,10 @@ mapproxy_yaml_spec = {
                 'profile_name': str(),
                 'region_name': str(),
                 'endpoint_url': str(),
+            },
+            'azureblob': {
+                'connection_string': str(),
+                'container_name': str(),
             },
         },
         'grid': {

--- a/mapproxy/test/system/fixture/cache_azureblob.yaml
+++ b/mapproxy/test/system/fixture/cache_azureblob.yaml
@@ -1,0 +1,59 @@
+globals:
+  cache:
+    azureblob:
+      connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1"
+      container_name: default-container
+
+services:
+  tms:
+  wms:
+    md:
+      title: MapProxy Azure Blob
+
+layers:
+  - name: default
+    title: Default
+    sources: [default_cache]
+  - name: quadkey
+    title: Quadkey
+    sources: [quadkey_cache]
+  - name: reverse
+    title: Reverse
+    sources: [reverse_cache]
+
+caches:
+  default_cache:
+    grids: [webmercator]
+    cache:
+      type: azureblob
+    sources: [tms]
+
+  quadkey_cache:
+    grids: [webmercator]
+    cache:
+      type: azureblob
+      container_name: tiles
+      directory_layout: quadkey
+      directory: quadkeytiles
+    sources: [tms]
+
+  reverse_cache:
+    grids: [webmercator]
+    cache:
+      type: azureblob
+      container_name: tiles
+      directory_layout: reverse_tms
+      directory: reversetiles
+    sources: [tms]
+
+grids:
+  webmercator:
+    name: WebMerc
+    base: GLOBAL_WEBMERCATOR
+
+
+sources:
+  tms:
+    type: tile
+    url: http://localhost:42423/tiles/%(tc_path)s.png
+

--- a/mapproxy/test/system/test_cache_azureblob.py
+++ b/mapproxy/test/system/test_cache_azureblob.py
@@ -1,0 +1,120 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2022 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import os
+from io import BytesIO
+
+import pytest
+
+from mapproxy.request.wms import WMS111MapRequest
+from mapproxy.test.image import is_png, create_tmp_image
+from mapproxy.test.system import SysTest
+
+try:
+    from mapproxy.cache.azureblob import AzureBlobCache, azure_container_client
+except ImportError:
+    AzureBlobCache = None
+    azure_container_client = None
+
+
+def azureblob_connection():
+    # Use default storage account of Azurite emulator
+    host = os.environ['MAPPROXY_TEST_AZURE_BLOB']
+    return 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=' \
+           'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr' \
+           '/KBHBeksoGMGw==;BlobEndpoint=' + host + '/devstoreaccount1;'
+
+
+@pytest.fixture(scope="module")
+def config_file():
+    return "cache_azureblob.yaml"
+
+
+@pytest.fixture(scope="module")
+def azureblob_containers():
+    container = azure_container_client(azureblob_connection(), 'default-container')
+    if not container.exists():
+        container.create_container()
+    container = azure_container_client(azureblob_connection(), 'tiles')
+    if not container.exists():
+        container.create_container()
+
+    yield
+
+
+@pytest.mark.skipif(not AzureBlobCache or not os.environ.get('MAPPROXY_TEST_AZURE_BLOB'),
+                    reason="azure-storage-blob package and MAPPROXY_TEST_AZURE_BLOB env required")
+@pytest.mark.usefixtures("azureblob_containers")
+class TestAzureBlobCache(SysTest):
+
+    def setup(self):
+        self.common_map_req = WMS111MapRequest(
+            url="/service?",
+            param=dict(
+                service="WMS",
+                version="1.1.1",
+                bbox="-150,-40,-140,-30",
+                width="100",
+                height="100",
+                layers="default",
+                srs="EPSG:4326",
+                format="image/png",
+                styles="",
+                request="GetMap",
+            ),
+        )
+
+    def test_get_map_cached(self, app):
+        tile = create_tmp_image((256, 256))
+        container = azure_container_client(azureblob_connection(), 'default-container')
+        container.upload_blob(
+            name="default_cache/WebMerc/4/1/9.png",
+            data=BytesIO(tile),
+            overwrite=True
+        )
+        resp = app.get(self.common_map_req)
+        assert resp.content_type == "image/png"
+        data = BytesIO(resp.body)
+        assert is_png(data)
+
+    def test_get_map_cached_quadkey(self, app):
+        tile = create_tmp_image((256, 256))
+        container = azure_container_client(azureblob_connection(), 'tiles')
+        container.upload_blob(
+            name="quadkeytiles/2003.png",
+            data=BytesIO(tile),
+            overwrite=True
+        )
+        self.common_map_req.params.layers = "quadkey"
+        resp = app.get(self.common_map_req)
+        assert resp.content_type == "image/png"
+        data = BytesIO(resp.body)
+        assert is_png(data)
+
+    def test_get_map_cached_reverse_tms(self, app):
+        tile = create_tmp_image((256, 256))
+        container = azure_container_client(azureblob_connection(), 'tiles')
+        container.upload_blob(
+            name="reversetiles/9/1/4.png",
+            data=BytesIO(tile),
+            overwrite=True
+        )
+        self.common_map_req.params.layers = "reverse"
+        resp = app.get(self.common_map_req)
+        assert resp.content_type == "image/png"
+        data = BytesIO(resp.body)
+        assert is_png(data)

--- a/mapproxy/test/unit/test_cache_azureblob.py
+++ b/mapproxy/test/unit/test_cache_azureblob.py
@@ -1,0 +1,95 @@
+# This file is part of the MapProxy project.
+# Copyright (C) 2022 Omniscale <http://omniscale.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+try:
+    from mapproxy.cache.azureblob import AzureBlobCache, azure_container_client
+except ImportError:
+    AzureBlobCache = None
+    azure_container_client = None
+
+from mapproxy.test.unit.test_cache_tile import TileCacheTestBase
+
+
+@pytest.mark.skipif(not AzureBlobCache or not os.environ.get('MAPPROXY_TEST_AZURE_BLOB'),
+                    reason="azure-storage-blob package and MAPPROXY_TEST_AZURE_BLOB env required")
+class TestAzureBlobCache(TileCacheTestBase):
+    always_loads_metadata = True
+    uses_utc = True
+
+    def setup(self):
+        TileCacheTestBase.setup(self)
+
+        self.container = 'mapproxy-azure-unit-test'
+        self.base_path = '/mycache/webmercator'
+        self.file_ext = 'png'
+
+        # Use default storage account of Azurite emulator
+        self.host = os.environ['MAPPROXY_TEST_AZURE_BLOB']
+        self.connection_string = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=' \
+                                 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr' \
+                                 '/KBHBeksoGMGw==;BlobEndpoint=' + self.host + '/devstoreaccount1;'
+
+        self.container_client = azure_container_client(self.connection_string, self.container)
+        self.container_client.create_container()
+
+        self.cache = AzureBlobCache(
+            base_path=self.base_path,
+            file_ext=self.file_ext,
+            container_name=self.container,
+            connection_string=self.connection_string,
+        )
+
+    def teardown(self):
+        TileCacheTestBase.teardown(self)
+        self.container_client.delete_container()
+
+    @pytest.mark.parametrize('layout,tile_coord,key', [
+        ['mp', (12345, 67890, 2), 'mycache/webmercator/02/0001/2345/0006/7890.png'],
+        ['mp', (12345, 67890, 12), 'mycache/webmercator/12/0001/2345/0006/7890.png'],
+
+        ['tc', (12345, 67890, 2), 'mycache/webmercator/02/000/012/345/000/067/890.png'],
+        ['tc', (12345, 67890, 12), 'mycache/webmercator/12/000/012/345/000/067/890.png'],
+
+        ['tms', (12345, 67890, 2), 'mycache/webmercator/2/12345/67890.png'],
+        ['tms', (12345, 67890, 12), 'mycache/webmercator/12/12345/67890.png'],
+
+        ['reverse_tms', (12345, 67890, 2), 'mycache/webmercator/67890/12345/2.png'],
+        ['reverse_tms', (12345, 67890, 12), 'mycache/webmercator/67890/12345/12.png'],
+
+        ['quadkey', (0, 0, 0), 'mycache/webmercator/.png'],
+        ['quadkey', (0, 0, 1), 'mycache/webmercator/0.png'],
+        ['quadkey', (1, 1, 1), 'mycache/webmercator/3.png'],
+        ['quadkey', (12345, 67890, 12), 'mycache/webmercator/200200331021.png'],
+
+        ['arcgis', (1, 2, 3), 'mycache/webmercator/L03/R00000002/C00000001.png'],
+        ['arcgis', (9, 2, 3), 'mycache/webmercator/L03/R00000002/C00000009.png'],
+        ['arcgis', (10, 2, 3), 'mycache/webmercator/L03/R00000002/C0000000a.png'],
+        ['arcgis', (12345, 67890, 12), 'mycache/webmercator/L12/R00010932/C00003039.png'],
+    ])
+    def test_tile_key(self, layout, tile_coord, key):
+        cache = AzureBlobCache(
+            base_path=self.base_path,
+            file_ext=self.file_ext,
+            container_name=self.container,
+            connection_string=self.connection_string,
+            directory_layout=layout
+        )
+        cache.store_tile(self.create_tile(tile_coord))
+
+        assert self.container_client.get_blob_client(key).exists()

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
+azure-storage-blob>=12.9.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 Pillow==6.2.2;python_version<"3.0"


### PR DESCRIPTION
This PR add support for using Azure Blob storage as a cache. It includes the cache implementation, unit/system tests and docs. We at [PDOK](https://pdok.nl) would love to get this into MapProxy. If there's any feedback please let me know.

### Rationale
S3 is sometimes considered the _de facto_ API for object storage. Besides Amazon S3 there are more (smaller) providers offering this API. Microsoft Azure however is an exception. They are a major cloud provider but don't offer an S3 compatible API for their Azure Blob storage. MinIO gateway is the most well known 3rd party proxy solution you can place in front of Azure Blob but this comes with additional operational costs, complexity and challenges. Not to mention the development of [MinIO gateway has come to an halt and is officially deprecated](https://blog.min.io/deprecation-of-the-minio-gateway/). Therefore it would be great to have MapProxy offer **native Azure Blob integration**.