### PR TITLE
Add requires that are needed for the dev image to run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import pkg_resources
 
 install_requires = [
     'PyYAML>=3.0',
+    'future',
+    'pyproj>=2'
 ]
 
 def package_installed(pkg):


### PR DESCRIPTION
I do not know exactly if this is the desired way, but this seems to be needed in order to run the `-dev` image. The `-nginx` image seems to be a little more robust, but in my opinion this should not harm and will also get rid of the warning when starting the container (`Found libproj >=5. Using this library without pyproj is deprecated and not fully supported. Please install pyproj >= 2.`)

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
