### PR TITLE
Docker: introduce alpine based image for MapProxy

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -70,6 +70,34 @@ jobs:
             ghcr.io/${{ github.repository }}/mapproxy:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Build and push base alpine image
+        uses: docker/build-push-action@v5
+        if: ${{ inputs.tags }}
+        with:
+          context: docker/
+          file: ./docker/Dockerfile-alpine
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ inputs.tags }}
+          target: base
+          tags: |
+            ghcr.io/${{ github.repository }}/mapproxy:${{ inputs.tags }}-alpine
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push base alpine image
+        uses: docker/build-push-action@v5
+        if: ${{ !inputs.tags }}
+        with:
+          context: docker/
+          file: ./docker/Dockerfile-alpine
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          target: base
+          tags: |
+            ghcr.io/${{ github.repository }}/mapproxy:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-alpine
+          platforms: linux/amd64,linux/arm64
+
       - name: Build and push development image
         uses: docker/build-push-action@v5
         if: ${{ inputs.tags }}
@@ -124,4 +152,32 @@ jobs:
           target: nginx
           tags: |
             ghcr.io/${{ github.repository }}/mapproxy:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-nginx
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push alpine based nginx image
+        uses: docker/build-push-action@v5
+        if: ${{ inputs.tags }}
+        with:
+          context: docker/
+          file: ./docker/Dockerfile-alpine
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ inputs.tags }}
+          target: nginx
+          tags: |
+            ghcr.io/${{ github.repository }}/mapproxy:${{ inputs.tags }}-alpine-nginx
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push alpine based nginx image
+        uses: docker/build-push-action@v5
+        if: ${{ !inputs.tags }}
+        with:
+          context: docker/
+          file: ./docker/Dockerfile-alpine
+          push: true
+          build-args: |
+            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          target: nginx
+          tags: |
+            ghcr.io/${{ github.repository }}/mapproxy:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-alpine-nginx
           platforms: linux/amd64,linux/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nosetests*.xml
 .tox/
 
 .idea/
+*.iml

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -33,7 +33,7 @@ ENTRYPOINT ["sh", "-c", "/start_alpine.sh development"]
 FROM base AS nginx
 
 # use current version of nginx
