### PR TITLE
fix: set correct number of geotiff tags

### DIFF
--- a/mapproxy/image/__init__.py
+++ b/mapproxy/image/__init__.py
@@ -80,7 +80,7 @@ class GeoReference(object):
 
         model_type = 2 if self.srs.is_latlong else 1
         tags[TIFF_GEOKEYDIRECTORYTAG] = (
-            1, 1, 0, 4,  # {KeyDirectoryVersion, KeyRevision, MinorRevision, NumberOfKeys}
+            1, 1, 0, 3,  # {KeyDirectoryVersion, KeyRevision, MinorRevision, NumberOfKeys}
             1024, 0, 1, model_type,  # 1 projected, 2 geographic (lat/long)
             1025, 0, 1, 1,  # 1 RasterIsArea, 2 RasterIsPoint
             3072, 0, 1, get_epsg_num(self.srs.srs_code),

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -588,7 +588,7 @@ def assert_geotiff_tags(img, expected_origin, expected_pixel_res, srs, projected
         expected_pixel_res[0], expected_pixel_res[1], 0.0,
     ))
     assert len(tags[TIFF_GEOKEYDIRECTORYTAG]) == 4*4
-    assert tags[TIFF_GEOKEYDIRECTORYTAG][0*4+3] == 4
+    assert tags[TIFF_GEOKEYDIRECTORYTAG][0*4+3] == 3
     assert tags[TIFF_GEOKEYDIRECTORYTAG][1*4+3] == (1 if projected else 2)
     assert tags[TIFF_GEOKEYDIRECTORYTAG][3*4+3] == srs
 


### PR DESCRIPTION
Fixes #205 


<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
