### PR TITLE
Add parameter to change background map source

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -820,6 +820,18 @@ globals
 
 Here you can define some internals of MapProxy and default values that are used in the other configuration directives.
 
+.. _globals_background:
+
+``background``
+""""""""""""""
+
+Configuration of the background displayed in the map viewer. This background map can be observed in the /demo service 
+of MapProxy, in any of the three types of service (WMS, WMTS and TMS).
+
+.. _background_url:
+
+``url``
+  URL of the tile service (it MUST be a service that offers tiles in XYZ format e.g. "https://tile.openstreetmap.org/{z}/{x}/{y}.png")
 
 ``image``
 """""""""

--- a/doc/configuration_examples.rst
+++ b/doc/configuration_examples.rst
@@ -139,6 +139,25 @@ Example configuration for an OpenStreetMap tile service::
 
 .. note:: Please make sure you are allowed to access the tile service. Commercial tile provider often prohibit the direct access to tiles. The tile service from OpenStreetMap has a strict `Tile Usage Prolicy <http://wiki.openstreetmap.org/wiki/Tile_usage_policy>`_.
 
+
+.. _display_custom_background:
+
+Display custom background map in the map viewer of the demo service
+===================================================================
+
+In order to setup the background displayed in the map viewer of the /demo service of Mapproxy
+you need to add the service of the background map to ``globals``.
+
+Here is a minimal example with the default configuration::
+
+  globals:
+    # background map of the demo service
+    background:
+      # tile source in ZXY format
+      url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png" 
+
+.. note:: URL of the tile service MUST be in XYZ format. Please make sure you are allowed to access the tile service. Commercial tile provider often prohibit the direct access to tiles. The tile service from OpenStreetMap has a strict `Tile Usage Prolicy <http://wiki.openstreetmap.org/wiki/Tile_usage_policy>`_.
+
 .. _overlay_tiles_osm_openlayers:
 
 Overlay tiles with OpenStreetMap or Google Maps in OpenLayers

--- a/mapproxy/config/defaults.py
+++ b/mapproxy/config/defaults.py
@@ -26,6 +26,10 @@ wms = dict(
 )
 debug_mode = False
 
+background = dict(
+    url = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+)
+
 srs = dict(
     # user sets
     axis_order_ne = set(),

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -2207,9 +2207,10 @@ class ServiceConfiguration(ConfigurationBase):
                 services.append('wms_111')
 
         layers = odict(sorted(layers.items(), key=lambda x: x[1].name))
+        background =  self.context.globals.get_value('background', conf)
 
         return DemoServer(layers, md, tile_layers=tile_layers,
-            image_formats=image_formats, srs=srs, services=services, restful_template=restful_template)
+            image_formats=image_formats, srs=srs, services=services, restful_template=restful_template, background = background)
 
 
 def load_plugins():

--- a/mapproxy/config_template/base_config/full_example.yaml
+++ b/mapproxy/config_template/base_config/full_example.yaml
@@ -591,3 +591,8 @@ globals:
         encoding_options:
           # jpeg quality [0-100]
           jpeg_quality: 60
+
+  # background map of the demo service
+  background:
+    # tile source in ZXY format
+    url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png" 

--- a/mapproxy/service/templates/demo/tms_demo.html
+++ b/mapproxy/service/templates/demo/tms_demo.html
@@ -42,9 +42,13 @@ jscript_functions=None
             maxResolution: {{resolutions[0]}}
         });
 
+        const background_source = new ol.source.XYZ({
+            url: "{{background_url}}"
+        });
+
         const layers = [
             new ol.layer.Tile({
-                source: new ol.source.OSM()
+                source: background_source
             }),
             new ol.layer.Tile({source})
         ];

--- a/mapproxy/service/templates/demo/wms_demo.html
+++ b/mapproxy/service/templates/demo/wms_demo.html
@@ -42,9 +42,13 @@ jscript_functions=None
             }
         });
 
+        const background_source = new ol.source.XYZ({
+            url: "{{background_url}}"
+        });
+
         const layers = [
             new ol.layer.Tile({
-                source: new ol.source.OSM()
+                source: background_source
             }),
             new ol.layer.Image({source})
         ];

--- a/mapproxy/service/templates/demo/wmts_demo.html
+++ b/mapproxy/service/templates/demo/wmts_demo.html
@@ -58,9 +58,13 @@ jscript_functions=None
             })
         });
 
+        const background_source = new ol.source.XYZ({
+            url: "{{background_url}}"
+        });
+
         const layers = [
             new ol.layer.Tile({
-                source: new ol.source.OSM()
+                source: background_source
             }),
             new ol.layer.Tile({source})
         ];


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
Add the possibility to modify the background map shown in MapProxy, which by default takes the OpenStreetMap source.

This background map can be observed in the /demo service of MapProxy, in any of the three types of service (WMS, WMTS and TMS).
