### PR TITLE
Fix broken TMS/WMTS demo templates HTML

### DIFF
--- a/mapproxy/service/templates/demo/tms_demo.html
+++ b/mapproxy/service/templates/demo/tms_demo.html
@@ -1,7 +1,7 @@
 {{py:
 from html import escape
 import textwrap
-
+import json
 wrapper = textwrap.TextWrapper(replace_whitespace=False, width=90,
                                break_long_words=False)
 
@@ -23,7 +23,7 @@ jscript_functions=None
         const transparent = {{if format == 'png'}}true{{else}}false{{endif}};
         const format = "{{format}}";
         const srs = "{{srs}}";
-        const tileSize = "{{layer.grid.tile_size}}";  // TODO allow custom e.g. Retina tilesizes
+        const tileSize = {{json.dumps(layer.grid.tile_size)}};
         const extent = [{{', '.join(str(r) for r in layer.bbox)}}];
         const grid_extent = [{{', '.join(str(r) for r in layer.grid.bbox)}}];
         const resolutions = [{{', '.join(str(r) for r in resolutions)}}];
@@ -46,7 +46,7 @@ jscript_functions=None
             projection: "{{srs}}",
             maxResolution: {{resolutions[0]}},
             tileGrid: new  ol.tilegrid.TileGrid({
-               tileSize: 256,
+               tileSize: tileSize,
                resolutions: resolutions,
                extent: grid_extent
             }),

--- a/mapproxy/service/templates/demo/tms_demo.html
+++ b/mapproxy/service/templates/demo/tms_demo.html
@@ -20,9 +20,13 @@ jscript_functions=None
 <script type="text/javascript">
     async function init() {
 
-        const transparent = "{{if format == 'png'}}true{{endif}}";
+        const transparent = {{if format == 'png'}}true{{else}}false{{endif}};
+        const format = "{{format}}";
         const srs = "{{srs}}";
+        const tileSize = "{{layer.grid.tile_size}}";  // TODO allow custom e.g. Retina tilesizes
         const extent = [{{', '.join(str(r) for r in layer.bbox)}}];
+        const grid_extent = [{{', '.join(str(r) for r in layer.grid.bbox)}}];
+        const resolutions = [{{', '.join(str(r) for r in resolutions)}}];
 
         if (!ol.proj.get(srs)) {
             const allDefs = await import('./static/proj4defs.js');
@@ -35,11 +39,17 @@ jscript_functions=None
             ol.proj.proj4.register(proj4);
         }
 
+        // Define TMS as specialized XYZ service: origin lower-left and may have custom grid
         const source = new ol.source.XYZ({
-            url: '../tms/{{"/".join(layer.md["name_path"])}}/{z}/{x}/{-y}.png',
-            opaque: transparent === "true" ? false : true,
+            url: '../tms/1.0.0/{{"/".join(layer.md["name_path"])}}/{z}/{x}/{-y}.' + format,
+            opaque: transparent,
             projection: "{{srs}}",
-            maxResolution: {{resolutions[0]}}
+            maxResolution: {{resolutions[0]}},
+            tileGrid: new  ol.tilegrid.TileGrid({
+               tileSize: 256,
+               resolutions: resolutions,
+               extent: grid_extent
+            }),
         });
 
         const background_source = new ol.source.XYZ({

--- a/mapproxy/service/templates/demo/wmts_demo.html
+++ b/mapproxy/service/templates/demo/wmts_demo.html
@@ -1,6 +1,7 @@
 {{py:
 from html import escape
 import textwrap
+import json
 
 wrapper = textwrap.TextWrapper(replace_whitespace=False, width=90,
                                break_long_words=False)
@@ -20,7 +21,7 @@ jscript_functions=None
 <script type="text/javascript">
     async function init() {
 
-        const transparent = "{{if format == 'image/png'}}true{{endif}}";
+        const transparent = {{if format == 'image/png'}}true{{else}}false{{endif}};
         const srs = "{{srs}}";
         const grid_extent = [{{', '.join(str(r) for r in layer.grid.bbox)}}];
         const extent = [{{', '.join(str(r) for r in layer.bbox)}}];
@@ -29,6 +30,7 @@ jscript_functions=None
         for (let z = 0; z < resolutions.length; ++z) {
             matrixIds[z] = z;
         }
+        const tileSize = {{json.dumps(layer.grid.tile_size)}};
 
         if (!ol.proj.get(srs)) {
             const allDefs = await import('./static/proj4defs.js');
@@ -49,12 +51,13 @@ jscript_functions=None
             matrixSet: '{{matrix_set}}',
             format: "{{format}}",
             projection: "{{srs}}",
-            transparent: transparent === "true" ? true: false,
+            transparent: transparent,
             style: '',
             tileGrid: new ol.tilegrid.WMTS({
                 origin: ol.extent.getTopLeft(grid_extent),
                 resolutions: resolutions,
-                matrixIds
+                matrixIds: matrixIds,
+                tileSize: tileSize
             })
         });
 


### PR DESCRIPTION
The TMS demo was broken after the upgrade to OpenLayers 7. The template HTML assumes TMS access as an XYZ OL Class with swapped Y `{-y}`, tile coord. This created at least two problems that are fixed in this PR:

* the TMS URL path  should contain the `/1.0.0/` substring
* support for a custom Grid `ol.tilegrid.TileGrid` was lacking

Edit: WMTS demo template uses `ol.tilegrid.TileGrid`, but its constructor lacks a `tileSize` attribute (e.g.  custom for HQ/Retina 512x512 tiles).

These issues appeared when upgrading the [justb4/mapproxy Docker image](https://github.com/justb4/docker-mapproxy) (to MP 2.0.2). For now the Docker image is patched during builds using [this patch file](https://github.com/justb4/docker-mapproxy/blob/master/patches/03-tms-demo/tms-demo.patch). 

There may be additional improvements like explicit Origin (always confusing with custom grids and TMS), grid custom tile_size like for HQ/Retina tiles in both TMS and WMTS demo templates. Tile size from grid will be included in this PR.
IMHO `origin` is implicit (`sw`/`ll`) for TMS and already specified (`nw`/`ul`) for WMTS.
