### PR TITLE
Introduce docker

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,0 +1,68 @@
+name: Docker Build and Publish
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/mapproxy/mapproxy/mapproxy
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/
+          file: ./docker/Dockerfile
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          target: base
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+
+      - name: Build and push development image
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/
+          file: ./docker/Dockerfile
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          target: development
+          tags: |
+            ${{ steps.meta.outputs.tags }}-dev
+
+      - name: Build and push nginx image
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/
+          file: ./docker/Dockerfile
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          target: nginx
+          tags: |
+            ${{ steps.meta.outputs.tags }}-nginx

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -1,8 +1,26 @@
 ﻿Installation via Docker
-=======================
+========================
 
+MapProxy does have its own official docker images.
+These are currently hosted on the GitHub container registry and can be found here:
 
-There are several inofficial Docker images available on `Docker Hub`_ that provide ready-to-use containers for MapProxy.
+  -  https://github.com/orgs/mapproxy/packages/container/package/mapproxy
+
+Currently we have 3 different images for every release, named e.g.
+
+  - ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1
+  - ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-dev
+  - ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-nginx
+
+The first one comes with everything installed, but no HTTP WebServer running. You can use it to implement your custom setup.
+
+The second image, ending with `-dev`, starts the integrated webserver mapproxy provides through `mapproxy-util serve-develop`.
+
+The third image, ending with `-nginx`, comes bundled with a preconfigured `nginx`_ HTTP Server, that lets you use MapProxy instantly in a production environment.
+
+See the quickstart section below for a configuration / example on how to use those images.
+
+There are also several inofficial Docker images available on `Docker Hub`_ that provide ready-to-use containers for MapProxy.
 
 .. _`Docker Hub`: https://hub.docker.com/search?q=mapproxy
 
@@ -11,31 +29,90 @@ The community has very good experiences with the following ones:
 - https://hub.docker.com/repository/docker/justb4/mapproxy/general (`github just4b <https://github.com/justb4/docker-mapproxy>`_)
 - https://hub.docker.com/r/kartoza/mapproxy (`github kartoza <https://github.com/kartoza/docker-mapproxy>`_)
 
-
-Quickstart
-------------------
-
-As for an example the image of `kartoza/mapproxy`_ is used (`just4b/docker-mapproxy <https://hub.docker.com/repository/docker/justb4/mapproxy/general>`_ works the same way).
-
-Create a directory (e.g. `mapproxy`) for your configuration files and mount it as a volume:
-
-::
-
-  docker run --name "mapproxy" -p 8080:8080 -d -t -v `pwd`/mapproxy:/mapproxy kartoza/mapproxy
-
-Afterwards, the `MapProxy` instance is running on `localhost:8080`.
-
-In a production environment you might want to put a `nginx`_ in front of the MapProxy container, that serves as a reverse proxy.
-See the `Kartoza GitHub Repository`_ for detailed documentation and example docker-compose files. 
-
-.. _`kartoza/mapproxy`: https://hub.docker.com/r/kartoza/mapproxy
-.. _`nginx`: https://nginx.org
-.. _`GitHub Repository`: https://github.com/kartoza/docker-mapproxy
-
 There are also images available that already include binaries for `MapServer` or `Mapnik`:
 
 - https://github.com/justb4/docker-mapproxy-mapserver
 - https://github.com/justb4/docker-mapproxy-mapserver-mapnik
 
