### PR TITLE
fix: raise more specific error if trying to parse WMTS capabilities

### DIFF
--- a/mapproxy/script/conf/app.py
+++ b/mapproxy/script/conf/app.py
@@ -147,7 +147,7 @@ def config_command(args):
             cap = parse_capabilities(BytesIO(cap_doc))
         except (xml.etree.ElementTree.ParseError, ValueError) as ex:
             print(ex, file=sys.stderr)
-            print(cap_doc[:1000] + ('...' if len(cap_doc) > 1000 else ''), file=sys.stderr)
+            print(f"{cap_doc[:1000]} {'...' if len(cap_doc) > 1000 else ''}", file=sys.stderr)
             return 3
     elif gpkg:
         if os.path.isfile(gpkg):

--- a/mapproxy/util/ext/wmsparse/parse.py
+++ b/mapproxy/util/ext/wmsparse/parse.py
@@ -295,8 +295,10 @@ def parse_capabilities(fileobj):
         return WMS111Capabilities(tree)
     elif root_tag == '{http://www.opengis.net/wms}WMS_Capabilities':
         return WMS130Capabilities(tree)
+    elif root_tag.startswith('{http://www.opengis.net/wmts'):
+        raise ValueError('Parsing of WMTS capabilities is not supported')
     else:
-        raise ValueError('unknown start tag in capabilities: ' + root_tag)
+        raise ValueError(f'Unknown start tag in capabilities: {root_tag}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
