### PR TITLE
rename nose methods setup and teardown

### DIFF
--- a/mapproxy/test/helper.py
+++ b/mapproxy/test/helper.py
@@ -35,7 +35,7 @@ class Mocker(object):
     `setup` will initialize a `mocker.Mocker`. The `teardown` method
     will run ``mocker.verify()``.
     """
-    def setup(self):
+    def setup_method(self):
         self.mocker = mocker.Mocker()
     def expect_and_return(self, mock_call, return_val):
         """
@@ -59,7 +59,7 @@ class Mocker(object):
         if base_cls:
             return self.mocker.mock(base_cls)
         return self.mocker.mock()
-    def teardown(self):
+    def teardown_method(self):
         self.mocker.verify()
 
 class TempFiles(object):

--- a/mapproxy/test/system/test_arcgis.py
+++ b/mapproxy/test/system/test_arcgis.py
@@ -35,7 +35,7 @@ transp = create_tmp_image((512, 512), mode="RGBA", color=(0, 0, 0, 0))
 
 class TestArcgisSource(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_fi_req = WMS111FeatureInfoRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_cache_azureblob.py
+++ b/mapproxy/test/system/test_cache_azureblob.py
@@ -68,7 +68,7 @@ def azureblob_containers():
 @pytest.mark.usefixtures("azureblob_containers")
 class TestAzureBlobCache(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_cache_band_merge.py
+++ b/mapproxy/test/system/test_cache_band_merge.py
@@ -32,7 +32,7 @@ class TestCacheSource(SysTest):
     # test various band merge configurations with
     # cached base tile 0/0/0.png (R: 50 G: 100 B: 200)
 
-    def setup(self):
+    def setup_method(self):
         self.common_cap_req = WMTS100CapabilitiesRequest(
             url="/service?",
             param=dict(service="WMTS", version="1.0.0", request="GetCapabilities"),

--- a/mapproxy/test/system/test_cache_coverage.py
+++ b/mapproxy/test/system/test_cache_coverage.py
@@ -91,7 +91,7 @@ class TestCacheCoverage(SysTest):
         base_dir.join("boundary.geojson").write_binary(boundary_geojson)
         base_dir.join("bbox.geojson").write_binary(bbox_geojson)
 
-    def setup(self):
+    def setup_method(self):
         self.common_cap_req = WMTS100CapabilitiesRequest(
             url="/service?",
             param=dict(service="WMTS", version="1.0.0", request="GetCapabilities"),

--- a/mapproxy/test/system/test_cache_geopackage.py
+++ b/mapproxy/test/system/test_cache_geopackage.py
@@ -47,7 +47,7 @@ def fixture_gpkg(base_dir):
 @pytest.mark.usefixtures("fixture_gpkg")
 class TestGeopackageCache(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_cache_mbtiles.py
+++ b/mapproxy/test/system/test_cache_mbtiles.py
@@ -44,7 +44,7 @@ def fixture_gpkg(base_dir):
 @pytest.mark.usefixtures("fixture_gpkg")
 class TestMBTilesCache(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_cache_s3.py
+++ b/mapproxy/test/system/test_cache_s3.py
@@ -57,7 +57,7 @@ def s3_buckets():
 @pytest.mark.usefixtures("s3_buckets")
 class TestS3Cache(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_combined_sources.py
+++ b/mapproxy/test/system/test_combined_sources.py
@@ -33,7 +33,7 @@ def config_file():
 
 class TestCoverageWMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_coverage.py
+++ b/mapproxy/test/system/test_coverage.py
@@ -33,7 +33,7 @@ def config_file():
 
 class TestCoverageWMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_decorate_img.py
+++ b/mapproxy/test/system/test_decorate_img.py
@@ -42,7 +42,7 @@ def to_greyscale(image, service, layers, **kw):
 @pytest.mark.usefixtures("fixture_cache_data")
 class TestDecorateImg(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_tile_req = WMTS100TileRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_dimensions.py
+++ b/mapproxy/test/system/test_dimensions.py
@@ -44,7 +44,7 @@ def config_file():
 
 class TestDimensionsWMS130(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS130MapRequest(
             url="/service?", param=dict(service="WMS", version="1.3.0")
         )
@@ -114,7 +114,7 @@ class TestDimensionsWMS130(SysTest):
 
 class TestDimensionsWMS111(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )
@@ -180,7 +180,7 @@ class TestDimensionsWMS111(SysTest):
 
 class TestDimensionsWMS110(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS110MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.0")
         )
@@ -249,7 +249,7 @@ class TestDimensionsWMS110(SysTest):
 
 class TestDimensionsWMS100(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS100MapRequest(
             url="/service?", param=dict(service="WMS", wmtver="1.0.0")
         )

--- a/mapproxy/test/system/test_formats.py
+++ b/mapproxy/test/system/test_formats.py
@@ -37,7 +37,7 @@ def assert_file_format(filename, format):
 
 class TestWMS111(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )
@@ -176,7 +176,7 @@ class TestWMS111(SysTest):
 
 class TestTMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.expected_base_path = "/service?SERVICE=WMS&REQUEST=GetMap&HEIGHT=256" "&SRS=EPSG%3A900913&styles=&VERSION=1.1.1&WIDTH=256" "&BBOX=0.0,0.0,20037508.3428,20037508.3428"
         self.expected_direct_base_path = "/service?SERVICE=WMS&REQUEST=GetMap&HEIGHT=200" "&SRS=EPSG%3A4326&styles=&VERSION=1.1.1&WIDTH=200" "&BBOX=0.0,0.0,10.0,10.0"
 

--- a/mapproxy/test/system/test_legendgraphic.py
+++ b/mapproxy/test/system/test_legendgraphic.py
@@ -52,7 +52,7 @@ class TestWMSLegendgraphic(SysTest):
     def cache_dir(self, base_dir):
         return base_dir.join("cache_data")
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )

--- a/mapproxy/test/system/test_mapserver.py
+++ b/mapproxy/test/system/test_mapserver.py
@@ -54,7 +54,7 @@ class TestMapServerCGI(SysTest):
 
         base_dir.join("tmp").mkdir()
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_mixed_mode_format.py
+++ b/mapproxy/test/system/test_mixed_mode_format.py
@@ -35,7 +35,7 @@ def config_file():
 
 class TestWMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(
@@ -94,7 +94,7 @@ class TestWMS(SysTest):
 
 class TestTMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.expected_base_path = "/service?SERVICE=WMS&REQUEST=GetMap&HEIGHT=256" "&SRS=EPSG%3A900913&styles=&VERSION=1.1.1&WIDTH=512" "&BBOX=-20037508.3428,-20037508.3428,20037508.3428,0.0"
 
     def test_mixed_mode(self, app, cache_dir):
@@ -128,7 +128,7 @@ class TestTMS(SysTest):
 
 class TestWMTS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_tile_req = WMTS100TileRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_multi_cache_layers.py
+++ b/mapproxy/test/system/test_multi_cache_layers.py
@@ -47,7 +47,7 @@ TEST_TILE = create_tmp_image((256, 256))
 
 class TestMultiCacheLayer(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_cap_req = WMTS100CapabilitiesRequest(
             url="/service?",
             param=dict(service="WMTS", version="1.0.0", request="GetCapabilities"),

--- a/mapproxy/test/system/test_renderd_client.py
+++ b/mapproxy/test/system/test_renderd_client.py
@@ -47,7 +47,7 @@ except ImportError:
 
 class TestWMS111(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )

--- a/mapproxy/test/system/test_scalehints.py
+++ b/mapproxy/test/system/test_scalehints.py
@@ -45,7 +45,7 @@ def diagonal_res_to_pixel_res(res):
 
 class TestWMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )

--- a/mapproxy/test/system/test_seed.py
+++ b/mapproxy/test/system/test_seed.py
@@ -36,7 +36,7 @@ from mapproxy.test.image import tmp_image, create_tmp_image_buf, create_tmp_imag
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixture')
 
 class SeedTestEnvironment(object):
-    def setup(self):
+    def setup_method(self):
         self.dir = tempfile.mkdtemp()
         shutil.copy(os.path.join(FIXTURE_DIR, self.seed_conf_name), self.dir)
         shutil.copy(os.path.join(FIXTURE_DIR, self.mapproxy_conf_name), self.dir)
@@ -45,7 +45,7 @@ class SeedTestEnvironment(object):
         self.mapproxy_conf_file = os.path.join(self.dir, self.mapproxy_conf_name)
         self.mapproxy_conf = load_configuration(self.mapproxy_conf_file, seed=True)
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.dir)
 
     def make_tile(self, coord=(0, 0, 0), timestamp=None):

--- a/mapproxy/test/system/test_seed_only.py
+++ b/mapproxy/test/system/test_seed_only.py
@@ -32,7 +32,7 @@ def config_file():
 
 class TestSeedOnlyWMS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_sld.py
+++ b/mapproxy/test/system/test_sld.py
@@ -42,7 +42,7 @@ class TestWMS(SysTest):
     def additional_files(self, base_dir):
         base_dir.join("mysld.xml").write("<sld>")
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_source_errors.py
+++ b/mapproxy/test/system/test_source_errors.py
@@ -42,7 +42,7 @@ class TestWMS(SysTest):
     def config_file(self):
         return "source_errors.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(
@@ -140,7 +140,7 @@ class TestWMSRaise(SysTest):
     def config_file(self):
         return "source_errors_raise.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(
@@ -191,7 +191,7 @@ class TestTileErrors(SysTest):
     def config_file(self):
         return "source_errors.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_util_conf.py
+++ b/mapproxy/test/system/test_util_conf.py
@@ -31,10 +31,10 @@ def filename(name):
 
 class TestMapProxyConfCmd(object):
 
-    def setup(self):
+    def setup_method(self):
         self.dir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.exists(self.dir):
             shutil.rmtree(self.dir)
 

--- a/mapproxy/test/system/test_util_export.py
+++ b/mapproxy/test/system/test_util_export.py
@@ -47,7 +47,7 @@ def tile_server(tile_coords):
 
 class TestUtilExport(object):
 
-    def setup(self):
+    def setup_method(self):
         self.dir = tempfile.mkdtemp()
         self.dest = os.path.join(self.dir, "dest")
         self.mapproxy_conf_name = "mapproxy_export.yaml"
@@ -55,7 +55,7 @@ class TestUtilExport(object):
         self.mapproxy_conf_file = os.path.join(self.dir, self.mapproxy_conf_name)
         self.args = ["command_dummy", "-f", self.mapproxy_conf_file]
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.dir)
 
     def test_config_not_found(self):

--- a/mapproxy/test/system/test_util_grids.py
+++ b/mapproxy/test/system/test_util_grids.py
@@ -28,7 +28,7 @@ UNUSED_GRID_NAMES = ["GLOBAL_GEODETIC", "GLOBAL_MERCATOR", "GLOBAL_WEBMERCATOR"]
 
 class TestUtilGrids(object):
 
-    def setup(self):
+    def setup_method(self):
         self.mapproxy_config_file = os.path.join(FIXTURE_DIR, "util_grids.yaml")
         self.args = ["command_dummy", "-f", self.mapproxy_config_file]
 

--- a/mapproxy/test/system/test_util_wms_capabilities.py
+++ b/mapproxy/test/system/test_util_wms_capabilities.py
@@ -38,7 +38,7 @@ SERVICE_EXCEPTION_FILE = os.path.join(
 
 class TestUtilWMSCapabilities(object):
 
-    def setup(self):
+    def setup_method(self):
         self.client = HTTPClient()
         self.args = ["command_dummy", "--host", TESTSERVER_URL + "/service"]
 

--- a/mapproxy/test/system/test_watermark.py
+++ b/mapproxy/test/system/test_watermark.py
@@ -33,7 +33,7 @@ def config_file():
 
 class TestWatermark(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_wms.py
+++ b/mapproxy/test/system/test_wms.py
@@ -103,8 +103,8 @@ def bbox_srs_from_boundingbox(bbox_elem):
 class TestWMS111(SysTest):
     config_file = "layer.yaml"
 
-    def setup(self):
-        # WMSTest.setup(self)
+    def setup_method(self):
+        # WMSTest.setup_method(self)
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )
@@ -830,8 +830,8 @@ class TestWMS111(SysTest):
 class TestWMS110(SysTest):
     config_file = "layer.yaml"
 
-    def setup(self):
-        # WMSTest.setup(self)
+    def setup_method(self):
+        # WMSTest.setup_method(self)
         self.common_req = WMS110MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.0")
         )
@@ -1099,7 +1099,7 @@ class TestWMS110(SysTest):
 class TestWMS100(SysTest):
     config_file = "layer.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS100MapRequest(url="/service?", param=dict(wmtver="1.0.0"))
         self.common_map_req = WMS100MapRequest(
             url="/service?",
@@ -1302,7 +1302,7 @@ assert_xpath_wms130 = functools.partial(assert_xpath, namespaces=ns130)
 class TestWMS130(SysTest):
     config_file = "layer.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS130MapRequest(
             url="/service?", param=dict(service="WMS", version="1.3.0")
         )
@@ -1533,7 +1533,7 @@ class TestWMS130(SysTest):
 class TestWMSLinkSingleColorImages(SysTest):
     config_file = "layer.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_map_req = WMS111MapRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/system/test_wms_srs_extent.py
+++ b/mapproxy/test/system/test_wms_srs_extent.py
@@ -33,7 +33,7 @@ def config_file():
 
 class TestWMSSRSExtentTest(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_req = WMS111MapRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )

--- a/mapproxy/test/system/test_wmsc.py
+++ b/mapproxy/test/system/test_wmsc.py
@@ -38,7 +38,7 @@ def config_file():
 
 class TestWMSC(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_cap_req = WMS111CapabilitiesRequest(
             url="/service?", param=dict(service="WMS", version="1.1.1")
         )

--- a/mapproxy/test/system/test_wmts.py
+++ b/mapproxy/test/system/test_wmts.py
@@ -99,7 +99,7 @@ def fi_req_with_featurecount():
 
 class TestWMTS(SysTest):
 
-    def setup(self):
+    def setup_method(self):
         self.common_cap_req = WMTS100CapabilitiesRequest(
             url="/service?",
             param=dict(service="WMTS", version="1.0.0", request="GetCapabilities"),

--- a/mapproxy/test/system/test_xslt_featureinfo.py
+++ b/mapproxy/test/system/test_xslt_featureinfo.py
@@ -104,7 +104,7 @@ class TestWMSXSLTFeatureInfo(SysTest):
     def config_file(self):
         return "xslt_featureinfo.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_fi_req = WMS111FeatureInfoRequest(
             url="/service?",
             param=dict(
@@ -282,7 +282,7 @@ class TestWMSXSLTFeatureInfoInput(SysTest):
     def config_file(self):
         return "xslt_featureinfo_input.yaml"
 
-    def setup(self):
+    def setup_method(self):
         self.common_fi_req = WMS111FeatureInfoRequest(
             url="/service?",
             param=dict(

--- a/mapproxy/test/unit/test_async.py
+++ b/mapproxy/test/unit/test_async.py
@@ -222,7 +222,7 @@ class DummyException(Exception):
     pass
 
 class TestThreadedExecutorException(object):
-    def setup(self):
+    def setup_method(self):
         self.lock = threading.Lock()
         self.exec_count = 0
         self.te = ThreadPool(size=2)

--- a/mapproxy/test/unit/test_auth.py
+++ b/mapproxy/test/unit/test_auth.py
@@ -53,7 +53,7 @@ FI_REQ = "FORMAT=image%2Fpng&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetFeatureInfo&ST
 
 
 class TestWMSAuth(object):
-    def setup(self):
+    def setup_method(self):
         layers = {}
         wms_layers = {}
 
@@ -337,7 +337,7 @@ class DummyTileLayer(object):
 
 class TestTMSAuth(object):
     service = 'tms'
-    def setup(self):
+    def setup_method(self):
         self.layers = {}
 
         self.layers['layer1'] = DummyTileLayer('layer1')
@@ -408,8 +408,8 @@ class TestTileAuth(TestTMSAuth):
 
 class TestKMLAuth(TestTMSAuth):
     service = 'kml'
-    def setup(self):
-        TestTMSAuth.setup(self)
+    def setup_method(self):
+        TestTMSAuth.setup_method(self)
         self.server = KMLServer(self.layers, {})
 
     def tile_request(self, tile, auth):

--- a/mapproxy/test/unit/test_cache.py
+++ b/mapproxy/test/unit/test_cache.py
@@ -94,7 +94,7 @@ class MockTileClient(object):
         return ImageSource(create_debug_img((256, 256)))
 
 class TestTiledSourceGlobalGeodetic(object):
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(SRS(4326), bbox=[-180, -90, 180, 90])
         self.client = MockTileClient()
         self.source = TiledSource(self.grid, self.client)
@@ -1195,18 +1195,18 @@ class TestTileManagerRescaleTiles(object):
 class TileCacheTestBase(object):
     cache = None # set by subclasses
 
-    def setup(self):
+    def setup_method(self):
         self.cache_dir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         if hasattr(self.cache, 'cleanup'):
             self.cache.cleanup()
         if hasattr(self, 'cache_dir') and os.path.exists(self.cache_dir):
             shutil.rmtree(self.cache_dir)
 
 class TestTileManagerCacheBboxCoverage(TileCacheTestBase):
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = RecordFileCache(self.cache_dir, 'png', coverage=coverage([-50, -50, 50, 50], SRS(4326)))
     
     def test_load_tiles_in_coverage(self, tile_locker):
@@ -1257,8 +1257,8 @@ boundary_geojson = (
 )
 
 class TestTileManagerCacheGeojsonCoverage(TileCacheTestBase):
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         
         with TempFile() as tf:
             with open(tf, 'wb') as f:

--- a/mapproxy/test/unit/test_cache_azureblob.py
+++ b/mapproxy/test/unit/test_cache_azureblob.py
@@ -31,8 +31,8 @@ class TestAzureBlobCache(TileCacheTestBase):
     always_loads_metadata = True
     uses_utc = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
 
         self.container = 'mapproxy-azure-unit-test'
         self.base_path = '/mycache/webmercator'
@@ -54,8 +54,8 @@ class TestAzureBlobCache(TileCacheTestBase):
         self.container_client = self.cache.container_client
         self.container_client.create_container()
 
-    def teardown(self):
-        TileCacheTestBase.teardown(self)
+    def teardown_method(self):
+        TileCacheTestBase.teardown_method(self)
         self.container_client.delete_container()
     
     def test_default_coverage(self):

--- a/mapproxy/test/unit/test_cache_compact.py
+++ b/mapproxy/test/unit/test_cache_compact.py
@@ -35,8 +35,8 @@ class TestCompactCacheV1(TileCacheTestBase):
 
     always_loads_metadata = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = CompactCacheV1(
             cache_dir=self.cache_dir,
         )
@@ -136,8 +136,8 @@ class TestCompactCacheV2(TileCacheTestBase):
 
     always_loads_metadata = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = CompactCacheV2(
             cache_dir=self.cache_dir,
         )
@@ -233,10 +233,10 @@ class mockProgressLog(object):
         self.logs.sort(key=lambda x: (x['fname'], 'num'))
 
 class DefragmentationTestBase(object):
-    def setup(self):
+    def setup_method(self):
         self.cache_dir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.exists(self.cache_dir):
             shutil.rmtree(self.cache_dir)
 

--- a/mapproxy/test/unit/test_cache_couchdb.py
+++ b/mapproxy/test/unit/test_cache_couchdb.py
@@ -36,11 +36,11 @@ tile_image2 = create_tmp_image_buf((256, 256), color='red')
 class TestCouchDBCache(TileCacheTestBase):
     always_loads_metadata = True
 
-    def setup(self):
+    def setup_method(self):
         couch_address = os.environ['MAPPROXY_TEST_COUCHDB']
         db_name = 'mapproxy_test_%d' % random.randint(0, 100000)
 
-        TileCacheTestBase.setup(self)
+        TileCacheTestBase.setup_method(self)
 
         md_template = CouchDBMDTemplate({'row': '{{y}}', 'tile_column': '{{x}}',
             'zoom': '{{level}}', 'time': '{{timestamp}}', 'coord': '{{wgs_tile_centroid}}'})
@@ -48,10 +48,10 @@ class TestCouchDBCache(TileCacheTestBase):
             file_ext='png', tile_grid=tile_grid(3857, name='global-webmarcator'),
             md_template=md_template)
 
-    def teardown(self):
+    def teardown_method(self):
         import requests
         requests.delete(self.cache.couch_url)
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
     
     def test_default_coverage(self):
         assert self.cache.coverage is None

--- a/mapproxy/test/unit/test_cache_geopackage.py
+++ b/mapproxy/test/unit/test_cache_geopackage.py
@@ -40,8 +40,8 @@ class TestGeopackageCache(TileCacheTestBase):
 
     always_loads_metadata = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.gpkg_file = os.path.join(self.cache_dir, 'tmp.gpkg')
         self.table_name = 'test_tiles'
         self.cache = GeopackageCache(
@@ -50,10 +50,10 @@ class TestGeopackageCache(TileCacheTestBase):
             table_name=self.table_name,
         )
 
-    def teardown(self):
+    def teardown_method(self):
         if self.cache:
             self.cache.cleanup()
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
 
     def test_new_geopackage(self):
         assert os.path.exists(self.gpkg_file)
@@ -125,8 +125,8 @@ class TestGeopackageCache(TileCacheTestBase):
 
 
 class TestGeopackageCacheCoverage(TileCacheTestBase):
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.gpkg_file = os.path.join(self.cache_dir, 'tmp.gpkg')
         self.table_name = 'test_tiles'
         self.cache = GeopackageCache(
@@ -136,10 +136,10 @@ class TestGeopackageCacheCoverage(TileCacheTestBase):
             coverage=coverage([20, 20, 30, 30], SRS(4326))
         )
     
-    def teardown(self):
+    def teardown_method(self):
         if self.cache:
             self.cache.cleanup()
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
     
     def test_correct_coverage(self):
         assert self.cache.bbox == [20, 20, 30, 30]
@@ -149,18 +149,18 @@ class TestGeopackageLevelCache(TileCacheTestBase):
 
     always_loads_metadata = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = GeopackageLevelCache(
             self.cache_dir,
             tile_grid=tile_grid(3857, name='global-webmarcator'),
             table_name='test_tiles',
         )
 
-    def teardown(self):
+    def teardown_method(self):
         if self.cache:
             self.cache.cleanup()
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
         
     def test_default_coverage(self):
         assert self.cache.coverage is None

--- a/mapproxy/test/unit/test_cache_redis.py
+++ b/mapproxy/test/unit/test_cache_redis.py
@@ -33,15 +33,15 @@ from mapproxy.test.unit.test_cache_tile import TileCacheTestBase
 class TestRedisCache(TileCacheTestBase):
     always_loads_metadata = False
 
-    def setup(self):
+    def setup_method(self):
         redis_host = os.environ['MAPPROXY_TEST_REDIS']
         self.host, self.port = redis_host.split(':')
 
-        TileCacheTestBase.setup(self)
+        TileCacheTestBase.setup_method(self)
 
         self.cache = RedisCache(self.host, int(self.port), prefix='mapproxy-test', db=1)
 
-    def teardown(self):
+    def teardown_method(self):
         for k in self.cache.r.keys('mapproxy-test-*'):
             self.cache.r.delete(k)
     

--- a/mapproxy/test/unit/test_cache_riak.py
+++ b/mapproxy/test/unit/test_cache_riak.py
@@ -33,7 +33,7 @@ tile_image2 = create_tmp_image_buf((256, 256), color='red')
 @pytest.mark.skipif(sys.version_info > (3, 7), reason="riak is not compatible with this Python version")
 class RiakCacheTestBase(TileCacheTestBase):
     always_loads_metadata = True
-    def setup(self):
+    def setup_method(self):
         url = os.environ[self.riak_url_env]
         urlparts = urlparse.urlparse(url)
         protocol = urlparts.scheme.lower()
@@ -46,16 +46,16 @@ class RiakCacheTestBase(TileCacheTestBase):
 
         db_name = 'mapproxy_test_%d' % random.randint(0, 100000)
 
-        TileCacheTestBase.setup(self)
+        TileCacheTestBase.setup_method(self)
 
         self.cache = RiakCache([node], protocol, db_name, tile_grid=tile_grid(3857, name='global-webmarcator'))
 
-    def teardown(self):
+    def teardown_method(self):
         import riak
         bucket = self.cache.bucket
         for k in bucket.get_keys():
             riak.RiakObject(self.cache.connection, bucket, k).delete()
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
     
     def test_default_coverage(self):
         assert self.cache.coverage is None

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -39,8 +39,8 @@ class TestS3Cache(TileCacheTestBase):
     always_loads_metadata = True
     uses_utc = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
 
         self.mock = mock_s3()
         self.mock.start()
@@ -58,9 +58,9 @@ class TestS3Cache(TileCacheTestBase):
             _concurrent_writer=1, # moto is not thread safe
         )
         
-    def teardown(self):
+    def teardown_method(self):
         self.mock.stop()
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
     
     def test_default_coverage(self):
         assert self.cache.coverage is None

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -48,10 +48,10 @@ class TileCacheTestBase(object):
 
     cache = None # set by subclasses
 
-    def setup(self):
+    def setup_method(self):
         self.cache_dir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         if hasattr(self.cache, 'cleanup'):
             self.cache.cleanup()
         if hasattr(self, 'cache_dir') and os.path.exists(self.cache_dir):
@@ -206,8 +206,8 @@ class TileCacheTestBase(object):
         self.cache.store_tile(tile)
 
 class TestFileTileCache(TileCacheTestBase):
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = FileCache(self.cache_dir, 'png')
     
     def test_default_coverage(self):
@@ -353,14 +353,14 @@ class TestFileTileCache(TileCacheTestBase):
             cache.level_location(0)
 
 class TestMBTileCache(TileCacheTestBase):
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = MBTilesCache(os.path.join(self.cache_dir, 'tmp.mbtiles'))
 
-    def teardown(self):
+    def teardown_method(self):
         if self.cache:
             self.cache.cleanup()
-        TileCacheTestBase.teardown(self)
+        TileCacheTestBase.teardown_method(self)
     
     def test_default_coverage(self):
         assert self.cache.coverage is None
@@ -403,8 +403,8 @@ class TestMBTileCache(TileCacheTestBase):
 
 
 class TestQuadkeyFileTileCache(TileCacheTestBase):
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = FileCache(self.cache_dir, 'png', directory_layout='quadkey')
     
     def test_default_coverage(self):
@@ -420,8 +420,8 @@ class TestQuadkeyFileTileCache(TileCacheTestBase):
 class TestMBTileLevelCache(TileCacheTestBase):
     always_loads_metadata = True
 
-    def setup(self):
-        TileCacheTestBase.setup(self)
+    def setup_method(self):
+        TileCacheTestBase.setup_method(self)
         self.cache = MBTilesLevelCache(self.cache_dir)
     
     def test_default_coverage(self):

--- a/mapproxy/test/unit/test_client.py
+++ b/mapproxy/test/unit/test_client.py
@@ -43,7 +43,7 @@ TESTSERVER_URL = 'http://%s:%s' % TESTSERVER_ADDRESS
 
 
 class TestHTTPClient(object):
-    def setup(self):
+    def setup_method(self):
         self.client = HTTPClient()
 
     def test_post(self):
@@ -380,7 +380,7 @@ class TestWMSClient(object):
 
 
 class TestCombinedWMSClient(object):
-    def setup(self):
+    def setup_method(self):
         self.http = MockHTTPClient()
     def test_combine(self):
         req1 = WMS111MapRequest(url=TESTSERVER_URL + '/service?map=foo',
@@ -443,7 +443,7 @@ class TestWMSInfoClient(object):
                            '&BBOX=428333.552496,5538630.70275,500000.0,5650300.78652'), http.requested[0]
 
 class TestWMSMapRequest100(object):
-    def setup(self):
+    def setup_method(self):
         self.r = WMS100MapRequest(param=dict(layers='foo', version='1.1.1', request='GetMap'))
         self.r.params = self.r.adapt_params_to_version()
     def test_version(self):
@@ -457,7 +457,7 @@ class TestWMSMapRequest100(object):
         assert_query_eq(str(self.r.params), 'layers=foo&styles=&request=map&wmtver=1.0.0')
 
 class TestWMSMapRequest130(object):
-    def setup(self):
+    def setup_method(self):
         self.r = WMS130MapRequest(param=dict(layers='foo', WMTVER='1.0.0'))
         self.r.params = self.r.adapt_params_to_version()
     def test_version(self):
@@ -471,7 +471,7 @@ class TestWMSMapRequest130(object):
         query_eq(str(self.r.params), 'layers=foo&styles=&service=WMS&request=GetMap&version=1.3.0')
 
 class TestWMSMapRequest111(object):
-    def setup(self):
+    def setup_method(self):
         self.r = WMS111MapRequest(param=dict(layers='foo', WMTVER='1.0.0'))
         self.r.params = self.r.adapt_params_to_version()
     def test_version(self):

--- a/mapproxy/test/unit/test_client_cgi.py
+++ b/mapproxy/test/unit/test_client_cgi.py
@@ -64,10 +64,10 @@ if not os.path.exists('testfile'):
 @pytest.mark.skipif(sys.platform == 'win32', reason="tests not ported to windows")
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="tests skipped for python 2")
 class TestCGIClient(object):
-    def setup(self):
+    def setup_method(self):
         self.script_dir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.script_dir)
 
     def create_script(self, script=TEST_CGI_SCRIPT, executable=True):

--- a/mapproxy/test/unit/test_config.py
+++ b/mapproxy/test/unit/test_config.py
@@ -92,7 +92,7 @@ class TestDefaultsLoading(object):
 
 
 class TestSRSConfig(object):
-    def setup(self):
+    def setup_method(self):
         import mapproxy.config.config
         mapproxy.config.config._config.pop()
 

--- a/mapproxy/test/unit/test_decorate_img.py
+++ b/mapproxy/test/unit/test_decorate_img.py
@@ -71,7 +71,7 @@ class DummyTileLayer(object):
 
 class TestDecorateImg(object):
 
-    def setup(self):
+    def setup_method(self):
         # Base server
         self.server = Server()
         # WMS Server

--- a/mapproxy/test/unit/test_exceptions.py
+++ b/mapproxy/test/unit/test_exceptions.py
@@ -30,8 +30,8 @@ from mapproxy.test.image import is_png
 
 
 class ExceptionHandlerTest(Mocker):
-    def setup(self):
-        Mocker.setup(self)
+    def setup_method(self):
+        Mocker.setup_method(self)
         req = url_decode("""LAYERS=foo&FORMAT=image%2Fpng&SERVICE=WMS&VERSION=1.1.1&
 REQUEST=GetMap&STYLES=&EXCEPTIONS=application%2Fvnd.ogc.se_xml&SRS=EPSG%3A900913&
 BBOX=8,4,9,5&WIDTH=150&HEIGHT=100""".replace('\n', ''))

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -34,7 +34,7 @@ from mapproxy.test.helper import strip_whitespace
 
 class TestXSLTransformer(object):
 
-    def setup(self):
+    def setup_method(self):
         fd, self.xsl_script = tempfile.mkstemp(".xsl")
         os.close(fd)
         xsl = (
@@ -54,7 +54,7 @@ class TestXSLTransformer(object):
         with open(self.xsl_script, "wb") as f:
             f.write(xsl)
 
-    def teardown(self):
+    def teardown_method(self):
         os.remove(self.xsl_script)
 
     def test_transformer(self):
@@ -123,13 +123,13 @@ class TestXMLFeatureInfoDocs(object):
 
 class TestXMLFeatureInfoDocsNoLXML(object):
 
-    def setup(self):
+    def setup_method(self):
         from mapproxy import featureinfo
 
         self.old_etree = featureinfo.etree
         featureinfo.etree = None
 
-    def teardown(self):
+    def teardown_method(self):
         from mapproxy import featureinfo
 
         featureinfo.etree = self.old_etree
@@ -191,13 +191,13 @@ class TestHTMLFeatureInfoDocs(object):
 
 class TestHTMLFeatureInfoDocsNoLXML(object):
 
-    def setup(self):
+    def setup_method(self):
         from mapproxy import featureinfo
 
         self.old_etree = featureinfo.etree
         featureinfo.etree = None
 
-    def teardown(self):
+    def teardown_method(self):
         from mapproxy import featureinfo
 
         featureinfo.etree = self.old_etree

--- a/mapproxy/test/unit/test_geom.py
+++ b/mapproxy/test/unit/test_geom.py
@@ -205,7 +205,7 @@ class TestBBOXPolygon(object):
 
 
 class TestGeomCoverage(object):
-    def setup(self):
+    def setup_method(self):
         # box from 10 10 to 80 80 with small spike/corner to -10 60 (upper left)
         self.geom = shapely.wkt.loads(
             "POLYGON((10 10, 10 50, -10 60, 10 80, 80 80, 80 10, 10 10))")
@@ -249,7 +249,7 @@ class TestGeomCoverage(object):
         assert coverage(g1, SRS(4326)) != coverage(g4, SRS(4326))
 
 class TestBBOXCoverage(object):
-    def setup(self):
+    def setup_method(self):
         self.coverage = coverage([-10, 10, 80, 80], SRS(4326))
 
     def test_bbox(self):
@@ -300,7 +300,7 @@ class TestBBOXCoverage(object):
 
 
 class TestUnionCoverage(object):
-    def setup(self):
+    def setup_method(self):
         self.coverage = union_coverage([
             coverage([0, 0, 10, 10], SRS(4326)),
             coverage(shapely.wkt.loads("POLYGON((10 0, 20 0, 20 10, 10 10, 10 0))"), SRS(4326)),
@@ -323,7 +323,7 @@ class TestUnionCoverage(object):
 
 
 class TestDiffCoverage(object):
-    def setup(self):
+    def setup_method(self):
         g1 = coverage(shapely.wkt.loads("POLYGON((-10 0, 20 0, 20 10, -10 10, -10 0))"), SRS(4326))
         g2 = coverage([0, 2, 8, 8], SRS(4326))
         g3 = coverage(shapely.wkt.loads("POLYGON((-1000000 500000, 0 500000, 0 1000000, -1000000 1000000, -1000000 500000))"), SRS(3857))
@@ -346,7 +346,7 @@ class TestDiffCoverage(object):
 
 
 class TestIntersectionCoverage(object):
-    def setup(self):
+    def setup_method(self):
         g1 = coverage(shapely.wkt.loads("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"), SRS(4326))
         g2 = coverage([5, 5, 15, 15], SRS(4326))
         self.coverage = intersection_coverage([g1, g2])
@@ -365,7 +365,7 @@ class TestIntersectionCoverage(object):
 
 
 class TestMultiCoverage(object):
-    def setup(self):
+    def setup_method(self):
         # box from 10 10 to 80 80 with small spike/corner to -10 60 (upper left)
         self.geom = shapely.wkt.loads(
             "POLYGON((10 10, 10 50, -10 60, 10 80, 80 80, 80 10, 10 10))")
@@ -405,7 +405,7 @@ class TestMultiCoverage(object):
 
 
 class TestMapExtent(object):
-    def setup(self):
+    def setup_method(self):
         self.extent = MapExtent([-10, 10, 80, 80], SRS(4326))
 
     def test_bbox(self):

--- a/mapproxy/test/unit/test_grid.py
+++ b/mapproxy/test/unit/test_grid.py
@@ -137,7 +137,7 @@ def test_metagrid_tiles_w_meta_size():
          ((2, 2, 2), (512, 256)), ((3, 2, 2), (768, 256))]
 
 class TestMetaGridGeodetic(object):
-    def setup(self):
+    def setup_method(self):
         self.mgrid = MetaGrid(grid=tile_grid('EPSG:4326'), meta_size=(2, 2), meta_buffer=10)
 
     def test_meta_bbox_level_0(self):
@@ -219,7 +219,7 @@ class TestMetaGridGeodetic(object):
             ])
 
 class TestMetaGridGeodeticUL(object):
-    def setup(self):
+    def setup_method(self):
         self.tile_grid = tile_grid('EPSG:4326', origin='ul')
         self.mgrid = MetaGrid(grid=self.tile_grid, meta_size=(2, 2), meta_buffer=10)
 
@@ -294,7 +294,7 @@ class TestMetaGridGeodeticUL(object):
 
 
 class TestMetaTile(object):
-    def setup(self):
+    def setup_method(self):
         self.mgrid = MetaGrid(grid=tile_grid('EPSG:4326'), meta_size=(2, 2), meta_buffer=10)
     def test_meta_tile(self):
         meta_tile = self.mgrid.meta_tile((2, 0, 2))
@@ -317,7 +317,7 @@ class TestMetaTile(object):
         assert meta_tile.grid_size == (4, 2)
 
 class TestMetaTileSQRT2(object):
-    def setup(self):
+    def setup_method(self):
         self.grid = tile_grid('EPSG:4326', res_factor='sqrt2')
         self.mgrid = MetaGrid(grid=self.grid, meta_size=(4, 4), meta_buffer=10)
     def test_meta_tile(self):
@@ -357,7 +357,7 @@ class TestMetaTileSQRT2(object):
 
 
 class TestMinimalMetaTile(object):
-    def setup(self):
+    def setup_method(self):
         self.mgrid = MetaGrid(grid=tile_grid('EPSG:4326'), meta_size=(2, 2), meta_buffer=10)
 
     def test_minimal_tiles(self):
@@ -411,7 +411,7 @@ class TestMinimalMetaTile(object):
 
 
 class TestMetaGridLevelMetaTiles(object):
-    def setup(self):
+    def setup_method(self):
         self.meta_grid = MetaGrid(TileGrid(), meta_size=(2, 2))
 
     def test_full_grid_0(self):
@@ -439,7 +439,7 @@ class TestMetaGridLevelMetaTiles(object):
         assert meta_tiles[3] == (2, 0, 2)
 
 class TestMetaGridLevelMetaTilesGeodetic(object):
-    def setup(self):
+    def setup_method(self):
         self.meta_grid = MetaGrid(TileGrid(is_geodetic=True), meta_size=(2, 2))
 
     def test_full_grid_2(self):
@@ -502,7 +502,7 @@ class TestTileGridResolutions(object):
 
 
 class TestWGS84TileGrid(object):
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(is_geodetic=True)
 
     def test_resolution(self):
@@ -534,7 +534,7 @@ class TestWGS84TileGrid(object):
         assert list(tiles) == [(2, 1, 2), (3, 1, 2)]
 
 class TestWGS83TileGridUL(object):
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(4326, bbox=(-180, -90, 180, 90), origin='ul')
 
     def test_resolution(self):
@@ -585,7 +585,7 @@ class TestWGS83TileGridUL(object):
         assert bbox == (0.0, -90.0, 180.0, 90.0)
 
 class TestGKTileGrid(TileGridTest):
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(SRS(31467), bbox=(3250000, 5230000, 3930000, 6110000))
 
     def test_bbox(self):
@@ -638,7 +638,7 @@ class TestGKTileGridUL(TileGridTest):
     """
     Custom grid with ul origin.
     """
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(SRS(31467),
             bbox=(3300000, 5300000, 3900000, 6000000), origin='ul',
             res=[1500, 1000, 500, 300, 150, 100])
@@ -688,7 +688,7 @@ class TestGKTileGridUL(TileGridTest):
 
 
 class TestClosestLevelTinyResFactor(object):
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(SRS(31467),
             bbox=[420000,30000,900000,350000], origin='ul',
             res=[4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5],
@@ -780,7 +780,7 @@ class TestOrigins(object):
         assert grid.supports_access_with_origin('ul')
 
 class TestFixedResolutionsTileGrid(TileGridTest):
-    def setup(self):
+    def setup_method(self):
         self.res = [1000.0, 500.0, 200.0, 100.0, 50.0, 20.0, 5.0]
         bbox = (3250000, 5230000, 3930000, 6110000)
         self.grid = TileGrid(SRS(31467), bbox=bbox, res=self.res)
@@ -838,7 +838,7 @@ class TestFixedResolutionsTileGrid(TileGridTest):
         assert tile_bbox == (3250000.0, 5230000.0, 3301200.0, 5281200.0)
 
 class TestGeodeticTileGrid(TileGridTest):
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(is_geodetic=True, )
     def test_auto_resolution(self):
         grid = TileGrid(is_geodetic=True, bbox=(-10, 30, 10, 40), tile_size=(20, 20))

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -61,10 +61,10 @@ TIFF_FORMAT = ImageOptions(format="image/tiff")
 
 class TestImageSource(object):
 
-    def setup(self):
+    def setup_method(self):
         self.tmp_filename = create_tmp_image_file((100, 100))
 
-    def teardown(self):
+    def teardown_method(self):
         os.remove(self.tmp_filename)
 
     def test_from_filename(self):
@@ -254,7 +254,7 @@ class ROnly(object):
 
 class TestReadBufWrapper(object):
 
-    def setup(self):
+    def setup_method(self):
         rbuf = ROnly()
         self.rbuf_wrapper = ReadBufWrapper(rbuf)
 
@@ -291,7 +291,7 @@ class TestReadBufWrapper(object):
 
 class TestMergeAll(object):
 
-    def setup(self):
+    def setup_method(self):
         self.cleanup_tiles = []
 
     def test_full_merge(self):
@@ -347,7 +347,7 @@ class TestMergeAll(object):
         assert img.size == (100, 100)
         assert img.getcolors() == [(100 * 100, (200, 100, 30, 40))]
 
-    def teardown(self):
+    def teardown_method(self):
         for tile_fname in self.cleanup_tiles:
             if tile_fname and os.path.isfile(tile_fname):
                 os.remove(tile_fname)
@@ -355,13 +355,13 @@ class TestMergeAll(object):
 
 class TestGetCrop(object):
 
-    def setup(self):
+    def setup_method(self):
         self.tmp_file = create_tmp_image_file((100, 100), two_colored=True)
         self.img = ImageSource(
             self.tmp_file, image_opts=ImageOptions(format="image/png"), size=(100, 100)
         )
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.exists(self.tmp_file):
             os.remove(self.tmp_file)
 
@@ -540,7 +540,7 @@ class TestLayerCompositeMerge(object):
 
 class TestTransform(object):
 
-    def setup(self):
+    def setup_method(self):
         self.src_img = ImageSource(create_debug_img((200, 200), transparent=False))
         self.src_srs = SRS(31467)
         self.dst_size = (100, 150)
@@ -861,7 +861,7 @@ class TestPeekImageFormat(object):
 
 class TestBandMerge(object):
 
-    def setup(self):
+    def setup_method(self):
         self.img0 = ImageSource(Image.new("RGB", (10, 10), (0, 10, 20)))
         self.img1 = ImageSource(Image.new("RGB", (10, 10), (100, 110, 120)))
         self.img2 = ImageSource(Image.new("RGB", (10, 10), (200, 210, 220)))

--- a/mapproxy/test/unit/test_image_mask.py
+++ b/mapproxy/test/unit/test_image_mask.py
@@ -133,7 +133,7 @@ class TestMaskImage(object):
 
 class TestLayerCoverageMerge(object):
 
-    def setup(self):
+    def setup_method(self):
         self.coverage1 = coverage(
             Polygon([(0, 0), (0, 10), (10, 10), (10, 0)]), 3857
         )

--- a/mapproxy/test/unit/test_image_messages.py
+++ b/mapproxy/test/unit/test_image_messages.py
@@ -156,7 +156,7 @@ class TestMessageImage(object):
 
 class TestWatermarkTileFilter(object):
 
-    def setup(self):
+    def setup_method(self):
         self.tile = Tile((0, 0, 0))
         self.filter = watermark_filter("Test")
 

--- a/mapproxy/test/unit/test_request.py
+++ b/mapproxy/test/unit/test_request.py
@@ -149,7 +149,7 @@ class DummyRequest(object):
 
 class TestWMSMapRequest(object):
 
-    def setup(self):
+    def setup_method(self):
         self.base_req = url_decode(
             """SERVICE=WMS&format=image%2Fpng&layers=foo&styles=&
 REQUEST=GetMap&height=300&srs=EPSG%3A4326&VERSION=1.1.1&
@@ -161,8 +161,8 @@ bbox=7,50,8,51&width=400""".replace(
 
 class TestWMS100MapRequest(TestWMSMapRequest):
 
-    def setup(self):
-        TestWMSMapRequest.setup(self)
+    def setup_method(self):
+        TestWMSMapRequest.setup_method(self)
         del self.base_req["service"]
         del self.base_req["version"]
         self.base_req["wmtver"] = "1.0.0"
@@ -184,8 +184,8 @@ class TestWMS111MapRequest(TestWMSMapRequest):
 
 class TestWMS130MapRequest(TestWMSMapRequest):
 
-    def setup(self):
-        TestWMSMapRequest.setup(self)
+    def setup_method(self):
+        TestWMSMapRequest.setup_method(self)
         self.base_req["version"] = "1.3.0"
         self.base_req["crs"] = self.base_req["srs"]
         del self.base_req["srs"]
@@ -221,8 +221,8 @@ class TestWMS130MapRequest(TestWMSMapRequest):
 
 class TestWMS111FeatureInfoRequest(TestWMSMapRequest):
 
-    def setup(self):
-        TestWMSMapRequest.setup(self)
+    def setup_method(self):
+        TestWMSMapRequest.setup_method(self)
         self.base_req["request"] = "GetFeatureInfo"
         self.base_req["x"] = "100"
         self.base_req["y"] = "150"
@@ -368,7 +368,7 @@ class TestArcGISIndentifyRequest(object):
 
 class TestRequest(object):
 
-    def setup(self):
+    def setup_method(self):
         self.env = {
             "HTTP_HOST": "localhost:5050",
             "PATH_INFO": "/service",
@@ -461,7 +461,7 @@ def test_maprequest_from_request():
 
 class TestWMSMapRequestParams(object):
 
-    def setup(self):
+    def setup_method(self):
         self.m = WMSMapRequestParams(
             url_decode(
                 "layers=bar&bBOx=-90,-80,70.0, 80&format=image/png"
@@ -620,7 +620,7 @@ BBOX=8,4,9,5&WIDTH=984&HEIGHT=708""".replace(
         )
     )
 
-    def setup(self):
+    def setup_method(self):
         self.req = Request(self.env)
 
     def test_valid_request(self):
@@ -654,7 +654,7 @@ BBOX=8,4,9,5&WIDTH=984&HEIGHT=708""".replace(
 
 class TestSRSAxisOrder(object):
 
-    def setup(self):
+    def setup_method(self):
         params111 = url_decode(
             """LAYERS=foo&FORMAT=image%2Fjpeg&SERVICE=WMS&
 VERSION=1.1.1&REQUEST=GetMap&STYLES=&EXCEPTIONS=application%2Fvnd.ogc.se_xml&

--- a/mapproxy/test/unit/test_seed.py
+++ b/mapproxy/test/unit/test_seed.py
@@ -71,7 +71,7 @@ class MockCache(object):
 
 class TestSeeder(object):
 
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(SRS(4326), bbox=[-180, -90, 180, 90])
         self.source = TiledSource(self.grid, None)
         self.tile_mgr = TileManager(

--- a/mapproxy/test/unit/test_tiled_source.py
+++ b/mapproxy/test/unit/test_tiled_source.py
@@ -29,7 +29,7 @@ TESTSERVER_URL = ("http://%s:%d" % TEST_SERVER_ADDRESS) + "/%(tms_path)s.png"
 
 class TestTileClientOnError(object):
 
-    def setup(self):
+    def setup_method(self):
         self.grid = TileGrid(SRS(4326), bbox=[-180, -90, 180, 90])
         self.client = TileClient(TileURLTemplate(TESTSERVER_URL))
 

--- a/mapproxy/test/unit/test_utils.py
+++ b/mapproxy/test/unit/test_utils.py
@@ -40,14 +40,14 @@ is_win = sys.platform == "win32"
 
 class TestFileLock(Mocker):
 
-    def setup(self):
-        Mocker.setup(self)
+    def setup_method(self):
+        Mocker.setup_method(self)
         self.lock_dir = tempfile.mkdtemp()
         self.lock_file = os.path.join(self.lock_dir, "lock.lck")
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.lock_dir)
-        Mocker.teardown(self)
+        Mocker.teardown_method(self)
 
     def test_file_lock_timeout(self):
         lock = self._create_lock()
@@ -174,11 +174,11 @@ def assert_locked(lock_file, timeout=0.02, step=0.001):
 
 class TestSemLock(object):
 
-    def setup(self):
+    def setup_method(self):
         self.lock_dir = tempfile.mkdtemp()
         self.lock_file = os.path.join(self.lock_dir, "lock.lck")
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.lock_dir)
 
     def count_lockfiles(self):
@@ -252,10 +252,10 @@ class TestSemLock(object):
 
 class DirTest(object):
 
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.exists(self.tmpdir):
             shutil.rmtree(self.tmpdir)
 
@@ -417,10 +417,10 @@ def _write_atomic_data(i_filename):
 
 class TestWriteAtomic(object):
 
-    def setup(self):
+    def setup_method(self):
         self.dirname = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         if self.dirname:
             shutil.rmtree(self.dirname)
 

--- a/mapproxy/test/unit/test_yaml.py
+++ b/mapproxy/test/unit/test_yaml.py
@@ -22,10 +22,10 @@ from mapproxy.compat import string_type
 
 class TestLoadYAMLFile(object):
 
-    def setup(self):
+    def setup_method(self):
         self.tmp_files = []
 
-    def teardown(self):
+    def teardown_method(self):
         for f in self.tmp_files:
             os.unlink(f)
 


### PR DESCRIPTION
Get rid of the thousands of deprecation warnings issued from Pytest. Nose is history.

```
mapproxy/test/unit/test_utils.py::TestCleanupDirectory::test_remove_some
  /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/fixtures.py:911: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  mapproxy/test/unit/test_utils.py::TestCleanupDirectory::test_remove_some is using nose-specific method: `teardown(self)`
  To remove this warning, rename it to `teardown_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
```
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
