### PR TITLE
Fix variable referenced before assignment error

### DIFF
--- a/mapproxy/util/lib.py
+++ b/mapproxy/util/lib.py
@@ -90,6 +90,7 @@ def find_library(lib_name, paths=None, exts=None):
     If nothing is found None is returned.
     """
     if not paths or not exts:
+        lib = None
         try:
             lib = _find_library(lib_name)
         except FileNotFoundError:


### PR DESCRIPTION
A follow up of https://github.com/mapproxy/mapproxy/pull/617, which fixes the error
`UnboundLocalError: local variable 'lib' referenced before assignment` 
which slips through pylints detection.