### PR TITLE
use one azure client per tile worker thread (to fix unsafe thread operations

### DIFF
--- a/mapproxy/test/system/test_cache_azureblob.py
+++ b/mapproxy/test/system/test_cache_azureblob.py
@@ -25,10 +25,9 @@ from mapproxy.test.image import is_png, create_tmp_image
 from mapproxy.test.system import SysTest
 
 try:
-    from mapproxy.cache.azureblob import AzureBlobCache, azure_container_client
+    from mapproxy.cache.azureblob import AzureBlobCache
 except ImportError:
     AzureBlobCache = None
-    azure_container_client = None
 
 
 def azureblob_connection():
@@ -37,6 +36,14 @@ def azureblob_connection():
     return 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=' \
            'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr' \
            '/KBHBeksoGMGw==;BlobEndpoint=' + host + '/devstoreaccount1;'
+
+
+def azure_container_client(connection_string, container_name):
+    return AzureBlobCache(
+        base_path="",
+        file_ext="",
+        connection_string=connection_string,
+        container_name=container_name).container_client
 
 
 @pytest.fixture(scope="module")

--- a/mapproxy/test/unit/test_cache_azureblob.py
+++ b/mapproxy/test/unit/test_cache_azureblob.py
@@ -18,10 +18,9 @@ import os
 import pytest
 
 try:
-    from mapproxy.cache.azureblob import AzureBlobCache, azure_container_client
+    from mapproxy.cache.azureblob import AzureBlobCache
 except ImportError:
     AzureBlobCache = None
-    azure_container_client = None
 
 from mapproxy.test.unit.test_cache_tile import TileCacheTestBase
 
@@ -45,15 +44,15 @@ class TestAzureBlobCache(TileCacheTestBase):
                                  'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr' \
                                  '/KBHBeksoGMGw==;BlobEndpoint=' + self.host + '/devstoreaccount1;'
 
-        self.container_client = azure_container_client(self.connection_string, self.container)
-        self.container_client.create_container()
-
         self.cache = AzureBlobCache(
             base_path=self.base_path,
             file_ext=self.file_ext,
             container_name=self.container,
             connection_string=self.connection_string,
         )
+
+        self.container_client = self.cache.container_client
+        self.container_client.create_container()
 
     def teardown(self):
         TileCacheTestBase.teardown(self)


### PR DESCRIPTION
In #608 azure blob storage was added as a cache. This PR fixes issues when running with multiple workers. Because the client turned out to be not thread safe.

`threading.local()` is used to keep a copy of the client per thread, as is done in other cache implementations, like s3.
