### PR TITLE
Support passing request params to a source

### DIFF
--- a/mapproxy/cache/renderd.py
+++ b/mapproxy/cache/renderd.py
@@ -41,8 +41,8 @@ def has_renderd_support():
 
 
 class RenderdTileCreator(TileCreator):
-    def __init__(self, renderd_address, tile_mgr, dimensions=None, priority=100, tile_locker=None):
-        TileCreator.__init__(self, tile_mgr, dimensions)
+    def __init__(self, renderd_address, tile_mgr, dimensions=None, priority=100, tile_locker=None, extra_params=None):
+        TileCreator.__init__(self, tile_mgr, dimensions, extra_params)
         self.tile_locker = tile_locker.lock or self.tile_mgr.lock
         self.renderd_address = renderd_address
         self.priority = priority

--- a/mapproxy/client/tile.py
+++ b/mapproxy/client/tile.py
@@ -22,8 +22,8 @@ class TileClient(object):
         self.http_client = http_client
         self.grid = grid
 
-    def get_tile(self, tile_coord, format=None):
-        url = self.url_template.substitute(tile_coord, format, self.grid)
+    def get_tile(self, tile_coord, format=None, extra_params=None):
+        url = self.url_template.substitute(tile_coord, format, self.grid, extra_params)
         if self.http_client:
             return self.http_client.open_image(url)
         else:
@@ -66,7 +66,7 @@ class TileURLTemplate(object):
         self.with_arcgiscache_path = True if '%(arcgiscache_path)' in template else False
         self.with_bbox = True if '%(bbox)' in template else False
 
-    def substitute(self, tile_coord, format=None, grid=None):
+    def substitute(self, tile_coord, format=None, grid=None, extra_params=None):
         x, y, z = tile_coord
         data = dict(x=x, y=y, z=z)
         data['format'] = format or self.format
@@ -80,6 +80,9 @@ class TileURLTemplate(object):
             data['arcgiscache_path'] = arcgiscache_path(tile_coord)
         if self.with_bbox:
             data['bbox'] = bbox(tile_coord, grid)
+        if extra_params:
+            data.update(extra_params)
+
 
         return self.template % data
 

--- a/mapproxy/client/wms.py
+++ b/mapproxy/client/wms.py
@@ -104,6 +104,7 @@ class WMSClient(object):
         req.params.srs = query.srs.srs_code
         req.params.format = format
         req.params.update(query.dimensions_for_params(self.fwd_req_params))
+        req.params.update(query.extra_params_for_params(self.fwd_req_params))
         return req
 
     def combined_client(self, other, query):

--- a/mapproxy/layer.py
+++ b/mapproxy/layer.py
@@ -123,7 +123,7 @@ class MapQuery(object):
     """
 
     def __init__(self, bbox, size, srs, format='image/png', transparent=False,
-                 tiled_only=False, dimensions=None):
+                 tiled_only=False, dimensions=None, extra_params=None):
         self.bbox = bbox
         self.size = size
         self.srs = srs
@@ -131,6 +131,18 @@ class MapQuery(object):
         self.transparent = transparent
         self.tiled_only = tiled_only
         self.dimensions = dimensions or {}
+        self.extra_params = extra_params or {}
+
+    def extra_params_for_params(self, params):
+        """
+        Return subset of the extra_params.
+
+        >>> mq = MapQuery(None, None, None, extra_params={'key': 1, 'bar': 2})
+        >>> mq.extra_params_for_params(set(['KeY', 'baz']))
+        {'key': 1}
+        """
+        params = [p.lower() for p in params]
+        return dict((k, v) for k, v in self.extra_params.items() if k.lower() in params)
 
     def dimensions_for_params(self, params):
         """
@@ -465,7 +477,7 @@ class CacheMapLayer(MapLayer):
 
         with self.tile_manager.session():
             tile_collection = self.tile_manager.load_tile_coords(
-                affected_tile_coords, with_metadata=query.tiled_only, dimensions=query.dimensions)
+                affected_tile_coords, with_metadata=query.tiled_only, dimensions=query.dimensions, extra_params=query.extra_params)
 
         if tile_collection.empty:
             raise BlankImage()

--- a/mapproxy/request/tile.py
+++ b/mapproxy/request/tile.py
@@ -50,6 +50,7 @@ class TileRequest(object):
         self.origin = self.http.args.get('origin')
         if self.origin not in ('sw', 'nw', None):
             self.origin = None
