### PR TITLE
Remove python 3.7 support as its EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     env:
       MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -39,7 +39,7 @@ This will change the ``PATH`` for your `current` session.
 Install Dependencies
 --------------------
 
-MapProxy is written in Python, thus you will need a working Python installation. MapProxy works with Python 3.7 or higher, which should already be installed with most Linux distributions.
+MapProxy is written in Python, thus you will need a working Python installation. MapProxy works with Python 3.8 or higher, which should already be installed with most Linux distributions.
 
 MapProxy requires a few third-party libraries that are required to run. There are different ways to install each dependency. Read :ref:`dependency_details` for a list of all required and optional dependencies.
 

--- a/doc/install_windows.rst
+++ b/doc/install_windows.rst
@@ -1,7 +1,7 @@
 Installation on Windows
 =======================
 
-At first you need a working Python installation. You can download Python from: https://www.python.org/download/. MapProxy requires Python 3.7 or higher.
+At first you need a working Python installation. You can download Python from: https://www.python.org/download/. MapProxy requires Python 3.8 or higher.
 
 Virtualenv
 ----------

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,8 +1,7 @@
 azure-storage-blob>=12.9.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-Pillow==9.5.0;python_version<"3.8"
-Pillow==10.0.1;python_version>="3.8"
+Pillow==10.0.1
 PyYAML==6.0.1
 WebOb==1.8.7
 Shapely==2.0.1
@@ -41,17 +40,15 @@ more-itertools==8.4.0
 moto==4.2.4
 networkx==3.1;python_version>="3.9"
 networkx==2.8.7;python_version=="3.8"
-networkx==2.6;python_version<"3.8"
 numpy==1.26.0;python_version>="3.9"
 numpy==1.24.0;python_version=="3.8"
-numpy==1.21.0;python_version<"3.8"
 packaging==23.2
 pluggy==0.13.1
 py==1.11.0
 pyasn1==0.5.0
 pycparser==2.20
 pyparsing==2.4.7
-pyproj==2.6.1.post1;python_version in "3.7 3.8"
+pyproj==2.6.1.post1;python_version=="3.8"
 pyproj==3.3.1;python_version in "3.9 3.10"
 pyproj==3.5.0;python_version>"3.10"
 pyrsistent==0.19.3

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
As the title says, this removes support for python version 3.7, as it is end-of-life.