### PR TITLE
Do not rely on GeoServer format for json based legends

### DIFF
--- a/mapproxy/image/merge.py
+++ b/mapproxy/image/merge.py
@@ -312,5 +312,7 @@ def concat_json_legends(legends):
     for legend in legends:
         legend_str = legend.read().decode('utf-8')
         legend_dict = json.loads(legend_str)
-        legends_dict['Legend'].append(legend_dict['Legend'][0])
+        if 'Legend' in legend_dict:
+            legend_dict = legend_dict['Legend'][0]
+        legends_dict['Legend'].append(legend_dict)
     return json.dumps(legends_dict)


### PR DESCRIPTION
Hello,

This PR follows https://github.com/mapproxy/mapproxy/issues/540 but for QGIS Server. 

Currently, MapProxy supports the `application/json` `legendgraphic` format but in a very specific structure based on GeoServer response:

``` json
{"Legend": [{}]}
``` 

On QGIS Server side, a response looks like:

``` json
{"nodes": [{}]}
```

On `master`, MapProxy is failing when QGIS Server returns a `json/application` legend:

``` console
fatal error in service for /service/wms?VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=seine_section&FORMAT=application/json
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/mapproxy/wsgiapp.py", line 141, in __call__
    resp = self.handlers[handler_name].handle(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/mapproxy/service/ows.py", line 38, in handle
    return self.services[service].handle(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/mapproxy/service/base.py", line 30, in handle
    return handler(parsed_req)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/mapproxy/service/wms.py", line 308, in legendgraphic
    [legends.append(i) for i in legend if i is not None]
  File "/usr/local/lib/python3.11/site-packages/mapproxy/service/wms.py", line 308, in <listcomp>
    [legends.append(i) for i in legend if i is not None]
  File "/usr/local/lib/python3.11/site-packages/mapproxy/service/wms.py", line 744, in legend
    yield lyr.get_legend(query)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/mapproxy/source/wms.py", line 262, in get_legend
    return concat_json_legends(legends)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/mapproxy/image/merge.py", line 315, in concat_json_legends
    legends_dict['Legend'].append(legend_dict['Legend'][0])
                                  ~~~~~~~~~~~^^^^^^^^^^
KeyError: 'Legend'
```