### PR TITLE
feat: include WMS legend url in WMTS capabilities

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -304,7 +304,7 @@ Please read :ref:`scale vs. resolution <scale_resolution>` for some notes on `sc
 ``legendurl``
 """""""""""""
 
-Configure a URL to an image that should be returned as the legend for this layer. Local URLs (``file://``) are also supported. MapProxy ignores the legends from the sources of this layer if you configure a ``legendurl`` here.
+Configure a URL to an image that should be returned as the legend for this layer. Local URLs (``file://``) are also supported. MapProxy ignores the legends from the sources of this layer if you configure a ``legendurl`` here. If WMS and WMTS are enabled the address to the WMS `GetLegendGraphic` endpoint will be included in the WMTS capabilities as the legend url.
 
 .. _layer_metadata:
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1957,6 +1957,7 @@ class LayerConfiguration(ConfigurationBase):
                         md=md,
                         tile_manager=cache_source,
                         dimensions=dimensions,
+                        legend='legendurl' in self.conf and 'wms' in self.context.services.conf
                     )
                 )
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1950,6 +1950,12 @@ class LayerConfiguration(ConfigurationBase):
                 md['format'] = self.context.caches[cache_name].image_opts().format
                 md['cache_name'] = cache_name
                 md['extent'] = extent
+                legend_version = None
+                if 'legendurl' in self.conf:
+                    wms_conf = self.context.services.conf.get('wms', None)
+                    # GetLegendGraphic with legendurl does not seem to work in non 1.3.0 versions
+                    if wms_conf is not None and '1.3.0' in wms_conf.get('versions', ['1.3.0']):
+                        legend_version = '1.3.0'
                 tile_layers.append(
                     TileLayer(
                         self.conf['name'], self.conf['title'],
@@ -1957,7 +1963,7 @@ class LayerConfiguration(ConfigurationBase):
                         md=md,
                         tile_manager=cache_source,
                         dimensions=dimensions,
-                        legend='legendurl' in self.conf and 'wms' in self.context.services.conf
+                        legend_version=legend_version
                     )
                 )
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -31,6 +31,7 @@ import hashlib
 import warnings
 from copy import deepcopy, copy
 from functools import partial
+from packaging.version import Version
 
 import logging
 from urllib.parse import urlparse
@@ -1952,10 +1953,11 @@ class LayerConfiguration(ConfigurationBase):
                 md['extent'] = extent
                 legend_version = None
                 if 'legendurl' in self.conf:
-                    wms_conf = self.context.services.conf.get('wms', None)
-                    # GetLegendGraphic with legendurl does not seem to work in non 1.3.0 versions
-                    if wms_conf is not None and '1.3.0' in wms_conf.get('versions', ['1.3.0']):
-                        legend_version = '1.3.0'
+                    wms_conf = self.context.services.conf.get('wms')
+                    if wms_conf is not None:
+                        versions = wms_conf.get('versions', ['1.3.0'])
+                        versions.sort(key=Version)
+                        legend_version = versions[-1]
                 tile_layers.append(
                     TileLayer(
                         self.conf['name'], self.conf['title'],

--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -97,10 +97,10 @@
       <ows:Identifier>{{layer.name}}</ows:Identifier>
       <Style>
         <ows:Identifier>default</ows:Identifier>
-        {{if layer.legend}}
+        {{if layer.legend_version}}
         <LegendURL
           format="image/png"
-          xlink:href="{{service.url}}?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;format=image%2Fpng&amp;layer={{layer.name}}"
+          xlink:href="{{service.url}}?service=WMS&amp;request=GetLegendGraphic&amp;version={{layer.legend_version}}&amp;format=image%2Fpng&amp;layer={{layer.name}}"
         />
         {{endif}}
       </Style>

--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -11,7 +11,7 @@
         <ows:Keyword{{if kw.vocabulary}} vocabulary="{{kw.vocabulary}}"{{endif}}>{{keyword}}</ows:Keyword>
       {{endfor}}
     {{endfor}}
-    </ows:Keywords> 
+    </ows:Keywords>
     {{endif}}
     <ows:ServiceType>OGC WMTS</ows:ServiceType>
     <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
@@ -97,6 +97,12 @@
       <ows:Identifier>{{layer.name}}</ows:Identifier>
       <Style>
         <ows:Identifier>default</ows:Identifier>
+        {{if layer.legend}}
+        <LegendURL
+          format="image/png"
+          xlink:href="{{service.url}}?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;format=image%2Fpng&amp;layer={{layer.name}}"
+        />
+        {{endif}}
       </Style>
       <Format>image/{{layer.format}}</Format>
       {{if layer.queryable}}

--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -100,7 +100,7 @@
         {{if layer.legend_version}}
         <LegendURL
           format="image/png"
-          xlink:href="{{service.url}}?service=WMS&amp;request=GetLegendGraphic&amp;version={{layer.legend_version}}&amp;format=image%2Fpng&amp;layer={{layer.name}}"
+          xlink:href="{{wms_service_url}}?service=WMS&amp;request=GetLegendGraphic&amp;version={{layer.legend_version}}&amp;format=image%2Fpng&amp;layer={{layer.name}}"
         />
         {{endif}}
       </Style>

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -204,7 +204,7 @@ class TileServer(Server):
 
 
 class TileLayer(object):
-    def __init__(self, name, title, md, tile_manager, info_sources=[], dimensions=None, legend=False):
+    def __init__(self, name, title, md, tile_manager, info_sources=[], dimensions=None, legend_version=None):
         """
         :param md: the layer metadata
         :param tile_manager: the layer tile manager
@@ -220,7 +220,7 @@ class TileLayer(object):
         self._empty_tile = None
         self._mixed_format = True if self.md.get('format', False) == 'mixed' else False
         self.empty_response_as_png = True
-        self.legend = legend
+        self.legend_version = legend_version
 
     @property
     def bbox(self):

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -204,7 +204,7 @@ class TileServer(Server):
 
 
 class TileLayer(object):
-    def __init__(self, name, title, md, tile_manager, info_sources=[], dimensions=None):
+    def __init__(self, name, title, md, tile_manager, info_sources=[], dimensions=None, legend=False):
         """
         :param md: the layer metadata
         :param tile_manager: the layer tile manager
@@ -220,6 +220,7 @@ class TileLayer(object):
         self._empty_tile = None
         self._mixed_format = True if self.md.get('format', False) == 'mixed' else False
         self.empty_response_as_png = True
+        self.legend = legend
 
     @property
     def bbox(self):

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -18,6 +18,7 @@ WMS service handler
 """
 from __future__ import print_function
 
+import re
 from functools import partial
 
 from mapproxy.request.wmts import (
@@ -273,11 +274,13 @@ class Capabilities(object):
         return self._render_template(_map_request.capabilities_template)
 
     def template_context(self):
-        return dict(service=bunch(default='', **self.service),
+        service = bunch(default='', **self.service)
+        return dict(service=service,
                     restful=False,
                     layers=self.layers,
                     info_formats=self.info_formats,
-                    tile_matrix_sets=self.matrix_sets)
+                    tile_matrix_sets=self.matrix_sets,
+                    wms_service_url=service.url)
 
     def _render_template(self, template):
         template = get_template(template)
@@ -294,7 +297,8 @@ class RestfulCapabilities(Capabilities):
         self.fi_url_converter = fi_url_converter
 
     def template_context(self):
-        return dict(service=bunch(default='', **self.service),
+        service = bunch(default='', **self.service)
+        return dict(service=service,
                     restful=True,
                     layers=self.layers,
                     info_formats=self.info_formats,
@@ -306,6 +310,7 @@ class RestfulCapabilities(Capabilities):
                     dimension_keys=dict((k.lower(), k) for k in self.url_converter.dimensions),
                     format_resource_template=format_resource_template,
                     format_info_resource_template=format_info_resource_template,
+                    wms_service_url=re.sub(r'wmts$', 'service', service.url)
                     )
 
 

--- a/mapproxy/test/system/fixture/legendgraphic.yaml
+++ b/mapproxy/test/system/fixture/legendgraphic.yaml
@@ -27,6 +27,7 @@ services:
         email: info@example.org
       access_constraints:
         Here be dragons.
+  wmts:
 
 layers:
   - name: wms_legend
@@ -45,6 +46,13 @@ layers:
     title: Layer with a static LegendURL
     legendurl: http://localhost:42423/staticlegend_layer.png
     sources: [legendurl_static_2]
+  - name: wmts_layer_legendurl
+    title: WMTS Layer with a static LegendURL
+    legendurl: http://localhost:42423/staticlegend_layer.png
+    sources: [tile_cache]
+  - name: wmts_layer_no_legendurl
+    title: WMTS Layer without a static LegendURL
+    sources: [tile_cache]
 
 sources:
   legend_cache:
@@ -91,3 +99,9 @@ sources:
       url: http://localhost:42423/service
       layers: foo
 
+caches:
+  tile_cache:
+    cache:
+      type: file
+    grids: [GLOBAL_WEBMERCATOR]
+    sources: []

--- a/mapproxy/test/system/fixture/legendgraphic.yaml
+++ b/mapproxy/test/system/fixture/legendgraphic.yaml
@@ -28,6 +28,8 @@ services:
       access_constraints:
         Here be dragons.
   wmts:
+    restful: true
+    kvp: true
 
 layers:
   - name: wms_legend


### PR DESCRIPTION
If WMTS and WMS are enabled and a layer has configured a `legendurl`, the WMTS Capabilities will advertise the WMS `GetLegendGraphic` URL as a `LegendURL`.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
