### PR TITLE
Configure image options for caches

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -84,6 +84,11 @@ This is the default cache type and it uses a single file for each tile. Availabl
 
   .. versionadded:: 1.6.0
 
+``image``:
+  See :ref:`image_options` for options.
+
+  .. versionadded:: 1.16.1
+
 .. _cache_mbtiles:
 
 ``mbtiles``

--- a/mapproxy/cache/file.py
+++ b/mapproxy/cache/file.py
@@ -30,7 +30,7 @@ class FileCache(TileCacheBase):
     This class is responsible to store and load the actual tile data.
     """
     def __init__(self, cache_dir, file_ext, directory_layout='tc',
-                 link_single_color_images=False, coverage=None):
+                 link_single_color_images=False, coverage=None, image_opts=None):
         """
         :param cache_dir: the path where the tile will be stored
         :param file_ext: the file extension that will be appended to
@@ -41,6 +41,7 @@ class FileCache(TileCacheBase):
         self.lock_cache_id = md5.hexdigest()
         self.cache_dir = cache_dir
         self.file_ext = file_ext
+        self.image_opts = image_opts
         self.link_single_color_images = link_single_color_images
         self._tile_location, self._level_location = path.location_funcs(layout=directory_layout)
         if self._level_location is None:
@@ -117,7 +118,7 @@ class FileCache(TileCacheBase):
         if os.path.exists(location):
             if with_metadata:
                 self.load_tile_metadata(tile, dimensions=dimensions)
-            tile.source = ImageSource(location)
+            tile.source = ImageSource(location, image_opts=self.image_opts)
             return True
         return False
 

--- a/mapproxy/test/system/fixture/multi_cache_layers.yaml
+++ b/mapproxy/test/system/fixture/multi_cache_layers.yaml
@@ -40,6 +40,9 @@ layers:
   - name: cache
     title: single cache layer
     sources: [utm_cache]
+  - name: cache_image
+    title: cache layer with image opts
+    sources: [cache_image]
 
 caches:
   utm_cache:
@@ -52,6 +55,14 @@ caches:
     grids: [gk3]
     disable_storage: true
     sources: [utm_cache]
+  cache_image:
+    grids: [GLOBAL_WEBMERCATOR, wmts_incompatible_grid, crs84quad]
+    sources: [wms_source]
+    image:
+      mode: P
+      transparent: true
+      encoding_options:
+        quantizer: fastoctree
 
 sources:
   wms_source:

--- a/mapproxy/test/system/test_multi_cache_layers.py
+++ b/mapproxy/test/system/test_multi_cache_layers.py
@@ -68,6 +68,10 @@ class TestMultiCacheLayer(SysTest):
             ),
         )
 
+    def test_image_config(self, app):
+        resp = app.get("/tms/1.0.0/")
+        assert "http://localhost/tms/1.0.0/cache_image/EPSG25832" in resp
+
     def test_tms_capabilities(self, app):
         resp = app.get("/tms/1.0.0/")
         assert "http://localhost/tms/1.0.0/multi_cache/EPSG25832" in resp
@@ -76,7 +80,7 @@ class TestMultiCacheLayer(SysTest):
         assert "http://localhost/tms/1.0.0/multi_cache/EPSG31467" in resp
         assert "http://localhost/tms/1.0.0/cache/EPSG25832" in resp
         xml = resp.lxml
-        assert xml.xpath("count(//TileMap)") == 5
+        assert xml.xpath("count(//TileMap)") == 8
 
     def test_wmts_capabilities(self, app):
         req = str(self.common_cap_req)
@@ -89,7 +93,7 @@ class TestMultiCacheLayer(SysTest):
         )
         assert set(
             xml.xpath("//wmts:Layer/ows:Identifier/text()", namespaces=ns_wmts)
-        ) == set(["cache", "multi_cache"])
+        ) == set(["cache", "multi_cache", "cache_image"])
         assert set(
             xml.xpath(
                 "//wmts:Contents/wmts:TileMatrixSet/ows:Identifier/text()",
@@ -111,7 +115,7 @@ class TestMultiCacheLayer(SysTest):
         )
 
         layer_names = set(xml.xpath("//Layer/Layer/Name/text()"))
-        expected_names = set(["wms_only", "cache"])
+        expected_names = set(["wms_only", "cache", "cache_image"])
         assert layer_names == expected_names
 
     def test_get_tile_webmerc(self, app):


### PR DESCRIPTION
When configuring two WMS sources with transparent image options and two caches, requesting with an empty cache will result in proper merged transparent images. Once the cache contains the (properly stored transparent) tiles the merge will result in the tiles not being transparent any more as the `ImageSource` instances are created without `image_opts`.

If image options are configured on file caches they were only used to determine the file format to store the tiles. This PR changes that to also pass the image options to the `ImageSource` instances, resulting in proper behaviour when merging images.
