### PR TITLE
only require importlib_resources on python 3.8 (#955)

### DIFF
--- a/mapproxy/image/message.py
+++ b/mapproxy/image/message.py
@@ -17,7 +17,10 @@ from __future__ import division
 
 import logging
 import os
-import importlib_resources
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 
 from mapproxy.config import base_config, abspath
 from mapproxy.compat.image import Image, ImageColor, ImageDraw, ImageFont

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -18,7 +18,10 @@ Demo service handler
 """
 from __future__ import division
 
-import importlib_resources
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 import os
 import mimetypes
 from collections import defaultdict

--- a/mapproxy/template.py
+++ b/mapproxy/template.py
@@ -16,7 +16,10 @@
 """
 Loading of template files (e.g. capability documents)
 """
-import importlib_resources
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 import os
 from mapproxy.util.ext.tempita import Template, bunch
 from mapproxy.config.config import base_config

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     'future',
     'pyproj>=2',
     'jsonschema>=4',
-    'importlib_resources',
+    'importlib_resources;python_version<="3.8"',
     'werkzeug==1.0.1'
 ]
 


### PR DESCRIPTION
actually tested this time, `mapproxy-util` starts fine here on 3.11