### PR TITLE
examples: replace old Omniscale service and metadata from examples/tests with dummy values

### DIFF
--- a/doc/configuration_examples.rst
+++ b/doc/configuration_examples.rst
@@ -179,7 +179,7 @@ The basic configuration for this use-case with MapProxy may look like this::
   sources:
     street_tile_source:
       type: tile
-      url: http://osm.omniscale.net/proxy/tiles/ \
+      url: http://example.org/tiles/ \
         1.0.0/osm_roads_EPSG900913/%(z)s/%(x)s/%(y)s.png
       transparent: true
 
@@ -218,7 +218,7 @@ You can change how MapProxy calculates the origin of the tile coordinates, if yo
 The following example uses the class OpenLayers.Layer.OSM::
 
     var overlay_layer = new OpenLayers.Layer.OSM("OSM osm_layer",
-        "http://x.osm.omniscale.net/proxy/tiles/ \
+        "http://example.org/tiles/ \
         osm_roads_EPSG900913/${z}/${x}/${y}.png?origin=nw",
         {isBaseLayer: false, tileOptions: {crossOriginKeyword: null}}
     );

--- a/doc/mapproxy_util.rst
+++ b/doc/mapproxy_util.rst
@@ -255,7 +255,7 @@ With the following MapProxy layer configuration:
 
   layers:
     - name: osm
-      title: Omniscale OSM WMS - osm.omniscale.net
+      title: My OSM Layer
       sources: [osm_cache]
     - name: foo
       title: Group Layer
@@ -288,7 +288,7 @@ Parsed capabilities document:
       llbbox: [-180.0, -85.0511287798, 180.0, 85.0511287798]
       layers:
         - name: osm