+        self.extra_params = self._get_extra_params(request.args)
 
     def _init_request(self):
         """
@@ -68,6 +69,13 @@ class TileRequest(object):
             self.tile = tuple([int(match.group(v)) for v in ['x', 'y', 'z']])
         if not self.format:
             self.format = match.group('format')
+
+    def _get_extra_params(self, param):
+        if param:
+            # Treat all query string parameters as extra_parameters
+            extra_params = dict((key, param.get(key)) for key in param.keys())
+            return extra_params
+        return {}
 
     @property
     def exception_handler(self):
@@ -106,6 +114,7 @@ class TMSRequest(TileRequest):
             self.request_handler_name = 'tms_root_resource'
         else:
             self._init_request()
+        self.extra_params = dict((key, request.args.get(key)) for key in request.args.keys())
 
     @property
     def exception_handler(self):

--- a/mapproxy/request/wms/__init__.py
+++ b/mapproxy/request/wms/__init__.py
@@ -196,8 +196,25 @@ class WMSMapRequest(WMSRequest):
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
         self.dimensions = self._get_dimensions(param)
+        self.extra_params = self._get_extra_params(param)
         WMSRequest.__init__(self, param=param, url=url, validate=validate,
                             non_strict=non_strict, **kw)
+
+    def _get_extra_params(self, param):
+        # All parameters that aren't standard WMS parameters or dimensions
+        if param:
+            wms_keys = list(self.fixed_params.keys()) + self.expected_param + ['transparent']
+            if self.dimensions:
+                wms_keys = wms_keys + list(self.dimensions.keys())
+            keys = []
+            if isinstance(param, RequestParams):
+                keys = list(map(lambda k: k[0], param.iteritems()))
+            else:
+                keys = list(param.keys())
+            extra_keys = set(keys) - set(wms_keys)
+            extra_params = dict([(key, param.get(key)) for key in extra_keys])
+            return extra_params
+        return {}
 
     def _get_dimensions(self, param):
         if param:

--- a/mapproxy/request/wmts.py
+++ b/mapproxy/request/wmts.py
@@ -144,8 +144,23 @@ class WMTS100TileRequest(WMTSRequest):
                       'tilematrix', 'tilerow', 'tilecol', 'format']
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
+        self.extra_params = self._get_extra_params(param)
         WMTSRequest.__init__(self, param=param, url=url, validate=validate,
                              non_strict=non_strict, **kw)
+
+    def _get_extra_params(self, param):
+        if param:
+            # All parameters that aren't standard WMTS parameters or dimensions
+            wmts_keys = list(self.fixed_params.keys()) + self.expected_param
+            keys = []
+            if isinstance(param, RequestParams):
+                keys = list(map(lambda k: k[0], param.iteritems()))
+            else:
+                keys = list(param.keys())
+            extra_keys = set(keys) - set(wmts_keys)
+            extra_params = dict([(key, param.get(key)) for key in extra_keys])
+            return extra_params
+        return {}
 
     def make_request(self):
         self.layer = self.params.layer
@@ -345,6 +360,7 @@ class WMTS100RestTileRequest(TileRequest):
         self.dimensions = {}
         self.req_vars = req_vars
         self.url_converter = url_converter
+        self.extra_params = self._get_extra_params(request.args)
 
     def make_request(self):
         """

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -311,7 +311,8 @@ class TileLayer(object):
         try:
             with self.tile_manager.session():
                 tile = self.tile_manager.load_tile_coord(tile_coord,
-                                                         dimensions=dimensions, with_metadata=True)
+                                                         dimensions=dimensions, with_metadata=True,
+                                                         extra_params=tile_request.extra_params)
             if tile.source is None:
                 return self.empty_response()
 

--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -84,7 +84,8 @@ class WMSServer(Server):
         self.check_map_request(map_request)
 
         params = map_request.params
-        query = MapQuery(params.bbox, params.size, SRS(params.srs), params.format, dimensions=map_request.dimensions)
+        query = MapQuery(params.bbox, params.size, SRS(params.srs), params.format, dimensions=map_request.dimensions,
+                         extra_params=map_request.extra_params)
 
         if map_request.params.get('tiled', 'false').lower() == 'true':
             query.tiled_only = True

--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -73,7 +73,7 @@ class TiledSource(MapLayer):
         tile_coord = next(tiles)
 
         try:
-            return self.client.get_tile(tile_coord, format=query.format)
+            return self.client.get_tile(tile_coord, format=query.format, extra_params=query.extra_params)
         except HTTPClientError as e:
             if self.error_handler:
                 resp = self.error_handler.handle(e.response_code, query)

--- a/mapproxy/test/system/fixture/wmts_dimensions.yaml
+++ b/mapproxy/test/system/fixture/wmts_dimensions.yaml
@@ -54,4 +54,3 @@ sources:
     req:
       url: http://localhost:42423/service2
       layers: foo,bar
-    forward_req_params: ['time', 'elevation']

--- a/mapproxy/test/unit/test_cache.py
+++ b/mapproxy/test/unit/test_cache.py
@@ -95,7 +95,7 @@ class MockTileClient(object):
     def __init__(self):
         self.requested_tiles = []
 
-    def get_tile(self, tile_coord, format=None):
+    def get_tile(self, tile_coord, format=None, extra_params=None):
         self.requested_tiles.append(tile_coord)
         return ImageSource(create_debug_img((256, 256)))
 


### PR DESCRIPTION
We (@AstunTechnology) have a requirement to pass an API key through MapProxy onto a WMTS source with the response being cached. Unlike dimensions the API key should not be taken into account when caching, resulting in all users benefiting from a short-term cache.

This PR adds the concept of `extra_params` which are those request parameters that are not part of a standard request. The `extra_params` are available to WMS and tile sources for inclusion in source requests. To include a parameter from `extra_params` in a WMS source request the `forward_req_params` property is set to a list of required parameter names; for a tile source a placeholder is defined in the URL.

Existing tests have been updated to take into account this new functionality.