### PR TITLE
Only test multiline messages with FreeType

### DIFF
--- a/mapproxy/test/unit/test_image_messages.py
+++ b/mapproxy/test/unit/test_image_messages.py
@@ -23,9 +23,13 @@ from mapproxy.image.message import TextDraw, message_image
 from mapproxy.image.opts import ImageOptions
 from mapproxy.tilefilter import watermark_filter
 
+import pytest
 
 PNG_FORMAT = ImageOptions(format="image/png")
 
+requires_freetype = pytest.mark.skipif(
+    not isinstance(ImageFont.load_default(), ImageFont.FreeTypeFont),
+    reason="Test expects the default Pillow FreeTypeFont")
 
 class TestTextDraw(object):
 
@@ -38,6 +42,7 @@ class TestTextDraw(object):
         assert total_box == boxes[0]
         assert len(boxes) == 1
 
+    @requires_freetype
     def test_multiline_ul(self):
         font = ImageFont.load_default()
         td = TextDraw("Hello\nWorld", font)
@@ -47,6 +52,7 @@ class TestTextDraw(object):
         assert total_box == (5, 7, 33, 28)
         assert boxes == [(5, 7, 30, 15), (5, 20, 33, 28)]
 
+    @requires_freetype
     def test_multiline_lr(self):
         font = ImageFont.load_default()
         td = TextDraw("Hello\nWorld", font, placement="lr")
@@ -56,6 +62,7 @@ class TestTextDraw(object):
         assert total_box == (67, 76, 95, 97)
         assert boxes == [(67, 76, 92, 84), (67, 89, 95, 97)]
 
+    @requires_freetype
     def test_multiline_center(self):
         font = ImageFont.load_default()
         td = TextDraw("Hello\nWorld", font, placement="cc")
@@ -65,6 +72,7 @@ class TestTextDraw(object):
         assert total_box == (36, 42, 64, 63)
         assert boxes == [(36, 42, 61, 50), (36, 55, 64, 63)]
 
+    @requires_freetype
     def test_unicode(self):
         font = ImageFont.load_default()
         td = TextDraw(u"Héllö\nWørld", font, placement="cc")
@@ -124,6 +132,7 @@ class TestMessageImage(object):
             15000,
         ]
 
+    @requires_freetype
     def test_message(self):
         image_opts = PNG_FORMAT.copy()
         image_opts.bgcolor = "#113399"


### PR DESCRIPTION
As a followup to https://github.com/mapproxy/mapproxy/pull/755#issuecomment-1780844465 these tests fail now on platforms, which cannot provide the new default Pillow FreeTypeFont.

Example for aarch64 on openSUSE-Tumbleweed:

