### PR TITLE
Fix installation command

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,7 +7,7 @@ This tutorial was created and tested with Debian and Ubuntu, if you're installin
 
 MapProxy is `registered at the Python Package Index <https://pypi.org/project/MapProxy/>`_ (PyPI). If you have Python 2.7.9 or higher, you can install MapProxy with::
 
-  sudo python -m pip MapProxy
+  sudo python -m pip install MapProxy
 
 This is really, easy `but` we recommend to install MapProxy into a `virtual Python environment`_. A ``virtualenv`` is a self-contained Python installation where you can install arbitrary Python packages without affecting the system installation. You also don't need root permissions for the installation.
 


### PR DESCRIPTION
I think it was probably just a typo, fixed it now. Without `install`, installation does not work.