-          title: Omniscale OSM WMS - osm.omniscale.net
+          title: My OSM Layer
           url: http://127.0.0.1:8080/service?
           opaque: False
           srs: ['EPSG:31467', 'EPSG:31466', 'EPSG:25832', 'EPSG:25831', 'EPSG:25833',

--- a/doc/mapproxy_util_autoconfig.rst
+++ b/doc/mapproxy_util_autoconfig.rst
@@ -61,19 +61,19 @@ Example
 Print configuration on console::
 
     mapproxy-util autoconfig \
-        --capabilities http://osm.omniscale.net/proxy/service
+        --capabilities http://example.org/service
 
 Write MapProxy and MapProxy-seeding configuration to files::
 
     mapproxy-util autoconfig \
-        --capabilities http://osm.omniscale.net/proxy/service \
+        --capabilities http://example.org/service \
         --output mapproxy.yaml \
         --output-seed seed.yaml
 
 Write MapProxy configuration with caches for grids from ``base.yaml``::
 
     mapproxy-util autoconfig \
-        --capabilities http://osm.omniscale.net/proxy/service \
+        --capabilities http://example.org/service \
         --output mapproxy.yaml \
         --base base.yaml
 

--- a/doc/test.html
+++ b/doc/test.html
@@ -23,13 +23,13 @@
 
 
 
-        // var overlay_layer = new OpenLayers.Layer.TMS('TMS street_layer', 'http://x.osm.omniscale.net/proxy/tiles/',
+        // var overlay_layer = new OpenLayers.Layer.TMS('TMS street_layer', 'http://127.0.0.1:8080/tiles/',
         //     {layername: 'osm_roads_EPSG900913', type: 'png',
         //      isBaseLayer: false
         // });
 
         var overlay_layer = new OpenLayers.Layer.OSM("OSM osm_layer",
-            "http://x.osm.omniscale.net/proxy/tiles/osm_roads_EPSG900913/${z}/${x}/${y}.png?origin=nw",
+            "http://127.0.0.1:8080/tiles/osm_roads_EPSG900913/${z}/${x}/${y}.png?origin=nw",
             {isBaseLayer: false, tileOptions: {crossOriginKeyword: null}}
         );
 

--- a/doc/tutorial.yaml
+++ b/doc/tutorial.yaml
@@ -14,7 +14,7 @@ services:
             country: Germany
             phone: +49(0)000-000000-0
             fax: +49(0)000-000000-0
-            email: info@omniscale.de
+            email: email@example.org
         access_constraints:
             This service is intended for private and
             evaluation use only. The data is licensed
@@ -28,7 +28,7 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm
   #end source
 #start caches
@@ -69,12 +69,12 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm
   roads_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm_roads
       transparent: true
 
@@ -93,7 +93,7 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm
     coverage:
       bbox: [5.5, 47.4, 15.2, 54.8]

--- a/doc/yaml/cache_conf.yaml
+++ b/doc/yaml/cache_conf.yaml
@@ -15,7 +15,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       access_constraints:
         Insert license and copyright information for this service.
       fees: 'None'
@@ -24,7 +24,7 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm
 
 caches:

--- a/doc/yaml/grid_conf.yaml
+++ b/doc/yaml/grid_conf.yaml
@@ -15,7 +15,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       access_constraints:
         Insert license and copyright information for this service.
       fees: 'None'
@@ -24,7 +24,7 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm
 
 caches:

--- a/doc/yaml/merged_conf.yaml
+++ b/doc/yaml/merged_conf.yaml
@@ -15,7 +15,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       access_constraints:
         Insert license and copyright information for this service.
       fees: 'None'
@@ -24,12 +24,12 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service
       layers: osm
   roads_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service
       layers: osm_roads
       transparent: true
 

--- a/doc/yaml/meta_conf.yaml
+++ b/doc/yaml/meta_conf.yaml
@@ -15,7 +15,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       access_constraints:
         Insert license and copyright information for this service.
       fees: 'None'
@@ -24,7 +24,7 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service
       layers: osm
     coverage:
       bbox: [5.5, 47.4, 15.2, 54.8]

--- a/doc/yaml/simple_conf.yaml
+++ b/doc/yaml/simple_conf.yaml
@@ -15,7 +15,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       access_constraints:
         Insert license and copyright information for this service.
       fees: 'None'
@@ -24,7 +24,7 @@ sources:
   test_wms:
     type: wms
     req:
-      url: http://osm.omniscale.net/proxy/service?
+      url: http://example.org/service?
       layers: osm
 
 layers:

--- a/mapproxy/config_template/base_config/full_example.yaml
+++ b/mapproxy/config_template/base_config/full_example.yaml
@@ -47,7 +47,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       # multiline strings are possible with the right indention
       access_constraints:
         Insert license and copyright information for this service.
@@ -68,7 +68,7 @@ services:
 
     # add attribution text in the lower-right corner.
     attribution:
-      text: '(c) Omniscale'
+      text: '(c) Acme'
 
     # return an OGC service exception when one or more sources return errors
     # or no response at all (e.g. timeout)
@@ -101,7 +101,7 @@ services:
         country: Germany
         phone: +49(0)000-000000-0
         fax: +49(0)000-000000-0
-        email: info@omniscale.de
+        email: info@example.org
       # multiline strings are possible with the right indention
       access_constraints:
         Insert license and copyright information for this service.
@@ -110,12 +110,12 @@ services:
 layers:
   # layer with minimal options
   - name: osm
-    title: Omniscale OSM WMS - osm.omniscale.net
+    title: OSM
     sources: [osm_cache]
 
   # layer with multiple sources
   - name: merged_layer
-    title: Omniscale OSM WMS - osm.omniscale.net
+    title: OSM merged
     sources: [osm_cache, osm_cache_full_example]
 
   # these layers supports the GetLegendGraphicRequest
@@ -351,7 +351,7 @@ sources:
   osm_wms:
     type: wms
     req:
-      url: https://maps.omniscale.net/v2/demo/style.default/service?
+      url: http://example.org/service?
       layers: osm
 
   # WMS source for use with tagged sources

--- a/mapproxy/config_template/base_config/mapproxy.yaml
+++ b/mapproxy/config_template/base_config/mapproxy.yaml
@@ -38,7 +38,7 @@ services:
 
 layers:
   - name: osm
-    title: Omniscale OSM WMS - osm.omniscale.net
+    title: OSM
     sources: [osm_cache]
 
 caches:
@@ -50,7 +50,7 @@ sources:
   osm_wms:
     type: wms
     req:
-      url: https://maps.omniscale.net/v2/demo/style.default/service?
+      url: http://example.org/service?
       layers: osm
 
 grids:

--- a/mapproxy/test/system/fixture/coverage.yaml
+++ b/mapproxy/test/system/fixture/coverage.yaml
@@ -15,16 +15,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/demo.yaml
+++ b/mapproxy/test/system/fixture/demo.yaml
@@ -30,16 +30,16 @@ services:
         - keywords: [wmskey1,wmskey2,wmskey3]
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/formats.yaml
+++ b/mapproxy/test/system/fixture/formats.yaml
@@ -14,16 +14,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/inspire.yaml
+++ b/mapproxy/test/system/fixture/inspire.yaml
@@ -30,16 +30,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
     inspire_md:

--- a/mapproxy/test/system/fixture/inspire_full.yaml
+++ b/mapproxy/test/system/fixture/inspire_full.yaml
@@ -30,16 +30,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
       keyword_list:

--- a/mapproxy/test/system/fixture/layer.yaml
+++ b/mapproxy/test/system/fixture/layer.yaml
@@ -36,16 +36,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/legendgraphic.yaml
+++ b/mapproxy/test/system/fixture/legendgraphic.yaml
@@ -15,16 +15,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/mixed_mode.yaml
+++ b/mapproxy/test/system/fixture/mixed_mode.yaml
@@ -15,16 +15,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/multi_cache_layers.yaml
+++ b/mapproxy/test/system/fixture/multi_cache_layers.yaml
@@ -18,16 +18,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
 
 layers:
   - name: multi_cache

--- a/mapproxy/test/system/fixture/scalehints.yaml
+++ b/mapproxy/test/system/fixture/scalehints.yaml
@@ -15,16 +15,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/seedonly.yaml
+++ b/mapproxy/test/system/fixture/seedonly.yaml
@@ -15,16 +15,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/util-conf-wms-111-cap.xml
+++ b/mapproxy/test/system/fixture/util-conf-wms-111-cap.xml
@@ -6,26 +6,26 @@
 <WMT_MS_Capabilities version="1.1.1">
 <Service>
   <Name>OGC:WMS</Name>
-  <Title>Omniscale OpenStreetMap WMS</Title>
-  <Abstract>Omniscale OpenStreetMap WMS (powered by MapProxy)</Abstract>
-  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://omniscale.de/"/>
+  <Title>ACME OpenStreetMap WMS</Title>
+  <Abstract>ACME OpenStreetMap WMS (powered by MapProxy)</Abstract>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/"/>
   <ContactInformation>
       <ContactPersonPrimary>
-        <ContactPerson>Oliver Tonnhofer</ContactPerson>
-        <ContactOrganization>Omniscale</ContactOrganization>
+        <ContactPerson>Bob Mustermann</ContactPerson>
+        <ContactOrganization>ACME</ContactOrganization>
       </ContactPersonPrimary>
       <ContactPosition>Technical Director</ContactPosition>
       <ContactAddress>
         <AddressType>postal</AddressType>
-        <Address>Nadorster Str. 60</Address>
-        <City>Oldenburg</City>
+        <Address>Fakestreet 123</Address>
+        <City>Fakecity</City>
         <StateOrProvince></StateOrProvince>
-        <PostCode>26123</PostCode>
+        <PostCode>12345</PostCode>
         <Country>Germany</Country>
       </ContactAddress>
-      <ContactVoiceTelephone>+49(0)441-9392774-0</ContactVoiceTelephone>
-      <ContactFacsimileTelephone>+49(0)441-9392774-9</ContactFacsimileTelephone>
-      <ContactElectronicMailAddress>osm@omniscale.de</ContactElectronicMailAddress>
+      <ContactVoiceTelephone>0123456789</ContactVoiceTelephone>
+      <ContactFacsimileTelephone>0123456789</ContactFacsimileTelephone>
+      <ContactElectronicMailAddress>info@example.org</ContactElectronicMailAddress>
   </ContactInformation>
   <Fees>none</Fees>
   <AccessConstraints>Here be dragons.</AccessConstraints>
@@ -36,7 +36,7 @@
       <Format>application/vnd.ogc.wms_xml</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetCapabilities>
@@ -48,7 +48,7 @@
         <Format>image/tiff</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetMap>
@@ -58,7 +58,7 @@
       <Format>application/vnd.ogc.gml</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetFeatureInfo>
@@ -69,7 +69,7 @@
     <Format>application/vnd.ogc.se_blank</Format>
   </Exception>
   <Layer>
-    <Title>Omniscale OpenStreetMap WMS</Title>
+    <Title>ACME OpenStreetMap WMS</Title>
     <SRS>EPSG:4326 EPSG:4258 CRS:84 EPSG:900913 EPSG:31466 EPSG:31467 EPSG:31468 EPSG:25831 EPSG:25832 EPSG:25833 EPSG:3857</SRS>
     <LatLonBoundingBox minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798" />
     <BoundingBox SRS="EPSG:4326" minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798" />

--- a/mapproxy/test/system/fixture/util_wms_capabilities111.xml
+++ b/mapproxy/test/system/fixture/util_wms_capabilities111.xml
@@ -25,7 +25,7 @@
       </ContactAddress>
       <ContactVoiceTelephone>+49(0)000-000000-0</ContactVoiceTelephone>
       <ContactFacsimileTelephone>+49(0)000-000000-0</ContactFacsimileTelephone>
-      <ContactElectronicMailAddress>info@omniscale.de</ContactElectronicMailAddress>
+      <ContactElectronicMailAddress>info@example.org</ContactElectronicMailAddress>
   </ContactInformation>
   <Fees>None</Fees>
   <AccessConstraints>Here be dragons.</AccessConstraints>
@@ -85,7 +85,7 @@
     <BoundingBox SRS="EPSG:4326" minx="-180.0" miny="-85.0511287798" maxx="180.0" maxy="85.0511287798" />
     <Layer>
       <Name>osm</Name>
-      <Title>Omniscale OSM WMS - osm.omniscale.net</Title>
+      <Title>ACME OSM WMS</Title>
       <LatLonBoundingBox minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798" />
       <BoundingBox SRS="EPSG:900913" minx="-20037508.3428" miny="-20037508.3428" maxx="20037508.3428" maxy="20037508.3428" />
       <BoundingBox SRS="EPSG:4326" minx="-180.0" miny="-85.0511287798" maxx="180.0" maxy="85.0511287798" />

--- a/mapproxy/test/system/fixture/util_wms_capabilities130.xml
+++ b/mapproxy/test/system/fixture/util_wms_capabilities130.xml
@@ -21,7 +21,7 @@
       </ContactAddress>
       <ContactVoiceTelephone>+49(0)000-000000-0</ContactVoiceTelephone>
       <ContactFacsimileTelephone>+49(0)000-000000-0</ContactFacsimileTelephone>
-      <ContactElectronicMailAddress>info@omniscale.de</ContactElectronicMailAddress>
+      <ContactElectronicMailAddress>info@example.org</ContactElectronicMailAddress>
   </ContactInformation>
     <Fees>None</Fees>
     <AccessConstraints>Here be dragons.</AccessConstraints>
@@ -83,7 +83,7 @@
     <BoundingBox CRS="EPSG:3857" minx="-20037508.3428" miny="-20037508.3428" maxx="20037508.3428" maxy="20037508.3428" />
     <Layer>
       <Name>osm</Name>
-      <Title>Omniscale OSM WMS - osm.omniscale.net</Title>
+      <Title>ACME OSM WMS</Title>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>-180</westBoundLongitude>
         <eastBoundLongitude>180</eastBoundLongitude>

--- a/mapproxy/test/system/fixture/wms_versions.yaml
+++ b/mapproxy/test/system/fixture/wms_versions.yaml
@@ -12,16 +12,16 @@ services:
       abstract: This is MapProxy.
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/fixture/wmts.yaml
+++ b/mapproxy/test/system/fixture/wmts.yaml
@@ -29,16 +29,16 @@ services:
         - keywords: [wmskey1,wmskey2,wmskey3]
       online_resource: http://mapproxy.org/
       contact:
-        person: Oliver Tonnhofer
+        person: Bob Mustermann
         position: Technical Director
-        organization: Omniscale
-        address: Nadorster Str. 60
-        city: Oldenburg
-        postcode: 26123
+        organisation: Acme
+        address: Fakestreet 123
+        city: Fakecity
+        postcode: 12345
         country: Germany
-        phone: +49(0)441-9392774-0
-        fax: +49(0)441-9392774-9
-        email: info@omniscale.de
+        phone: 0123456789
+        fax: 0123456789
+        email: info@example.org
       access_constraints:
         Here be dragons.
 

--- a/mapproxy/test/system/test_util_conf.py
+++ b/mapproxy/test/system/test_util_conf.py
@@ -104,7 +104,7 @@ class TestMapProxyConfCmd(object):
                     ],
                     "req": {
                         "layers": "osm_roads",
-                        "url": "http://osm.omniscale.net/proxy/service?",
+                        "url": "http://example.org/service",
                         "transparent": True,
                     },
                     "type": "wms",
