### PR TITLE
ensure make_app returns valid MapProxyApp object

### DIFF
--- a/mapproxy/wsgiapp.py
+++ b/mapproxy/wsgiapp.py
@@ -49,7 +49,7 @@ def make_wsgi_app(services_conf=None, debug=False, ignore_config_warnings=True, 
 
     if reloader:
         def make_app():
-            make_wsgi_app(services_conf=services_conf, debug=debug, reloader=False)
+            return make_wsgi_app(services_conf=services_conf, debug=debug, reloader=False)
         return ReloaderApp(services_conf, make_app)
 
     try:


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
This PR adresses #888 and ensures a MapProxyApp object is returned by the wsgiapp. make_wsgi_app .make_app() function.