### PR TITLE
Add S3 performance option to request via urllib2

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -500,6 +500,9 @@ Available options:
 ``directory_layout``:
   Defines the directory layout for the tiles (``12/12345/67890.png``, ``L12/R00010932/C00003039.png``, etc.).  See :ref:`cache_file` for available options. Defaults to ``tms`` (e.g. ``12/12345/67890.png``). This cache cache also supports ``reverse_tms`` where tiles are stored as ``y/x/z.format``. See *note* below.
 
+``use_http_get``:
+  When set to ``true``, requests to S3 ``GetObject`` will be fetched via urllib2 instead of boto, which decreases response times. Defaults to ``false``.
+
 .. note::
   The hierarchical ``directory_layouts`` can hit limitations of S3 *"if you are routinely processing 100 or more requests per second"*. ``directory_layout: reverse_tms`` can work around this limitation. Please read `S3 Request Rate and Performance Considerations <http://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html>`_ for more information on this issue.
 

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -24,6 +24,8 @@ from mapproxy.cache import path
 from mapproxy.cache.base import tile_buffer, TileCacheBase
 from mapproxy.util import async_
 from mapproxy.util.py import reraise_exception
+from urllib import request as urllib2
+from urllib.error import HTTPError
 
 try:
     import boto3
@@ -51,7 +53,7 @@ class S3Cache(TileCacheBase):
 
     def __init__(self, base_path, file_ext, directory_layout='tms',
                  bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
-                 _concurrent_writer=4, access_control_list=None, coverage=None):
+                 _concurrent_writer=4, access_control_list=None, coverage=None, use_http_get=False):
         super(S3Cache, self).__init__(coverage)
         self.lock_cache_id = hashlib.md5(base_path.encode('utf-8') + bucket_name.encode('utf-8')).hexdigest()
         self.bucket_name = bucket_name
@@ -59,6 +61,7 @@ class S3Cache(TileCacheBase):
         self.region_name = region_name
         self.endpoint_url = endpoint_url
         self.access_control_list = access_control_list
+        self.use_http_get = use_http_get
 
         try:
             self.bucket = self.conn().head_bucket(Bucket=bucket_name)
@@ -78,6 +81,9 @@ class S3Cache(TileCacheBase):
         self._concurrent_writer = _concurrent_writer
 
         self._tile_location, _ = path.location_funcs(layout=directory_layout)
+
+    def get_bucket_url(self, tile):
+        return "https://{bucket}.s3.{region}.amazonaws.com/{key}".format(bucket=self.bucket_name, region=self.region_name, key=self.tile_key(tile))
 
     def tile_key(self, tile):
         return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
@@ -104,14 +110,24 @@ class S3Cache(TileCacheBase):
 
     def is_cached(self, tile, dimensions=None):
         if tile.is_missing():
-            key = self.tile_key(tile)
-            try:
-                r = self.conn().head_object(Bucket=self.bucket_name, Key=key)
-                self._set_metadata(r, tile)
-            except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] in ('404', 'NoSuchKey'):
-                    return False
-                raise
+            if self.use_http_get:
+                try:
+                    req = urllib2.Request(self.get_bucket_url(tile))
+                    response = urllib2.urlopen(req)
+                    self._set_metadata(response.info(), tile)
+                except urllib2.HTTPError as e:
+                    if e.code == 403:
+                        return False
+                    raise
+            else:
+                key = self.tile_key(tile)
+                try:
+                    r = self.conn().head_object(Bucket=self.bucket_name, Key=key)
+                    self._set_metadata(r, tile)
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] in ('404', 'NoSuchKey'):
+                        return False
+                    raise
 
         return True
 
@@ -126,15 +142,24 @@ class S3Cache(TileCacheBase):
         key = self.tile_key(tile)
         log.debug('S3:load_tile, key: %s' % key)
 
-        try:
-            r  = self.conn().get_object(Bucket=self.bucket_name, Key=key)
-            self._set_metadata(r, tile)
-            tile.source = ImageSource(r['Body'])
-        except botocore.exceptions.ClientError as e:
-            error = e.response.get('Errors', e.response)['Error'] # moto get_object can return Error wrapped in Errors...
-            if error['Code'] in ('404', 'NoSuchKey'):
-                return False
-            raise
+        if self.use_http_get:
+            try:
+                req = urllib2.Request(self.get_bucket_url(tile))
+                tile.source = ImageSource(urllib2.urlopen(req))
+            except urllib2.HTTPError as e:
+                if e.code == 403:
+                    return False
+                raise
+        else:
+            try:
+                r  = self.conn().get_object(Bucket=self.bucket_name, Key=key)
+                self._set_metadata(r, tile)
+                tile.source = ImageSource(r['Body'])
+            except botocore.exceptions.ClientError as e:
+                error = e.response.get('Errors', e.response)['Error'] # moto get_object can return Error wrapped in Errors...
+                if error['Code'] in ('404', 'NoSuchKey'):
+                    return False
+                raise
 
         return True
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1230,6 +1230,10 @@ class CacheConfiguration(ConfigurationBase):
         access_control_list = self.context.globals.get_value('cache.access_control_list', self.conf,
             global_key='cache.s3.access_control_list')
 
+        use_http_get = self.context.globals.get_value('cache.use_http_get', self.conf,
+            global_key='cache.s3.use_http_get'
+        )
+
         directory_layout = self.conf['cache'].get('directory_layout', 'tms')
 
         base_path = self.conf['cache'].get('directory', None)
@@ -1245,7 +1249,8 @@ class CacheConfiguration(ConfigurationBase):
             region_name=region_name,
             endpoint_url=endpoint_url,
             access_control_list=access_control_list,
-            coverage=coverage
+            coverage=coverage,
+            use_http_get=use_http_get
         )
 
     def _sqlite_cache(self, grid_conf, file_ext):

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -166,6 +166,7 @@ cache_types = {
         'endpoint_url': str(),
         'access_control_list': str(),
         'tile_lock_dir': str(),
+        'use_http_get': bool(),
      }),
     'riak': combined(cache_commons, {
         'nodes': [riak_node],


### PR DESCRIPTION
This is based on https://github.com/mapproxy/mapproxy/pull/422 and enhances the performance for `GetObject` calls when configured to do so