@@ -129,7 +129,7 @@ class TestMapProxyConfCmd(object):
                     ],
                     "req": {
                         "layers": "osm",
-                        "url": "http://osm.omniscale.net/proxy/service?",
+                        "url": "http://example.org/service",
                         "transparent": True,
                     },
                     "type": "wms",
@@ -142,7 +142,7 @@ class TestMapProxyConfCmd(object):
 
             assert conf["layers"] == [
                 {
-                    "title": "Omniscale OpenStreetMap WMS",
+                    "title": "ACME OpenStreetMap WMS",
                     "layers": [
                         {
                             "name": "osm",
@@ -195,7 +195,7 @@ class TestMapProxyConfCmd(object):
 
             assert conf["layers"] == [
                 {
-                    "title": "Omniscale OpenStreetMap WMS",
+                    "title": "ACME OpenStreetMap WMS",
                     "layers": [
                         {
                             "name": "osm",
@@ -280,7 +280,7 @@ class TestMapProxyConfCmd(object):
                     "supported_srs": ["EPSG:3857"],
                     "req": {
                         "layers": "osm_roads",
-                        "url": "http://osm.omniscale.net/proxy/service?",
+                        "url": "http://example.org/service",
                         "transparent": True,
                         "param": 42,
                     },
@@ -303,7 +303,7 @@ class TestMapProxyConfCmd(object):
                     ],
                     "req": {
                         "layers": "osm",
-                        "url": "http://osm.omniscale.net/proxy/service?",
+                        "url": "http://example.org/service",
                         "transparent": True,
                         "param": 42,
                     },
@@ -330,7 +330,7 @@ class TestMapProxyConfCmd(object):
 
             assert conf["layers"] == [
                 {
-                    "title": "Omniscale OpenStreetMap WMS",
+                    "title": "ACME OpenStreetMap WMS",
                     "layers": [
                         {
                             "name": "osm",

--- a/mapproxy/util/ext/wmsparse/test/test_parse.py
+++ b/mapproxy/util/ext/wmsparse/test/test_parse.py
@@ -10,28 +10,28 @@ def local_filename(filename):
 class TestWMS111(object):
 
     def test_parse_metadata(self):
-        cap = parse_capabilities(local_filename("wms-omniscale-111.xml"))
+        cap = parse_capabilities(local_filename("wms-example-111.xml"))
         md = cap.metadata()
         assert md["name"] == "OGC:WMS"
-        assert md["title"] == "Omniscale OpenStreetMap WMS"
+        assert md["title"] == "ACME OpenStreetMap WMS"
         assert md["access_constraints"] == "Here be dragons."
         assert md["fees"] == "none"
-        assert md["online_resource"] == "http://omniscale.de/"
-        assert md["abstract"] == "Omniscale OpenStreetMap WMS (powered by MapProxy)"
+        assert md["online_resource"] == "http://example.org/"
+        assert md["abstract"] == "ACME OpenStreetMap WMS (powered by MapProxy)"
 
-        assert md["contact"]["person"] == "Oliver Tonnhofer"
-        assert md["contact"]["organization"] == "Omniscale"
+        assert md["contact"]["person"] == "Bob Mustermann"
+        assert md["contact"]["organization"] == "ACME"
         assert md["contact"]["position"] == "Technical Director"
-        assert md["contact"]["address"] == "Nadorster Str. 60"
-        assert md["contact"]["city"] == "Oldenburg"
-        assert md["contact"]["postcode"] == "26123"
+        assert md["contact"]["address"] == "Fakestreet 123"
+        assert md["contact"]["city"] == "Fakecity"
+        assert md["contact"]["postcode"] == "12345"
         assert md["contact"]["country"] == "Germany"
-        assert md["contact"]["phone"] == "+49(0)441-9392774-0"
-        assert md["contact"]["fax"] == "+49(0)441-9392774-9"
-        assert md["contact"]["email"] == "osm@omniscale.de"
+        assert md["contact"]["phone"] == "0123456789"
+        assert md["contact"]["fax"] == "0123456789"
+        assert md["contact"]["email"] == "info@example.org"
 
     def test_parse_layer(self):
-        cap = parse_capabilities(local_filename("wms-omniscale-111.xml"))
+        cap = parse_capabilities(local_filename("wms-example-111.xml"))
         lyrs = cap.layers_list()
         assert len(lyrs) == 2
         assert lyrs[0]["llbbox"] == [-180.0, -85.0511287798, 180.0, 85.0511287798]
@@ -64,16 +64,16 @@ class TestWMS111(object):
 class TestWMS130(object):
 
     def test_parse_metadata(self):
-        cap = parse_capabilities(local_filename("wms-omniscale-130.xml"))
+        cap = parse_capabilities(local_filename("wms-example-130.xml"))
         md = cap.metadata()
         assert md["name"] == "WMS"
-        assert md["title"] == "Omniscale OpenStreetMap WMS"
+        assert md["title"] == "ACME OpenStreetMap WMS"
 
         req = cap.requests()
-        assert req["GetMap"] == "http://osm.omniscale.net/proxy/service?"
+        assert req["GetMap"] == "http://example.org/service"
 
     def test_parse_layer(self):
-        cap = parse_capabilities(local_filename("wms-omniscale-130.xml"))
+        cap = parse_capabilities(local_filename("wms-example-130.xml"))
         lyrs = cap.layers_list()
         assert len(lyrs) == 2
         assert lyrs[0]["llbbox"] == [-180.0, -85.0511287798, 180.0, 85.0511287798]

--- a/mapproxy/util/ext/wmsparse/test/wms-example-111.xml
+++ b/mapproxy/util/ext/wmsparse/test/wms-example-111.xml
@@ -6,26 +6,26 @@
 <WMT_MS_Capabilities version="1.1.1">
 <Service>
   <Name>OGC:WMS</Name>
-  <Title>Omniscale OpenStreetMap WMS</Title>
-  <Abstract>Omniscale OpenStreetMap WMS (powered by MapProxy)</Abstract>
-  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://omniscale.de/"/>
+  <Title>ACME OpenStreetMap WMS</Title>
+  <Abstract>ACME OpenStreetMap WMS (powered by MapProxy)</Abstract>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/"/>
   <ContactInformation>
       <ContactPersonPrimary>
-        <ContactPerson>Oliver Tonnhofer</ContactPerson>
-        <ContactOrganization>Omniscale</ContactOrganization>
+        <ContactPerson>Bob Mustermann</ContactPerson>
+        <ContactOrganization>ACME</ContactOrganization>
       </ContactPersonPrimary>
       <ContactPosition>Technical Director</ContactPosition>
       <ContactAddress>
         <AddressType>postal</AddressType>
-        <Address>Nadorster Str. 60</Address>
-        <City>Oldenburg</City>
+        <Address>Fakestreet 123</Address>
+        <City>Fakecity</City>
         <StateOrProvince></StateOrProvince>
-        <PostCode>26123</PostCode>
+        <PostCode>12345</PostCode>
         <Country>Germany</Country>
       </ContactAddress>
-      <ContactVoiceTelephone>+49(0)441-9392774-0</ContactVoiceTelephone>
-      <ContactFacsimileTelephone>+49(0)441-9392774-9</ContactFacsimileTelephone>
-      <ContactElectronicMailAddress>osm@omniscale.de</ContactElectronicMailAddress>
+      <ContactVoiceTelephone>0123456789</ContactVoiceTelephone>
+      <ContactFacsimileTelephone>0123456789</ContactFacsimileTelephone>
+      <ContactElectronicMailAddress>info@example.org</ContactElectronicMailAddress>
   </ContactInformation>
   <Fees>none</Fees>
   <AccessConstraints>Here be dragons.</AccessConstraints>
@@ -36,7 +36,7 @@
       <Format>application/vnd.ogc.wms_xml</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetCapabilities>
@@ -48,7 +48,7 @@
         <Format>image/tiff</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetMap>
@@ -58,7 +58,7 @@
       <Format>application/vnd.ogc.gml</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetFeatureInfo>
@@ -69,7 +69,7 @@
     <Format>application/vnd.ogc.se_blank</Format>
   </Exception>
   <Layer>
-    <Title>Omniscale OpenStreetMap WMS</Title>
+    <Title>ACME OpenStreetMap WMS</Title>
     <SRS>EPSG:4326 EPSG:4258 CRS:84 EPSG:900913 EPSG:31466 EPSG:31467 EPSG:31468 EPSG:25831 EPSG:25832 EPSG:25833 EPSG:3857</SRS>
     <LatLonBoundingBox minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798" />
     <BoundingBox SRS="EPSG:4326" minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798" />

--- a/mapproxy/util/ext/wmsparse/test/wms-example-130.xml
+++ b/mapproxy/util/ext/wmsparse/test/wms-example-130.xml
@@ -2,26 +2,26 @@
 <WMS_Capabilities xmlns="http://www.opengis.net/wms" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
 <Service>
   <Name>WMS</Name>
-  <Title>Omniscale OpenStreetMap WMS</Title>
-  <Abstract>Omniscale OpenStreetMap WMS (powered by MapProxy)</Abstract>
-  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://omniscale.de/"/>
+  <Title>ACME OpenStreetMap WMS</Title>
+  <Abstract>ACME OpenStreetMap WMS (powered by MapProxy)</Abstract>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.org/"/>
   <ContactInformation>
       <ContactPersonPrimary>
-        <ContactPerson>Oliver Tonnhofer</ContactPerson>
-        <ContactOrganization>Omniscale</ContactOrganization>
+        <ContactPerson>Bob Mustermann</ContactPerson>
+        <ContactOrganization>ACME</ContactOrganization>
       </ContactPersonPrimary>
       <ContactPosition>Technical Director</ContactPosition>
       <ContactAddress>
         <AddressType>postal</AddressType>
-        <Address>Nadorster Str. 60</Address>
-        <City>Oldenburg</City>
+        <Address>Fakestreet 123</Address>
+        <City>Fakecity</City>
         <StateOrProvince></StateOrProvince>
-        <PostCode>26123</PostCode>
+        <PostCode>12345</PostCode>
         <Country>Germany</Country>
       </ContactAddress>
-      <ContactVoiceTelephone>+49(0)441-9392774-0</ContactVoiceTelephone>
-      <ContactFacsimileTelephone>+49(0)441-9392774-9</ContactFacsimileTelephone>
-      <ContactElectronicMailAddress>osm@omniscale.de</ContactElectronicMailAddress>
+      <ContactVoiceTelephone>0123456789</ContactVoiceTelephone>
+      <ContactFacsimileTelephone>0123456789</ContactFacsimileTelephone>
+      <ContactElectronicMailAddress>info@example.org</ContactElectronicMailAddress>
   </ContactInformation>
     <Fees>none</Fees>
     <AccessConstraints>This service is intended for private and evaluation use only. The data is licensed as Open Data Commons Open Database License (ODbL 1.0) (http://opendatacommons.org/licenses/odbl/1.0/)</AccessConstraints>
@@ -32,7 +32,7 @@
       <Format>text/xml</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetCapabilities>
@@ -44,7 +44,7 @@
       <Format>image/GeoTIFF</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetMap>
@@ -54,7 +54,7 @@
       <Format>text/xml</Format>
       <DCPType>
         <HTTP>
-          <Get><OnlineResource xlink:href="http://osm.omniscale.net/proxy/service?"/></Get>
+          <Get><OnlineResource xlink:href="http://example.org/service"/></Get>
         </HTTP>
       </DCPType>
     </GetFeatureInfo>
@@ -65,7 +65,7 @@
     <Format>BLANK</Format>
   </Exception>
   <Layer>
-    <Title>Omniscale OpenStreetMap WMS</Title>
+    <Title>ACME OpenStreetMap WMS</Title>
     <CRS>EPSG:4326</CRS>
     <CRS>EPSG:4258</CRS>
     <CRS>CRS:84</CRS>


### PR DESCRIPTION
Replaced old WMS service URLs and old metadata from all examples and test.