### PR TITLE
Test splitted build

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -34,17 +34,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-          images: |
-            ghcr.io/${{ github.repository }}/mapproxy
-          tags: |
-            type=semver,pattern={{version}}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -62,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
-          push: false
+          push: true
           target: base
           tags: ${{ needs.get-version.outputs.version }}
           platforms: linux/amd64,linux/arm64
@@ -71,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
-          push: false
+          push: true
           target: development
           tags: ${{ needs.get-version.outputs.version }}-dev
           platforms: linux/amd64,linux/arm64
@@ -80,31 +69,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
-          push: false
+          push: true
           target: nginx
           tags: ${{ needs.get-version.outputs.version }}-nginx
           platforms: linux/amd64,linux/arm64
-
-  run-trivy:
-    needs:
-      - get-version
-      - build-and-publish-ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run trivy
-        uses: aquasecurity/trivy-action@master
-        with:
-          format: 'table'
-          ignore-unfixed: true
-          image-ref: ${{ needs.get-version.outputs.version }}
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          vuln-type: 'os,library'
-
-#      - name: Upload Trivy scan results to GitHub Security tab
-#        uses: github/codeql-action/upload-sarif@v3
-#        with:
-#          sarif_file: 'trivy-results.sarif'
 
   build-and-publish-alpine:
     needs: get-version
@@ -112,17 +80,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-          images: |
-            ghcr.io/${{ github.repository }}/mapproxy
-          tags: |
-            type=semver,pattern={{version}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -141,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile-alpine
-          push: false
+          push: true
           target: base
           tags: ${{ needs.get-version.outputs.version }}-alpine
           platforms: linux/amd64,linux/arm64
@@ -150,7 +107,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile-alpine
-          push: false
+          push: true
           target: development
           tags: ${{ needs.get-version.outputs.version }}-alpine-dev
           platforms: linux/amd64,linux/arm64
@@ -159,7 +116,28 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile-alpine
-          push: false
+          push: true
           target: nginx
           tags: ${{ needs.get-version.outputs.version }}-alpine-nginx
           platforms: linux/amd64,linux/arm64
+
+  run-trivy:
+    needs:
+      - get-version
+      - build-and-publish-ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          format: 'table'
+          ignore-unfixed: true
+          image-ref: ${{ needs.get-version.outputs.version }}
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -8,7 +8,27 @@ on:
     tags:
       - "*.*.*"
 jobs:
-  build-and-publish:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=false
+          images: |
+            ghcr.io/${{ github.repository }}/mapproxy
+          tags: |
+            type=semver,pattern={{version}}
+
+  build-and-publish-ubuntu:
+    needs: get-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,67 +62,104 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
-          push: true
+          push: false
           target: base
-          tags: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          tags: ${{ needs.get-version.outputs.version }}
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push development image
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
-          push: true
+          push: false
           target: development
-          tags: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}-dev
+          tags: ${{ needs.get-version.outputs.version }}-dev
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push nginx image
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
-          push: true
+          push: false
           target: nginx
-          tags: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}-nginx
+          tags: ${{ needs.get-version.outputs.version }}-nginx
           platforms: linux/amd64,linux/arm64
+
+  run-trivy:
+    needs:
+      - get-version
+      - build-and-publish-ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          format: 'table'
+          ignore-unfixed: true
+          image-ref: ${{ needs.get-version.outputs.version }}
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+
+#      - name: Upload Trivy scan results to GitHub Security tab
+#        uses: github/codeql-action/upload-sarif@v3
+#        with:
+#          sarif_file: 'trivy-results.sarif'
+
+  build-and-publish-alpine:
+    needs: get-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=false
+          images: |
+            ghcr.io/${{ github.repository }}/mapproxy
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base alpine image
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile-alpine
-          push: true
+          push: false
           target: base
-          tags: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}-alpine
+          tags: ${{ needs.get-version.outputs.version }}-alpine
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push alpine development image
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile-alpine
-          push: true
+          push: false
           target: development
-          tags: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}-alpine-dev
+          tags: ${{ needs.get-version.outputs.version }}-alpine-dev
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push alpine based nginx image
         uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile-alpine
-          push: true
+          push: false
           target: nginx
-          tags: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}-alpine-nginx
+          tags: ${{ needs.get-version.outputs.version }}-alpine-nginx
           platforms: linux/amd64,linux/arm64
-
-      - name: Run trivy
-        uses: aquasecurity/trivy-action@master
-        with:
-          format: 'table'
-          ignore-unfixed: true
-          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          vuln-type: 'os,library'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -17,6 +17,7 @@ RUN apk -U upgrade --update \
       proj-util \
       geos \
       geos-dev \
+      libffi-dev \
     && rm -rf /var/cache/apk/*
 
 


### PR DESCRIPTION
This splits off the docker build into multiple concurrently running jobs, one for ubuntu and one for alpine

This is a test run: https://github.com/simonseyock/mapproxy/actions/runs/9956997508 (trivy fails because the images are not uploaded)

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
