### PR TITLE
Docker configuration hardening 

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,45 @@
+name: build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Manual supplied image tag like 1.16.0'
+        required: true
+        type: string
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build and push nginx image
+        uses: docker/build-push-action@v5
+        if: ${{ inputs.tags }}
+        with:
+          context: docker/
+          file: ./docker/Dockerfile
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ inputs.tags }}
+          target: nginx
+          tags: |
+            ghcr.io/${{ github.repository }}/mapproxy:${{ inputs.tags }}
+          platforms: linux/amd64,linux/arm64
+      - name: Run trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          format: 'table'
+          ignore-unfixed: true
+          image-ref: 'ghcr.io/${{ github.repository }}/mapproxy:${{ inputs.tags }}'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nosetests*.xml
 .tox/
 
 .idea/
+*.iml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.10-slim-bullseye AS base
+FROM python:3.10-slim-bookworm AS base
+
+LABEL maintainer="mapproxy.org"
 
 # The MAPPROXY_VERSION argument can be used like this to overwrite the default:
 # docker build --build-arg MAPPROXY_VERSION=1.15.1 [--target base|development|nginx] -t mapproxy:1.15.1 .
-ARG MAPPROXY_VERSION=1.15.1
+ARG MAPPROXY_VERSION=1.16.0
 
 RUN apt update && apt -y install --no-install-recommends \
   python3-pil \

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -4,6 +4,17 @@ upstream mapproxy {
 server {
     listen 80;
 
+    # Setting a keep-alive timeout on the server side helps in mitigation of DOS attacks
+    keepalive_timeout 10;
+
+    # Setting the send_timeout directive on the server side helps mitigate slow HTTP denial of
+    # service attacks
+    send_timeout 10;
+
+    # Hiding the version will slow down and deter some potential attackers since nginx version number is not visible
+    # for them
+    server_tokens off;
+
     root /var/www/html/;
 
     location /mapproxy/ {
@@ -11,5 +22,10 @@ server {
         uwsgi_param SCRIPT_NAME /mapproxy;
         uwsgi_pass mapproxy;
         include uwsgi_params;
+
+        # The server and x-powered-by header specify the version of the nginx => Do not show this information
+        # of the server to potential attackers
+        proxy_hide_header X-Powered-By;
+        proxy_hide_header Server;
     }
 }


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

This PR introduces some hardening of the Docker / NGinx configuration. In particular:

* Add an action that performs a trivy security scan on for base docker image (e.g.  `ghcr.io/mapproxy/mapproxy/mapproxy:2.0.0`) for tagged releases
* Update debian base image to `bookworm`: This will reduce the number of CVEs significantly, for example in the `nginx-image`:
   *  `docker run -it --rm ghcr.io/aquasecurity/trivy:canary image --severity CRITICAL,HIGH --report all ghcr.io/mapproxy/mapproxy/mapproxy:1.16.0`
   Result `Total: 253 (HIGH: 225, CRITICAL: 28)`
  * the updated image (local build)
   Result: `Total: 63 (HIGH: 61, CRITICAL: 2)`
* Apply some of recommendations listed in the CIS NGINX Benchmarks (see also https://www.cisecurity.org/cis-benchmarks), e.g.
  * hide server information (nginx version in headers…)
  * set proper values for timeouts