### PR TITLE
Fixed deprecated proj4 interface usage in source/mapnik.py

### DIFF
--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -231,7 +231,7 @@ class MapnikSource(MapLayer):
 
         m = self.map_obj(mapfile)
         m.resize(query.size[0], query.size[1])
-        m.srs = '+init=%s' % str(query.srs.srs_code.lower())
+        m.srs = str(query.srs.srs_code.lower())
         envelope = mapnik.Box2d(*query.bbox)
         m.zoom_to_box(envelope)
         data = None


### PR DESCRIPTION
Mapnik source on-the-fly reprojection used deprecated proj4 API for assigning mapnik.Map object's projection.

This behavior and the way to fix it is described in issue #538 

Debian package maintainers apply this fix with [one of patches](https://salsa.debian.org/debian-gis-team/mapproxy/-/blob/master/debian/patches/mapnik.patch?ref_type=heads) so that debian-based package works properly and does not fail to render mapnik sources. However it is not the case for installations based on source code (e.g. via pip)