### PR TITLE
Reverting ubuntu upgrade of action runners

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:  
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       redis-server:
         image: redis
@@ -29,7 +29,7 @@ jobs:
       
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
 
     env:
       MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'
@@ -44,8 +44,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt update
-        if [[ ${{ matrix.python-version }} = 2.7 ]]; then sudo apt install python2-dev; else sudo apt install python3-dev; fi
-        sudo apt install proj-bin libgeos-dev libgdal-dev libxslt1-dev libxml2-dev build-essential libjpeg-dev zlib1g-dev libfreetype6-dev protobuf-compiler libprotoc-dev -y
+        sudo apt install proj-bin libgeos-dev libgdal-dev libxslt1-dev libxml2-dev build-essential python-dev libjpeg-dev zlib1g-dev libfreetype6-dev protobuf-compiler libprotoc-dev -y
 
     - name: Checkout sources
       uses: actions/checkout@v2


### PR DESCRIPTION
This reverts the latest changes of the github workflows which lead to different problems when installing packages and running tests, which i could not resolve in time.