-ENV NGINX_VERSION=1.25.3
+ARG NGINX_VERSION=1.25.3
 
 RUN \
   apk --no-cache add build-base linux-headers openssl-dev pcre-dev wget zlib-dev ca-certificates uwsgi uwsgi-python3 supervisor && \

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,0 +1,70 @@
+FROM python:3.11-alpine AS base
+
+LABEL maintainer="mapproxy.org"
+
+# The MAPPROXY_VERSION argument can be used like this to overwrite the default:
+# docker build -f Dockerfile-alpine --build-arg MAPPROXY_VERSION=1.16.0 [--target base|development|nginx] -t mapproxy-alpine:1.16.0 .
+ARG MAPPROXY_VERSION=1.16.0
+
+RUN apk -U upgrade --update \
+    && apk add g++ py3-pip gdal gdal-dev gdal gdal-dev libxslt-dev libxml2 proj proj-dev proj-util geos geos-dev \
+    && rm -rf /var/cache/apk/* \
+    && pip install numpy pillow pyyaml pyproj lxml shapely \
+    && pip install MapProxy==$MAPPROXY_VERSION
+
+RUN mkdir /mapproxy
+
+WORKDIR /mapproxy
+
+COPY app.py .
+
+COPY start_alpine.sh /start_alpine.sh
+
+ENTRYPOINT ["sh", "-c", "/start_alpine.sh base"]
+
+###### development image ######
+FROM base AS development
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "/start_alpine.sh development"]
+
+##### nginx image ######
+FROM base AS nginx
+
+# use current version of nginx
+ENV NGINX_VERSION=1.25.3
+
+RUN \
+  apk --no-cache add build-base linux-headers openssl-dev pcre-dev wget zlib-dev ca-certificates uwsgi uwsgi-python3 supervisor && \
+  pip install uwsgi && \
+  cd /tmp && \
+  wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
+  tar xzf nginx-${NGINX_VERSION}.tar.gz && \
+  cd /tmp/nginx-${NGINX_VERSION} && \
+  ./configure \
+    --prefix=/etc/nginx \
+    --sbin-path=/usr/sbin/nginx \
+    --conf-path=/etc/nginx/nginx.conf \
+    --error-log-path=/var/log/nginx/error.log \
+    --http-log-path=/var/log/nginx/access.log \
+    --pid-path=/var/run/nginx.pid \
+    --lock-path=/var/run/nginx.lock \
+    --http-client-body-temp-path=/var/cache/nginx/client_temp \
+    --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+    --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+    --user=mapproxy \
+    --group=mapproxy && \
+  make && \
+  make install && \
+  sed -i -e 's/#access_log  logs\/access.log  main;/access_log \/dev\/stdout;/' -e 's/#error_log  logs\/error.log  notice;/error_log stderr notice;/' /etc/nginx/nginx.conf && \
+  rm -rf /tmp/* && \
+  apk del build-base linux-headers openssl-dev pcre-dev wget zlib-dev && \
+  rm -rf /var/cache/apk/*
+
+COPY uwsgi.conf .
+COPY nginx-alpine-default.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+
+ENTRYPOINT ["sh", "-c", "/start_alpine.sh nginx"]

--- a/docker/nginx-alpine-default.conf
+++ b/docker/nginx-alpine-default.conf
@@ -1,0 +1,31 @@
+events {}
+http {
+    server {
+        listen 80;
+
+        # Setting a keep-alive timeout on the server side helps mitigate denial of service attacks
+        keepalive_timeout 10;
+
+        # Setting the send_timeout directive on the server side helps mitigate slow HTTP denial of
+        # service attacks
+        send_timeout 10;
+
+        # Hiding the version will slow down and deter some potential attackers since nginx version number is not visible
+        # for them
+        server_tokens off;
+
+        root /var/www/html/;
+
+        location /mapproxy/ {
+            rewrite /mapproxy/(.+) /$1 break;
+            uwsgi_param SCRIPT_NAME /mapproxy;
+            uwsgi_pass 0.0.0.0:8080;
+            include uwsgi_params;
+
+            # The server and x-powered-by header specify the version of the nginx => Do not show this information
+            # of the server to potential attackers
+            proxy_hide_header X-Powered-By;
+            proxy_hide_header Server;
+        }
+    }
+}

--- a/docker/start_alpine.sh
+++ b/docker/start_alpine.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+TARGET=$1
+done=0
+trap 'done=1' TERM INT
+cd /mapproxy
+
+addgroup -S mapproxy && \
+  adduser -D -s /bin/sh -S -h /mapproxy/ -G mapproxy mapproxy && \
+  mkdir -p /var/cache/nginx/ /mapproxy/config/cache_data/ && \
+  chown -R mapproxy:mapproxy /mapproxy/config/ /var/cache/nginx/
+
+# create config files if they do not exist yet
+if [ ! -f /mapproxy/config/mapproxy.yaml ]; then
+  echo "No mapproxy configuration found. Creating one from template."
+  mapproxy-util create -t base-config config
+fi
+
+if [ "$TARGET" = "nginx" ]; then
+  su mapproxy -c "uwsgi --ini /mapproxy/uwsgi.conf --uid mapproxy &"
+  nginx &
+elif [ "$TARGET" = 'development' ]; then
+  su mapproxy -c "mapproxy-util serve-develop -b 0.0.0.0 /mapproxy/config/mapproxy.yaml &"
+else
+  echo "No-op container started. Overwrite ENTRYPOINT with needed mapproxy command."
+  su mapproxy -c "sleep infinity &"
+fi
+
+while [ $done = 0 ]; do
+  sleep 1 &
+  wait
+done


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

In this PR an Alpine based version of the Docker image is provided as a more lightweight alternative to the Debian based images. In comparison, the average image size could be reduced by ~30%.

![image](https://github.com/mapproxy/mapproxy/assets/10559603/b84c0ff0-f146-4be3-baaf-1cb7443326f4)


Since no current version of NGinx is available within the official Alpine repository, The NGinx executable (only for build target `nginx`) is built and installed additionally. The version can be overwritten in the build using the parameter `NGINX_VERSION`.
The NGinx configuration already contains the changes from https://github.com/mapproxy/mapproxy/pull/835