```python
[   47s] =================================== FAILURES ===================================
[   47s] ________________________ TestTextDraw.test_multiline_ul ________________________
[   47s] 
[   47s] self = <mapproxy.test.unit.test_image_messages.TestTextDraw object at 0xffff91dcfc50>
[   47s] 
[   47s]     def test_multiline_ul(self):
[   47s]         font = ImageFont.load_default()
[   47s]         td = TextDraw("Hello\nWorld", font)
[   47s]         img = Image.new("RGB", (100, 100))
[   47s]         draw = ImageDraw.Draw(img)
[   47s]         total_box, boxes = td.text_boxes(draw, (100, 100))
[   47s] >       assert total_box == (5, 7, 33, 28)
[   47s] E       assert (5, 5, 35, 30) == (5, 7, 33, 28)
[   47s] E         At index 1 diff: 5 != 7
[   47s] E         Full diff:
[   47s] E         - (5, 7, 33, 28)
[   47s] E         + (5, 5, 35, 30)
[   47s] 
[   47s] mapproxy/test/unit/test_image_messages.py:47: AssertionError
[   47s] ________________________ TestTextDraw.test_multiline_lr ________________________
[   47s] 
[   47s] self = <mapproxy.test.unit.test_image_messages.TestTextDraw object at 0xffff91dcd710>
[   47s] 
[   47s]     def test_multiline_lr(self):
[   47s]         font = ImageFont.load_default()
[   47s]         td = TextDraw("Hello\nWorld", font, placement="lr")
[   47s]         img = Image.new("RGB", (100, 100))
[   47s]         draw = ImageDraw.Draw(img)
[   47s]         total_box, boxes = td.text_boxes(draw, (100, 100))
[   47s] >       assert total_box == (67, 76, 95, 97)
[   47s] E       assert (65, 70, 95, 95) == (67, 76, 95, 97)
[   47s] E         At index 0 diff: 65 != 67
[   47s] E         Full diff:
[   47s] E         - (67, 76, 95, 97)
[   47s] E         + (65, 70, 95, 95)
[   47s] 
[   47s] mapproxy/test/unit/test_image_messages.py:56: AssertionError
[   47s] ______________________ TestTextDraw.test_multiline_center ______________________
[   47s] 
[   47s] self = <mapproxy.test.unit.test_image_messages.TestTextDraw object at 0xffff91dce5d0>
[   47s] 
[   47s]     def test_multiline_center(self):
[   47s]         font = ImageFont.load_default()
[   47s]         td = TextDraw("Hello\nWorld", font, placement="cc")
[   47s]         img = Image.new("RGB", (100, 100))
[   47s]         draw = ImageDraw.Draw(img)
[   47s]         total_box, boxes = td.text_boxes(draw, (100, 100))
[   47s] >       assert total_box == (36, 42, 64, 63)
[   47s] E       assert (35, 38, 65, 63) == (36, 42, 64, 63)
[   47s] E         At index 0 diff: 35 != 36
[   47s] E         Full diff:
[   47s] E         - (36, 42, 64, 63)
[   47s] E         + (35, 38, 65, 63)
[   47s] 
[   47s] mapproxy/test/unit/test_image_messages.py:65: AssertionError
[   47s] __________________________ TestTextDraw.test_unicode ___________________________
[   47s] 
[   47s] self = <mapproxy.test.unit.test_image_messages.TestTextDraw object at 0xffff91dccf10>
[   47s] 
[   47s]     def test_unicode(self):
[   47s]         font = ImageFont.load_default()
[   47s]         td = TextDraw(u"HÃ©llÃ¶\nWÃ¸rld", font, placement="cc")
[   47s]         img = Image.new("RGB", (100, 100))
[   47s]         draw = ImageDraw.Draw(img)
[   47s]         total_box, boxes = td.text_boxes(draw, (100, 100))
[   47s] >       assert total_box == (36, 42, 64, 63)
[   47s] E       assert (35, 38, 65, 63) == (36, 42, 64, 63)
[   47s] E         At index 0 diff: 35 != 36
[   47s] E         Full diff:
[   47s] E         - (36, 42, 64, 63)
[   47s] E         + (35, 38, 65, 63)
[   47s] 
[   47s] mapproxy/test/unit/test_image_messages.py:74: AssertionError
[   47s] ________________________ TestMessageImage.test_message _________________________
[   47s] 
[   47s] self = <mapproxy.test.unit.test_image_messages.TestMessageImage object at 0xffff90f69f10>
[   47s] 
[   47s]     def test_message(self):
[   47s]         image_opts = PNG_FORMAT.copy()
[   47s]         image_opts.bgcolor = "#113399"
[   47s]         img = message_image("test", size=(100, 150), image_opts=image_opts)
[   47s]         text_pixels = 75
[   47s]         image_pixels = 100 * 150
[   47s]         assert isinstance(img, ImageSource)
[   47s]         assert img.size == (100, 150)
[   47s]         # expect the large histogram count values to be the amount of background pixels
[   47s] >       assert [x for x in img.as_image().histogram() if x > 10] == [
[   47s]             image_pixels - text_pixels,
[   47s]             image_pixels - text_pixels,
[   47s]             image_pixels - text_pixels,
[   47s]         ]
[   47s] E       assert [14923, 77, 14923, 77, 14923, 77] == [14925, 14925, 14925]
[   47s] E         At index 0 diff: 14923 != 14925
[   47s] E         Left contains 3 more items, first extra item: 77
[   47s] E         Full diff:
[   47s] E         - [14925, 14925, 14925]
[   47s] E         + [14923, 77, 14923, 77, 14923, 77]
[   47s] 
[   47s] mapproxy/test/unit/test_image_messages.py:136: AssertionError
```