### PR TITLE
Allow md5 calls to work in FIPS environments

### DIFF
--- a/mapproxy/cache/compact.py
+++ b/mapproxy/cache/compact.py
@@ -36,7 +36,8 @@ class CompactCacheBase(TileCacheBase):
 
     def __init__(self, cache_dir, coverage=None):
         super(CompactCacheBase, self).__init__(coverage)
-        self.lock_cache_id = 'compactcache-' + hashlib.md5(cache_dir.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', cache_dir.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'compactcache-' + md5.hexdigest()
         self.cache_dir = cache_dir
 
     def _get_bundle_fname_and_offset(self, tile_coord):

--- a/mapproxy/cache/couchdb.py
+++ b/mapproxy/cache/couchdb.py
@@ -53,7 +53,8 @@ class CouchDBCache(TileCacheBase):
         if requests is None:
             raise ImportError("CouchDB backend requires 'requests' package.")
 
-        self.lock_cache_id = 'couchdb-' + hashlib.md5((url + db_name).encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', (url + db_name).encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'couchdb-' + md5.hexdigest()
         self.file_ext = file_ext
         self.tile_grid = tile_grid
         self.md_template = md_template

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -37,7 +37,7 @@ class FileCache(TileCacheBase):
             each tile (e.g. 'png')
         """
         super(FileCache, self).__init__(coverage)
-        self.lock_cache_id = hashlib.md5(cache_dir.encode('utf-8')).hexdigest()
+        self.lock_cache_id = hashlib.md5(cache_dir.encode('utf-8'), usedforsecurity=False).hexdigest()
         self.cache_dir = cache_dir
         self.file_ext = file_ext
         self.link_single_color_images = link_single_color_images

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -37,7 +37,8 @@ class FileCache(TileCacheBase):
             each tile (e.g. 'png')
         """
         super(FileCache, self).__init__(coverage)
-        self.lock_cache_id = hashlib.md5(cache_dir.encode('utf-8'), usedforsecurity=False).hexdigest()
+        md5 = hashlib.new('md5', cache_dir.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = md5.hexdigest()
         self.cache_dir = cache_dir
         self.file_ext = file_ext
         self.link_single_color_images = link_single_color_images

--- a/mapproxy/cache/geopackage.py
+++ b/mapproxy/cache/geopackage.py
@@ -40,7 +40,8 @@ class GeopackageCache(TileCacheBase):
         super(GeopackageCache, self).__init__(coverage)
         self.tile_grid = tile_grid
         self.table_name = self._check_table_name(table_name)
-        self.lock_cache_id = 'gpkg' + hashlib.md5(geopackage_file.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', geopackage_file.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'gpkg' + md5.hexdigest()
         self.geopackage_file = geopackage_file
         
         if coverage:
@@ -506,7 +507,8 @@ class GeopackageLevelCache(TileCacheBase):
 
     def __init__(self, geopackage_dir, tile_grid, table_name, timeout=30, wal=False, coverage=None):
         super(GeopackageLevelCache, self).__init__(coverage)
-        self.lock_cache_id = 'gpkg-' + hashlib.md5(geopackage_dir.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', geopackage_dir.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'gpkg-' + md5.hexdigest()
         self.cache_dir = geopackage_dir
         self.tile_grid = tile_grid
         self.table_name = table_name

--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -44,7 +44,8 @@ class MBTilesCache(TileCacheBase):
 
     def __init__(self, mbtile_file, with_timestamps=False, timeout=30, wal=False, ttl=0, coverage=None):
         super(MBTilesCache, self).__init__(coverage)
-        self.lock_cache_id = 'mbtiles-' + hashlib.md5(mbtile_file.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', mbtile_file.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'mbtiles-' + md5.hexdigest()
         self.mbtile_file = mbtile_file
         self.supports_timestamp = with_timestamps
         self.ttl = with_timestamps and ttl or 0
@@ -310,7 +311,8 @@ class MBTilesLevelCache(TileCacheBase):
 
     def __init__(self, mbtiles_dir, timeout=30, wal=False, ttl=0, coverage=None):
         super(MBTilesLevelCache, self).__init__(coverage)
-        self.lock_cache_id = 'sqlite-' + hashlib.md5(mbtiles_dir.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', mbtiles_dir.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'sqlite-' + md5.hexdigest()
         self.cache_dir = mbtiles_dir
         self._mbtiles = {}
         self.timeout = timeout

--- a/mapproxy/cache/redis.py
+++ b/mapproxy/cache/redis.py
@@ -49,7 +49,8 @@ class RedisCache(TileCacheBase):
 
         self.prefix = prefix
         # str(username) => if not set defaults to None
-        self.lock_cache_id = 'redis-' + hashlib.md5((host + str(port) + prefix + str(db) + str(username)).encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', (host + str(port) + prefix + str(db)).encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'redis-' + md5.hexdigest()
         self.ttl = ttl
         # Enable SSL only if certificate and key are provided (CA certificates are not mandatory, but if provided use them)
         ssl_enabled = all([self.ssl_certfile, self.ssl_keyfile])

--- a/mapproxy/cache/riak.py
+++ b/mapproxy/cache/riak.py
@@ -48,7 +48,8 @@ class RiakCache(TileCacheBase):
 
         self.nodes = nodes
         self.protocol = protocol
-        self.lock_cache_id = 'riak-' + hashlib.md5(bucket.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', bucket.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = 'riak-' + md5.hexdigest()
         self.request_timeout = timeout * 1000
         self.bucket_name = bucket
         self.tile_grid = tile_grid

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -53,7 +53,8 @@ class S3Cache(TileCacheBase):
                  bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
                  _concurrent_writer=4, access_control_list=None, coverage=None):
         super(S3Cache, self).__init__(coverage)
-        self.lock_cache_id = hashlib.md5(base_path.encode('utf-8') + bucket_name.encode('utf-8')).hexdigest()
+        md5 = hashlib.new('md5', base_path.encode('utf-8') + bucket_name.encode('utf-8'), usedforsecurity=False)
+        self.lock_cache_id = md5.hexdigest()
         self.bucket_name = bucket_name
         self.profile_name = profile_name
         self.region_name = region_name

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -776,7 +776,7 @@ class WMSSourceConfiguration(SourceConfiguration):
             lock_dir = self.context.globals.get_path('cache.lock_dir', self.conf)
             lock_timeout = self.context.globals.get_value('http.client_timeout', self.conf)
             url = urlparse.urlparse(self.conf['req']['url'])
-            md5 = hashlib.md5(url.netloc.encode('ascii'))
+            md5 = hashlib.new('md5', url.netloc.encode('ascii'), usedforsecurity=False)
             lock_file = os.path.join(lock_dir, md5.hexdigest() + '.lck')
             lock = lambda: SemLock(lock_file, concurrent_requests, timeout=lock_timeout)
 
@@ -922,7 +922,7 @@ class MapnikSourceConfiguration(SourceConfiguration):
             from mapproxy.util.lock import SemLock
             lock_dir = self.context.globals.get_path('cache.lock_dir', self.conf)
             mapfile = self.conf['mapfile']
-            md5 = hashlib.md5(mapfile.encode('utf-8'))
+            md5 = hashlib.new('md5', mapfile.encode('utf-8'), usedforsecurity=False)
             lock_file = os.path.join(lock_dir, md5.hexdigest() + '.lck')
             lock = lambda: SemLock(lock_file, concurrent_requests)
 

--- a/mapproxy/response.py
+++ b/mapproxy/response.py
@@ -87,7 +87,7 @@ class Response(object):
         """
         if etag_data:
             hash_src = ''.join((str(x) for x in etag_data)).encode('ascii')
-            self.etag = hashlib.md5(hash_src).hexdigest()
+            self.etag = hashlib.new('md5', hash_src, usedforsecurity=False).hexdigest()
 
         if no_cache:
             assert not timestamp and not max_age

--- a/mapproxy/test/system/test_kml.py
+++ b/mapproxy/test/system/test_kml.py
@@ -76,7 +76,8 @@ class TestKML(SysTest):
             (timestamp, timestamp),
         )
         max_age = base_config.tiles.expires_hours * 60 * 60
-        etag = hashlib.md5((str(timestamp) + str(size)).encode("ascii")).hexdigest()
+        md5 = hashlib.new('md5', (str(timestamp) + str(size)).encode("ascii"), usedforsecurity=False)
+        etag = md5.hexdigest()
         return etag, max_age
 
     def _check_cache_control_headers(self, resp, etag, max_age, timestamp=1234567890.0):
@@ -142,7 +143,8 @@ class TestKML(SysTest):
             "http://localhost/kml/wms_cache/EPSG900913/1/1/0.kml",
         ]
 
-        etag = hashlib.md5(resp.body).hexdigest()
+        md5 = hashlib.new('md5', resp.body, usedforsecurity=False)
+        etag = md5.hexdigest()
         max_age = base_config.tiles.expires_hours * 60 * 60
         self._check_cache_control_headers(resp, etag, max_age, None)
 

--- a/mapproxy/test/system/test_tms.py
+++ b/mapproxy/test/system/test_tms.py
@@ -186,7 +186,8 @@ class TestTileService(SysTest):
             (timestamp, timestamp),
         )
         max_age = base_config.tiles.expires_hours * 60 * 60
-        etag = hashlib.md5((str(timestamp) + str(size)).encode("ascii")).hexdigest()
+        md5 = hashlib.new('md5', (str(timestamp) + str(size)).encode("ascii"), usedforsecurity=False)
+        etag = md5.hexdigest()
         return etag, max_age
 
     def _check_cache_control_headers(self, resp, etag, max_age):


### PR DESCRIPTION
This is based on https://github.com/mapproxy/mapproxy/pull/607 but applies the new default to all method calls.