### PR TITLE
Order wmts, wms and tms layers by name in demo service

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -2164,6 +2164,8 @@ class ServiceConfiguration(ConfigurationBase):
                 # demo service only supports 1.1.1, use wms_111 as an indicator
                 services.append('wms_111')
 
+        layers = odict(sorted(layers.items(), key=lambda x: x[1].name))
+
         return DemoServer(layers, md, tile_layers=tile_layers,
             image_formats=image_formats, srs=srs, services=services, restful_template=restful_template)
 

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -215,6 +215,9 @@ class DemoServer(Server):
             tms_tile_layers[name].append(self.tile_layers[layer])
         wmts_layers = tms_tile_layers.copy()
 
+        wmts_layers = odict(sorted(wmts_layers.items(), key=lambda x: x[0]))
+        tms_tile_layers = odict(sorted(tms_tile_layers.items(), key=lambda x: x[0]))
+
         substitutions = dict(
             extra_services_html_beginning='',
             extra_services_html_end='',
@@ -229,9 +232,6 @@ class DemoServer(Server):
 
         for add_substitution in extra_substitution_handlers:
             add_substitution(self, req, substitutions)
-
-        wmts_layers = odict(sorted(wmts_layers.items(), key=lambda x: x[0]))
-        tms_tile_layers = odict(sorted(tms_tile_layers.items(), key=lambda x: x[0]))
 
         return template.substitute(substitutions)
 

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -24,6 +24,7 @@ import mimetypes
 from collections import defaultdict
 
 from mapproxy.config.config import base_config
+from mapproxy.util.ext.odict import odict
 from mapproxy.compat import PY2
 from mapproxy.exception import RequestError
 from mapproxy.service.base import Server
@@ -228,6 +229,9 @@ class DemoServer(Server):
 
         for add_substitution in extra_substitution_handlers:
             add_substitution(self, req, substitutions)
+
+        wmts_layers = odict(sorted(wmts_layers.items(), key=lambda x: x[0]))
+        tms_tile_layers = odict(sorted(tms_tile_layers.items(), key=lambda x: x[0]))
 
         return template.substitute(substitutions)
 

--- a/mapproxy/test/system/test_demo.py
+++ b/mapproxy/test/system/test_demo.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 import pytest
 
 from mapproxy.test.system import SysTest
@@ -37,3 +38,19 @@ class TestDemo(SysTest):
         resp = app.get("/demo/?srs=EPSG%3A3857&format=image%2Fpng&wms_layer=wms_cache", status=200)
         assert resp.content_type == "text/html"
         assert '<h2>Layer Preview - wms_cache</h2>' in resp
+
+    def test_layers_sorted_by_name(self, app):
+        resp = app.get("/demo/", status=200)
+
+        patternTable = re.compile(r'<table class="code">.*?</table>', re.DOTALL)
+        patternWMS = r'<td\s+rowspan="2">([\w\d-]+)</td>'
+        patternWMTS_TBS = r'<td\s+rowspan="1">([\w\d-]+)</td>'
+        tables = patternTable.findall(resp.text)
+
+        layersWMS = re.findall(patternWMS, resp.text, re.IGNORECASE)
+        layersWMTS = re.findall(patternWMTS_TBS, tables[1], re.IGNORECASE)
+        layersTBS = re.findall(patternWMTS_TBS, tables[2], re.IGNORECASE)
+
+        assert layersWMS == sorted(layersWMS)
+        assert layersWMTS == sorted(layersWMTS)
+        assert layersTBS == sorted(layersTBS)


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

Layers are ordered by name in WMTS, WMS and TMS in demo service solving issue https://github.com/mapproxy/mapproxy/issues/679
