### PR TITLE
fix: dependencies to proper versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH="${PATH}:/mapproxy/.local/bin"
 RUN mkdir mapproxy-dist
 COPY --from=builder /mapproxy/dist/* mapproxy-dist/
 
-RUN pip install werkzeug==1.0.1 requests riak==2.4.2 redis boto3 azure-storage-blob Shapely && \
+RUN pip install requests riak==2.4.2 redis boto3 azure-storage-blob Shapely && \
   pip install --find-links=./mapproxy-dist --no-index MapProxy && \
   pip cache purge
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -49,7 +49,7 @@ ENV PATH="${PATH}:/mapproxy/.local/bin"
 RUN mkdir mapproxy-dist
 COPY --from=builder /mapproxy/dist/* mapproxy-dist/
 
-RUN pip install werkzeug==1.0.1 requests riak==2.4.2 redis boto3 azure-storage-blob Shapely && \
+RUN pip install requests riak==2.4.2 redis boto3 azure-storage-blob Shapely && \
   pip install --find-links=./mapproxy-dist --no-index MapProxy && \
   pip cache purge
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -147,8 +147,7 @@ Start the test server
 
 To start a test server::
 
-    cd mymapproxy
-    mapproxy-util serve-develop mapproxy.yaml
+    mapproxy-util serve-develop mymapproxy/mapproxy.yaml
 
 There is already a test layer configured that obtains data from the `Omniscale OpenStreetMap WMS`_. Feel free to use this service for testing.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -21,17 +21,17 @@ Create a new virtual environment
 
 ``virtualenv`` is available as ``python-virtualenv`` on most Linux systems. You can also `install Virtualenv from source <https://virtualenv.pypa.io/en/latest/installation.html>`_.
 
-To create a new environment with the name ``mapproxy`` call::
+To create a new environment with the name ``venv`` call::
 
-    virtualenv --system-site-packages mapproxy
+    virtualenv --system-site-packages venv
 
-You should now have a Python installation under ``mapproxy/bin/python``.
+You should now have a Python installation under ``venv/bin/python``.
 
 .. note:: Virtualenv will use your Python system packages (like ``python-imaging`` or ``python-yaml``) only when the virtualenv was created with the ``--system-site-packages`` option.
 
-You need to either prefix all commands with ``mapproxy/bin``, set your ``PATH`` variable to include the bin directory or `activate` the virtualenv with::
+You need to either prefix all commands with ``venv/bin``, set your ``PATH`` variable to include the bin directory or `activate` the virtualenv with::
 
-    source mapproxy/bin/activate
+    source venv/bin/activate
 
 This will change the ``PATH`` for your `current` session.
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,7 +2,6 @@ azure-storage-blob>=12.9.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 Pillow==10.2.0
-PyYAML==6.0.1
 WebOb==1.8.7
 Shapely==2.0.1
 WebTest==3.0.0
@@ -24,9 +23,7 @@ docker==7.0.0
 docutils==0.20.1
 ecdsa==0.18.0
 flake8==7.0.0
-future==0.18.3
 idna==2.9
-importlib-resources==6.1.1
 iniconfig==2.0.0
 jmespath==1.0.1
 jsondiff==1.3.1
@@ -70,7 +67,6 @@ toml==0.10.2
 urllib3==1.26.18
 waitress==2.1.2
 websocket-client==1.7.0
-werkzeug==1.0.1
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.17.0

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,9 @@ install_requires = [
     'PyYAML>=3.0',
     'future',
     'pyproj>=2',
-    'jsonschema',
-    'importlib_resources'
+    'jsonschema>=4',
+    'importlib_resources',
+    'werkzeug==1.0.1'
 ]
 
 


### PR DESCRIPTION
Some versions are not high enough in a default python installation so I fixed them in the setup.py. I also added the werkzeug dependency because this is needed for the configuration creation and the test server. I think this is default functionality and should always be available.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