-.. note::
-  Please feel free to make suggestions for an official MapProxy docker image.
+
+Quickstart
+----------
+
+Depending on your needs, pull the desired image (see description above):
+
+ docker pull ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1
+
+or:
+
+  docker pull ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-dev
+
+or:
+
+  docker pull ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-nginx
+
+Create a directory (e.g. `mapproxyconfig`) for your configuration files. Put your configs into that folder.
+If you do not supply config files (seed.yaml and mapproxy.yaml) the image will create them for you.
+
+To start the docker container with a mount on your config folder, use the command matching your image.
+
+Running the `plain` image without starting a webserver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: sh
+
+  docker run --rm --name "mapproxy" -d -t -v `pwd`/mapproxyconfig:/mapproxy/config ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1
+
+Afterwards, the `MapProxy` instance is idling and you can connect with the container via e.g.
+
+  docker exec -it mapproxy bash
+
+Running the `dev` image
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: sh
+
+  docker run --rm --name "mapproxy" -p 8080:8080 -d -t -v `pwd`/mapproxyconfig:/mapproxy/config ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-dev
+
+Afterwards, the `MapProxy` instance is running on http://localhost:8080/demo/
+
+
+Running the `nginx` image
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: sh
+
+  docker run --rm --name "mapproxy" -p 80:80 -d -t -v `pwd`/mapproxyconfig:/mapproxy/config ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-nginx
+
+Afterwards, the `MapProxy` instance is running on http://localhost/mapproxy/demo/
+
+
+.. _`nginx`: https://nginx.org
+
+Build your own image
+--------------------
+There is currently one build argument you can use.
+
+  - `MAPPROXY_VERSION`: Set the version you want to build.
+
+Switch to the `docker` folder in the mapproxy repository checkout and then execute
+
+For the `plain` image without starting a webserver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: sh
+
+  docker build --build-arg MAPPROXY_VERSION=1.15.1 --target base -t ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1 .
+
+For the `dev` image
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: sh
+
+  docker build --build-arg MAPPROXY_VERSION=1.15.1 --target development -t ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-dev .
+
+For the `nginx` image
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: sh
+
+  docker build --build-arg MAPPROXY_VERSION=1.15.1 --target nginx -t ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-nginx .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,66 @@
+FROM python:3.10-slim-bullseye AS base
+
+# The MAPPROXY_VERSION argument can be used like this to overwrite the default:
+# docker build --build-arg MAPPROXY_VERSION=1.15.1 [--target base|development|nginx] -t mapproxy:1.15.1 .
+ARG MAPPROXY_VERSION=1.15.1
+
+RUN apt update && apt -y install --no-install-recommends \
+  python3-pil \
+  python3-yaml \
+  python3-pyproj \
+  libgeos-dev \
+  python3-lxml \
+  libgdal-dev \
+  python3-shapely \
+  libxml2-dev libxslt-dev && \
+  apt-get -y --purge autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /mapproxy
+
+WORKDIR /mapproxy
+
+# fix potential issue finding correct shared library libproj (fixed in newer releases)
+RUN ln -s /usr/lib/x86_64-linux-gnu/libproj.so /usr/lib/x86_64-linux-gnu/liblibproj.so
+
+RUN pip install MapProxy==$MAPPROXY_VERSION && \
+    # temporary fix for v1.15.1
+    if [ "$MAPPROXY_VERSION" = '1.15.1' ]; then pip install six; fi && \
+    pip cache purge
+
+COPY app.py .
+
+COPY start.sh .
+
+ENTRYPOINT ["bash", "-c", "./start.sh base"]
+
+###### development image ######
+
+FROM base AS development
+
+EXPOSE 8080
+
+ENTRYPOINT ["bash", "-c", "./start.sh development"]
+
+##### nginx image ######
+
+FROM base AS nginx
+
+RUN apt update && apt -y install --no-install-recommends nginx gcc
+
+# cleanup
+RUN apt-get -y --purge autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install uwsgi && \
+    pip cache purge
+
+COPY uwsgi.conf .
+
+COPY nginx-default.conf /etc/nginx/sites-enabled/default
+
+EXPOSE 80
+
+ENTRYPOINT ["bash", "-c", "./start.sh nginx"]

--- a/docker/app.py
+++ b/docker/app.py
@@ -1,0 +1,10 @@
+# WSGI module for use with Apache mod_wsgi or gunicorn
+
+# # uncomment the following lines for logging
+# # create a log.ini with `mapproxy-util create -t log-ini`
+# from logging.config import fileConfig
+# import os.path
+# fileConfig(r'/mapproxy/config/log.ini', {'here': os.path.dirname(__file__)})
+
+from mapproxy.wsgiapp import make_wsgi_app
+application = make_wsgi_app(r'/mapproxy/config/mapproxy.yaml', reloader=True)

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -1,0 +1,15 @@
+upstream mapproxy {
+    server 0.0.0.0:8080;
+}
+server {
+    listen 80;
+
+    root /var/www/html/;
+
+    location /mapproxy/ {
+        rewrite /mapproxy/(.+) /$1 break;
+        uwsgi_param SCRIPT_NAME /mapproxy;
+        uwsgi_pass mapproxy;
+        include uwsgi_params;
+    }
+}

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+TARGET=$1
+done=0
+trap 'done=1' TERM INT
+cd /mapproxy
+
+groupadd mapproxy && \
+useradd --home-dir /mapproxy -s /bin/bash -g mapproxy mapproxy && \
+chown -R mapproxy:mapproxy /mapproxy/config/cache_data
+
+# create config files if they do not exist yet
+if [ ! -f /mapproxy/config/mapproxy.yaml ]; then
+  echo "No mapproxy configuration found. Creating one from template."
+  mapproxy-util create -t base-config config
+fi
+
+if [ "$TARGET" = "nginx" ]; then
+  service nginx restart &&
+  su mapproxy -c "/usr/local/bin/uwsgi --ini /mapproxy/uwsgi.conf &"
+elif [ "$TARGET" = 'development' ]; then
+  su mapproxy -c "mapproxy-util serve-develop -b 0.0.0.0 /mapproxy/config/mapproxy.yaml &"
+else
+  echo "No-op container started. Overwrite ENTRYPOINT with needed mapproxy command."
+  su mapproxy -c "sleep infinity &"
+fi
+
+while [ $done = 0 ]; do
+  sleep 1 &
+  wait
+done

--- a/docker/uwsgi.conf
+++ b/docker/uwsgi.conf
@@ -1,0 +1,10 @@
+[uwsgi]
+master = true
+chdir = /mapproxy
+pyargv = /mapproxy/config/mapproxy.yaml
+wsgi-file = /mapproxy/app.py
+pidfile=/tmp/mapproxy.pid
+socket = 0.0.0.0:8080
+processes = 2
+threads = 10
+chmod-socket = 777


### PR DESCRIPTION
This introduces a docker file which is used to build and publish official mapproxy images.
Documentation on how to use the prebuild images as well for manually building images has been added.
The github action has not been tested yet and needs to be tested on the next upcoming release.

Images for older versions below 1.15.1 may get added over time.

Quick test:

`docker pull ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-nginx`
`docker run --rm --name "mapproxy" -p 80:80 -d -t -v pwd/mapproxyconfig:/mapproxy/config ghcr.io/mapproxy/mapproxy/mapproxy:1.15.1-nginx`

Open your browser on
http://localhost/mapproxy/demo/
