### PR TITLE
Update pillow to latest version

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,8 +1,7 @@
 azure-storage-blob>=12.9.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-Pillow==8.2.0;python_version in "3.7 3.8 3.9"
-Pillow==8.4.0;python_version>="3.10"
+Pillow==9.5.0
 PyYAML==5.4
 Shapely==1.7.0
 WebOb==1.8.6


### PR DESCRIPTION
as the title says. dependabot is currently deactivated and cannot be used for this update

closes https://github.com/mapproxy/mapproxy/pull/609