### PR TITLE
add tls auth

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1340,7 +1340,9 @@ class CacheConfiguration(ConfigurationBase):
         username = self.conf['cache'].get('username',None)
         password = self.conf['cache'].get('password', None)
         coverage = self.coverage()
-
+        ssl_certfile = self.conf['cache'].get('ssl_certfile',None)
+        ssl_keyfile = self.conf['cache'].get('ssl_keyfile', None)
+        ssl_ca_certs = self.conf['cache'].get('ssl_ca_certs', None)
         prefix = self.conf['cache'].get('prefix')
         if not prefix:
             prefix = self.conf['name'] + '_' + grid_conf.tile_grid().name
@@ -1353,7 +1355,10 @@ class CacheConfiguration(ConfigurationBase):
             password=password,
             prefix=prefix,
             ttl=ttl,
-            coverage=coverage
+            coverage=coverage,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
+            ssl_ca_certs=ssl_ca_certs
         )
 
     def _compact_cache(self, grid_conf, file_ext):

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -185,6 +185,9 @@ cache_types = {
         'db': int(),
         'prefix': str(),
         'default_ttl': int(),
+        'ssl_certfile': str(),
+        'ssl_keyfile': str(),
+        'ssl_ca_certs': str(),
     }),
     'compact': combined(cache_commons, {
         'directory': str(),

--- a/mapproxy/test/helper_scripts/README.md
+++ b/mapproxy/test/helper_scripts/README.md
@@ -1,0 +1,7 @@
+# pytest testing
+
+after running scripts in mapproxy/test/helper_scripts/*bootstrap.sh you can test all redis with
+
+```
+MAPPROXY_TEST_REDIS_AUTH=localhost:6381 MAPPROXY_TEST_REDIS=localhost:6379 MAPPROXY_TEST_REDIS_TLS=localhost:6380 pytest mapproxy/test/unit/test_cache_redis.py
+```

--- a/mapproxy/test/helper_scripts/config.sh
+++ b/mapproxy/test/helper_scripts/config.sh
@@ -1,0 +1,16 @@
+# Variables
+REDIS_CONF="redis.conf"
+REDIS_AUTH_CONF="redis_auth.conf"
+REDIS_TLS_CONF="redis_tls.conf"
+REDIS_CLI="/usr/bin/redis-cli"
+REDIS_SERVER="/usr/sbin/redis-server"
+REDIS_PORT=6379
+REDIS_TLS_PORT=6380
+REDIS_AUTH_PORT=6381
+
+TLS_DIR="../unit/fixture"
+HOSTNAME=$(hostname -f)
+MASTER_PASSWORD="solarwinds123" # Master password for Redis
+
+USERNAME="test"
+USER_PASSWORD="pw4test"

--- a/mapproxy/test/helper_scripts/redis_auth_bootstrap.sh
+++ b/mapproxy/test/helper_scripts/redis_auth_bootstrap.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source config.sh
+# there is asumption you are running as user and that you already have installed redis package
+# i run this on openSUSE tumbleweed and "it just works for me" so...
+
+
+# Create minimal configuration file
+> $REDIS_AUTH_CONF
+echo "port $REDIS_AUTH_PORT" >> $REDIS_AUTH_CONF
+echo "" >> $REDIS_AUTH_CONF
+echo "requirepass $MASTER_PASSWORD" >> $REDIS_AUTH_CONF
+
+# do trickery for creating test user....
+(
+        sleep 5;
+        $REDIS_CLI -h $HOSTNAME -p $REDIS_AUTH_PORT -a $MASTER_PASSWORD <<EOF
+ACL SETUSER $USERNAME on >$USER_PASSWORD ~* +@all
+EOF
+)&
+
+echo "Redis has been configured with authentication!"
+
+set +x
+$REDIS_SERVER $REDIS_AUTH_CONF

--- a/mapproxy/test/helper_scripts/redis_bootstrap.sh
+++ b/mapproxy/test/helper_scripts/redis_bootstrap.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+
+# there is asumption you are running as user and that you already have installed redis package
+# i run this on openSUSE tumbleweed and "it just works for me" so...
+
+source config.sh
+# Create minimal configuration file
+> $REDIS_CONF
+echo "port $REDIS_PORT" >> $REDIS_CONF
+echo "" >> $REDIS_CONF
+
+set +x
+$REDIS_SERVER $REDIS_CONF
+
+

--- a/mapproxy/test/helper_scripts/redis_tls_bootstrap.sh
+++ b/mapproxy/test/helper_scripts/redis_tls_bootstrap.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+source config.sh
+
+# there is asumption you are running as user and that you already have installed redis package
+# i run this on openSUSE tumbleweed and "it just works for me" so...
+
+# Create TLS directory
+mkdir -p $TLS_DIR
+cd $TLS_DIR
+
+# Generate CA key and cert
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -nodes -key ca.key -subj "/CN=RedisCA" -days 1024 -out ca.crt
+
+# Generate Redis server key and CSR
+openssl genrsa -out redis-server.key 4096
+openssl req -new -key redis-server.key -subj "/CN=$HOSTNAME" -out redis-server.csr
+
+# Server cert config
+cat > server-cert.conf <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = req_ext
+prompt = no
+
+[req_distinguished_name]
+CN = $HOSTNAME
+
+[req_ext]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = $HOSTNAME
+DNS.2 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+# Sign server CSR with CA
+openssl x509 -req -in redis-server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out redis-server.crt -days 365 -sha256 -extfile server-cert.conf
+
+# Generate Redis client key and CSR
+openssl genrsa -out redis-client.key 4096
+openssl req -new -key redis-client.key -subj "/CN=RedisClient" -out redis-client.csr
+
+# Sign client CSR with CA
+openssl x509 -req -in redis-client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out redis-client.crt -days 365 -sha256
+
+cd -
+
+# Create minimal configuration file
+> $REDIS_TLS_CONF
+echo "tls-port $REDIS_TLS_PORT" >> $REDIS_TLS_CONF
+echo "port 0" >> $REDIS_TLS_CONF
+echo "" >> $REDIS_TLS_CONF
+echo "tls-cert-file $TLS_DIR/redis-server.crt" >> $REDIS_TLS_CONF
+echo "tls-key-file $TLS_DIR/redis-server.key" >> $REDIS_TLS_CONF
+echo "tls-ca-cert-file $TLS_DIR/ca.crt" >> $REDIS_TLS_CONF
+echo "tls-auth-clients no" >> $REDIS_TLS_CONF
+
+echo "Redis has been configured with TLS!"
+
+set +x
+$REDIS_SERVER $REDIS_TLS_CONF

--- a/mapproxy/test/unit/test_cache_redis.py
+++ b/mapproxy/test/unit/test_cache_redis.py
@@ -36,6 +36,12 @@ class TestRedisCache(TileCacheTestBase):
     def setup_method(self):
         redis_host = os.environ['MAPPROXY_TEST_REDIS']
         self.host, self.port = redis_host.split(':')
+        if os.environ.get('MAPPROXY_TEST_REDIS_TLS'):
+            redis_host_tls = os.environ['MAPPROXY_TEST_REDIS_TLS']
+            self.tls_host, self.tls_port = redis_host_tls.split(':')
+        if os.environ.get('MAPPROXY_TEST_REDIS_AUTH'):
+            redis_host_tls = os.environ['MAPPROXY_TEST_REDIS_AUTH']
+            self.auth_host, self.auth_port = redis_host_tls.split(':')
 
         TileCacheTestBase.setup_method(self)
 
@@ -68,3 +74,49 @@ class TestRedisCache(TileCacheTestBase):
         self.create_cached_tile(tile)
         assert self.cache.remove_tile(tile)
         assert self.cache.remove_tile(tile)
+
+    @pytest.mark.skipif(not redis or not os.environ.get('MAPPROXY_TEST_REDIS_TLS'),
+                    reason="MAPPROXY_TEST_REDIS_TLS is required")
+    def test_tls_authentication_enabled(self):
+        print(os.curdir)
+        ssl_certfile = 'mapproxy/test/unit/fixture/redis-client.crt'
+        ssl_keyfile = 'mapproxy/test/unit/fixture/redis-client.key'
+        ssl_ca_certs = 'mapproxy/test/unit/fixture/ca.crt'
+        cache = RedisCache(self.tls_host, int(self.tls_port), prefix='mapproxy-test', db=1, ssl_certfile=ssl_certfile, ssl_keyfile=ssl_keyfile, ssl_ca_certs=ssl_ca_certs)
+        assert cache.r.connection_pool.connection_kwargs['ssl_certfile'] == ssl_certfile
+        assert cache.r.connection_pool.connection_kwargs['ssl_keyfile'] == ssl_keyfile
+        assert cache.r.connection_pool.connection_kwargs['ssl_ca_certs'] == ssl_ca_certs
+        t1 = self.create_tile(coord=(5382, 3234, 9))
+        assert cache.store_tile(t1)
+        time.sleep(0.1)
+        t2 = Tile(t1.coord)
+        assert cache.is_cached(t2)
+
+
+    @pytest.mark.skipif(not redis or not os.environ.get('MAPPROXY_TEST_REDIS_TLS'),
+                    reason="MAPPROXY_TEST_REDIS_TLS is required")
+    def test_tls_authentication_disabled(self):
+        cache = RedisCache(self.tls_host, int(self.tls_port), prefix='mapproxy-test', db=1)
+        assert 'ssl_certfile' not in cache.r.connection_pool.connection_kwargs
+        assert 'ssl_keyfile' not in cache.r.connection_pool.connection_kwargs
+        assert 'ssl_ca_certs' not in cache.r.connection_pool.connection_kwargs
+        assert not cache.r.connection_pool.connection_kwargs.get('ssl', False)
+        t1 = self.create_tile(coord=(5382, 4234, 9))
+        assert not cache.store_tile(t1)
+        time.sleep(0.1)
+        t2 = Tile(t1.coord)
+        assert not cache.is_cached(t2)
+
+
+    @pytest.mark.skipif(not redis or not os.environ.get('MAPPROXY_TEST_REDIS_AUTH'),
+                    reason="MAPPROXY_TEST_REDIS_AUTH is required to test authentication")
+    def test_user_password_authentication(self):
+        username = 'test'
+        password = 'pw4test'
+        cache = RedisCache(self.auth_host, int(self.auth_port), prefix='mapproxy-test', db=1, username=username, password=password)
+        assert cache.r.connection_pool.connection_kwargs['username'] == username
+        assert cache.r.connection_pool.connection_kwargs['password'] == password
+        t1 = self.create_tile(coord=(5382, 5234, 9))
+        assert cache.store_tile(t1)
+        t2 = Tile(t1.coord)
+        assert cache.is_cached(t2)


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
this PR adds tls authentication to redis cache implementation, to test implementation (all test cases) now there are shell scripts in `mapproxy/test/helper_scripts/` that run three redis instances with different configurations that are possible with current code.
@shimoncohen please test in your use case if that satisfies your requirements.

