### PR TITLE
Fix encoding issues with umlauts in xml featureinfo

### DIFF
--- a/mapproxy/featureinfo.py
+++ b/mapproxy/featureinfo.py
@@ -58,6 +58,7 @@ class TextFeatureInfoDoc(FeatureInfoDoc):
 
 class XMLFeatureInfoDoc(FeatureInfoDoc):
     info_type = "xml"
+    defaultEncoding = "UTF-8"
 
     def __init__(self, content):
         if isinstance(content, (string_type, bytes)):
@@ -81,7 +82,9 @@ class XMLFeatureInfoDoc(FeatureInfoDoc):
         return self._etree
 
     def _serialize_etree(self):
-        return etree.tostring(self._etree)
+        encoding = self._etree.docinfo.encoding if \
+            self._etree.docinfo.encoding else self.defaultEncoding
+        return etree.tostring(self._etree, encoding=encoding, xml_declaration=False)
 
     def _parse_content(self):
         doc = as_io(self._str_content)

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 import os
+import sys
 import tempfile
+import pytest
 
 from lxml import etree, html
 
@@ -96,6 +98,7 @@ class TestXMLFeatureInfoDocs(object):
         doc = XMLFeatureInfoDoc("<root>hello</root>")
         assert doc.as_etree().getroot().text == "hello"
 
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="test skipped for python 2")
     def test_umlauts(self):
         doc = XMLFeatureInfoDoc('<root>öäüß</root>')
         assert doc.as_etree().getroot().text == 'öäüß'

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -95,6 +95,14 @@ class TestXMLFeatureInfoDocs(object):
         doc = XMLFeatureInfoDoc("<root>hello</root>")
         assert doc.as_etree().getroot().text == "hello"
 
+    def test_umlauts(self):
+        doc = XMLFeatureInfoDoc('<root>öäüß</root>')
+        assert doc.as_etree().getroot().text == 'öäüß'
+
+        input_tree = etree.fromstring('<root>öäüß</root>'.encode('utf-8'))
+        doc = XMLFeatureInfoDoc(input_tree)
+        assert doc.as_string().decode("utf-8") == '<root>öäüß</root>'
+
     def test_combine(self):
         docs = [
             XMLFeatureInfoDoc("<root><a>foo</a></root>"),

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of the MapProxy project.
 # Copyright (C) 2011 Omniscale <http://omniscale.de>
 #


### PR DESCRIPTION
This fixes an encoding issue mentioned in https://github.com/mapproxy/mapproxy/issues/602 where returning an xml based feature response failed to due wrong default encoding in lxml.

Can be tested with the given service reported in the issue.

Closes https://github.com/mapproxy/mapproxy/issues/602
