### PR TITLE
Bump to Shapely 2.0.1

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -90,7 +90,7 @@ MapProxy uses YAML for the configuration parsing. It is available as ``python-ya
 
 Shapely and GEOS *(optional)*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You will need Shapely to use the :doc:`coverage feature <coverages>` of MapProxy. Shapely offers Python bindings for the GEOS library. You need Shapely (``python-shapely``) and GEOS (``libgeos-dev``). You can install Shapely as a Python package with ``pip install Shapely`` if you system does not provide a recent (>= 1.2.0) version of Shapely.
+You will need Shapely to use the :doc:`coverage feature <coverages>` of MapProxy. Shapely offers Python bindings for the GEOS library. You need Shapely (``python-shapely``) and GEOS (``libgeos-dev``). You can install Shapely as a Python package with ``pip install Shapely`` if you system does not provide a recent (>= 1.8) version of Shapely.
 
 GDAL *(optional)*
 ~~~~~~~~~~~~~~~~~

--- a/mapproxy/test/unit/test_geom.py
+++ b/mapproxy/test/unit/test_geom.py
@@ -22,11 +22,7 @@ import shutil
 import pytest
 import shapely
 import shapely.prepared
-try:
-    # shapely >=1.6
-    from shapely.errors import ReadingError
-except ImportError:
-    from shapely.geos import ReadingError
+from shapely.errors import ReadingError
 
 from mapproxy.srs import SRS, bbox_equals
 from mapproxy.util.geom import (

--- a/mapproxy/util/geom.py
+++ b/mapproxy/util/geom.py
@@ -32,11 +32,7 @@ try:
     import shapely.geometry
     import shapely.ops
     import shapely.prepared
-    try:
-        # shapely >=1.6
-        from shapely.errors import ReadingError
-    except ImportError:
-        from shapely.geos import ReadingError
+    from shapely.errors import ReadingError
     geom_support = True
 except ImportError:
     geom_support = False
@@ -234,7 +230,7 @@ def transform_polygon(transf, polygon):
 
 def transform_multipolygon(transf, multipolygon):
     transformed_polygons = []
-    for polygon in multipolygon:
+    for polygon in multipolygon.geoms:
         transformed_polygons.append(transform_polygon(transf, polygon))
     return shapely.geometry.MultiPolygon(transformed_polygons)
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 Pillow==9.5.0
 PyYAML==6.0.1
-Shapely==1.7.0
+Shapely==2.0.1
 WebOb==1.8.6
 WebTest==3.0.0
 attrs==19.3.0;python_version<"3.10"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -16,7 +16,7 @@ boto==2.49.0
 botocore==1.29.116
 certifi==2023.7.22
 cffi==1.15.1;
-cfn-lint==0.35.0
+cfn-lint==0.80.3
 chardet==5.2.0
 cryptography==41.0.4
 decorator==4.4.2

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -37,9 +37,11 @@ junit-xml==1.9
 lxml==4.9.3
 mock==4.0.2
 more-itertools==8.4.0
-moto==1.3.14;python_version<"3.10"
-moto==4.1.14;python_version>="3.10"
-networkx==2.4
+moto==4.2.4
+networkx==3.1
+numpy==1.26.0;python_version>="3.9"
+numpy==1.24.0;python_version=="3.8"
+numpy==1.21.0;python_version<"3.8"
 packaging==20.4
 pluggy==0.13.1
 py==1.11.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -38,7 +38,9 @@ lxml==4.9.3
 mock==4.0.2
 more-itertools==8.4.0
 moto==4.2.4
-networkx==3.1
+networkx==3.1;python_version>="3.9"
+networkx==2.8.7;python_version=="3.8"
+networkx==2.6;python_version<"3.8"
 numpy==1.26.0;python_version>="3.9"
 numpy==1.24.0;python_version=="3.8"
 numpy==1.21.0;python_version<"3.8"


### PR DESCRIPTION
Fixes #611 , supersedes #709 

Shapely 2 does not allow iterating over `MultiPolygon` directly: https://shapely.readthedocs.io/en/stable/migration.html