### PR TITLE
Added missing `dimensions` keyword argument to `load_tile_metadata()` and `store_tiles()` calls

### DIFF
--- a/mapproxy/cache/tile.py
+++ b/mapproxy/cache/tile.py
@@ -236,7 +236,7 @@ class TileManager(object):
         cached = self.cache.is_cached(tile, dimensions=dimensions)
         max_mtime = self.expire_timestamp(tile)
         if cached and max_mtime is not None:
-            self.cache.load_tile_metadata(tile)
+            self.cache.load_tile_metadata(tile, dimensions=self.dimensions)
             # file time stamp must be rounded to integer since time conversion functions
             # mktime and timetuple strip decimals from seconds
             stale = int(tile.timestamp) <= max_mtime
@@ -558,7 +558,7 @@ class TileCreator(object):
                         async_pool.shutdown(True)
                         reraise(ex)
 
-                self.cache.store_tiles([t for t in tiles if t.cacheable])
+                self.cache.store_tiles([t for t in tiles if t.cacheable], dimensions=self.dimensions)
                 return tiles
 
             # else


### PR DESCRIPTION
#928 

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
