### PR TITLE
Add docs for installation via docker

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,6 +7,7 @@ MapProxy Documentation
    install
    install_windows
    install_osgeo4w
+   install_docker
    tutorial
    configuration
    services

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -6,11 +6,17 @@ There are several inofficial Docker images available on `Docker Hub`_ that provi
 
 .. _`Docker Hub`: https://hub.docker.com/search?q=mapproxy
 
+The community has very good experiences with the following ones:
+
+- https://hub.docker.com/repository/docker/justb4/mapproxy/general (`github just4b <https://github.com/justb4/docker-mapproxy>`_)
+- https://hub.docker.com/r/kartoza/mapproxy (`github kartoza <https://github.com/kartoza/docker-mapproxy>`_)
+
 
 Quickstart
 ------------------
 
-As for an example the image of `kartoza/mapproxy`_ is used.
+As for an example the image of `kartoza/mapproxy`_ is used (`just4b/docker-mapproxy <https://hub.docker.com/repository/docker/justb4/mapproxy/general>`_ works the same way).
+
 Create a directory (e.g. `mapproxy`) for your configuration files and mount it as a volume:
 
 ::
@@ -20,8 +26,16 @@ Create a directory (e.g. `mapproxy`) for your configuration files and mount it a
 Afterwards, the `MapProxy` instance is running on `localhost:8080`.
 
 I a production environment you might want to put a `nginx`_ in front of the MapProxy container, that serves as a reverse proxy.
-See the `GitHub Repository`_ for detailed documentation and example docker-compose files. 
+See the `Kartoza GitHub Repository`_ for detailed documentation and example docker-compose files. 
 
 .. _`kartoza/mapproxy`: https://hub.docker.com/r/kartoza/mapproxy
 .. _`nginx`: https://nginx.org
 .. _`GitHub Repository`: https://github.com/kartoza/docker-mapproxy
+
+There are also images available that already include binaries for `MapServer` or `Mapnik`:
+
+- https://github.com/justb4/docker-mapproxy-mapserver
+- https://github.com/justb4/docker-mapproxy-mapserver-mapnik
+
+.. note::
+  Please feel free to make suggestions for an official MapProxy docker image.

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -1,0 +1,27 @@
+﻿Installation via Docker
+=======================
+
+
+There are several inofficial Docker images available on `Docker Hub`_ that provide ready-to-use containers for MapProxy.
+
+.. _`Docker Hub`: https://hub.docker.com/search?q=mapproxy
+
+
+Quickstart
+------------------
+
+As for an example the image of `kartoza/mapproxy`_ is used.
+Create a directory (e.g. `mapproxy`) for your configuration files and mount it as a volume:
+
+::
+
+  docker run --name "mapproxy" -p 8080:8080 -d -t -v `pwd`/mapproxy:/mapproxy kartoza/mapproxy
+
+Afterwards, the `MapProxy` instance is running on `localhost:8080`.
+
+I a production environment you might want to put a `nginx`_ in front of the MapProxy container, that serves as a reverse proxy.
+See the `GitHub Repository`_ for detailed documentation and example docker-compose files. 
+
+.. _`kartoza/mapproxy`: https://hub.docker.com/r/kartoza/mapproxy
+.. _`nginx`: https://nginx.org
+.. _`GitHub Repository`: https://github.com/kartoza/docker-mapproxy

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -25,7 +25,7 @@ Create a directory (e.g. `mapproxy`) for your configuration files and mount it a
 
 Afterwards, the `MapProxy` instance is running on `localhost:8080`.
 
-I a production environment you might want to put a `nginx`_ in front of the MapProxy container, that serves as a reverse proxy.
+In a production environment you might want to put a `nginx`_ in front of the MapProxy container, that serves as a reverse proxy.
 See the `Kartoza GitHub Repository`_ for detailed documentation and example docker-compose files. 
 
 .. _`kartoza/mapproxy`: https://hub.docker.com/r/kartoza/mapproxy


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

This adds docs for installation via docker. Since there's no official docker image yet, a short example for the kartoza image was added.
