### PR TITLE
fixed title level inconsistancy

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -544,10 +544,7 @@ Explanation::
   refresh_before:
     mtime: path/to/file
 
-Example
-~~~~~~~~
-
-::
+Here is an example that refreshes tiles everyday::
 
    caches:
      osm_cache:


### PR DESCRIPTION
Documentation for ```refresh_before``` for caches (https://github.com/mapproxy/mapproxy/pull/518) is not showing up because of title level inconsistancy
