### PR TITLE
Fix find library not found for ubuntu 22.04

### DIFF
--- a/mapproxy/util/lib.py
+++ b/mapproxy/util/lib.py
@@ -90,9 +90,15 @@ def find_library(lib_name, paths=None, exts=None):
     If nothing is found None is returned.
     """
     if not paths or not exts:
-        lib = _find_library(lib_name)
+        try:
+            lib = _find_library(lib_name)
+        except FileNotFoundError:
+            pass
         if lib is None and lib_name.startswith('lib'):
-            lib = _find_library(lib_name[3:])
+            try:
+                lib = _find_library(lib_name[3:])
+            except FileNotFoundError:
+                pass
         return lib
 
     for lib_name in [lib_name] + ([lib_name[3:]] if lib_name.startswith('lib') else []):


### PR DESCRIPTION
This PR prevents the error https://github.com/mapproxy/mapproxy/issues/600 that occurs on ubuntu 22.04
