### PR TITLE
Make WMTS LegendURL configurable

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -395,16 +395,17 @@ Each dimension is another dictionary with a list of ``values`` and an optional `
 ``wmts_kvp_legendurl`` and ``wmts_rest_legendurl``
 """"""""""""""""""""""""""""""""""""""""""""""""""
 
-It is possible which URLS the WMTS will advertise as LegendURLs through its capabilities. These will be inserted as a
-``LegendURL`` tag into the capabilities document. These URLs support two template variables ``{base_url}`` which is the
-base url of MapProxy and ``{layer_name}`` which is the name of the layer.
+It is possible to configure which URLS the WMTS will advertise as LegendURLs through its capabilities. These will be
+inserted as a ``LegendURL`` tag into the capabilities document. These URLs support two template variables ``{base_url}``
+which is the base url of MapProxy and ``{layer_name}`` which is the name of the layer.
 
 .. code-block:: yaml
 
   layers:
     - name: legend_layer
       tile_sources: [cache]
-      wmts_rest_legendurl: "{base_url}/legend/{layer_name}.png" # would become "http://127.0.0.1/legend/osm.png" on localhost
+      wmts_rest_legendurl: "{base_url}/legend/{layer_name}.png" # would become "http://127.0.0.1/legend/legend_layer.png" on localhost
+      wmts_kvp_legendurl: "http://external-service/fixed-name.png" # would be used as a fixed URL
 
 
 .. ``attribution``

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -392,6 +392,20 @@ Each dimension is another dictionary with a list of ``values`` and an optional `
             - 1000
             - 3000
 
+``wmts_kvp_legendurl`` and ``wmts_rest_legendurl``
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+It is possible which URLS the WMTS will advertise as LegendURLs through its capabilities. These will be inserted as a
+``LegendURL`` tag into the capabilities document. These URLs support two template variables ``{base_url}`` which is the
+base url of MapProxy and ``{layer_name}`` which is the name of the layer.
+
+.. code-block:: yaml
+
+  layers:
+    - name: legend_layer
+      tile_sources: [cache]
+      wmts_rest_legendurl: "{base_url}/legend/{layer_name}.png" # would become "http://127.0.0.1/legend/osm.png" on localhost
+
 
 .. ``attribution``
 .. """"""""""""""""

--- a/mapproxy/config/config-schema.json
+++ b/mapproxy/config/config-schema.json
@@ -392,6 +392,14 @@
           "description": "URL to an image used as a legend for this layer",
           "type": "string"
         },
+        "wmts_rest_legendurl": {
+          "description": "A static legendurl for the wmts rest capabilites",
+          "type": "string"
+        },
+        "wmts_kvp_legendurl": {
+          "description": "A static legendurl for the wmts kvp capabilites",
+          "type": "string"
+        },
         "md": {
           "title": "md",
           "description": "Additional metadata for this layer",

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1951,21 +1951,26 @@ class LayerConfiguration(ConfigurationBase):
                 md['format'] = self.context.caches[cache_name].image_opts().format
                 md['cache_name'] = cache_name
                 md['extent'] = extent
-                legend_version = None
+                md['wmts_kvp_legendurl'] = self.conf.get('wmts_kvp_legendurl')
+                md['wmts_rest_legendurl'] = self.conf.get('wmts_rest_legendurl')
                 if 'legendurl' in self.conf:
                     wms_conf = self.context.services.conf.get('wms')
                     if wms_conf is not None:
                         versions = wms_conf.get('versions', ['1.3.0'])
                         versions.sort(key=Version)
-                        legend_version = versions[-1]
+                        legendurl = (f'{{base_url}}/service?service=WMS&amp;request=GetLegendGraphic&amp;'
+                                     f'version={versions[-1]}&amp;format=image%2Fpng&amp;layer={md['name']}')
+                        if md['wmts_kvp_legendurl'] is None:
+                            md['wmts_kvp_legendurl'] = legendurl
+                        if md['wmts_rest_legendurl'] is None:
+                            md['wmts_rest_legendurl'] = legendurl
                 tile_layers.append(
                     TileLayer(
                         self.conf['name'], self.conf['title'],
                         info_sources=fi_sources,
                         md=md,
                         tile_manager=cache_source,
-                        dimensions=dimensions,
-                        legend_version=legend_version
+                        dimensions=dimensions
                     )
                 )
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1959,7 +1959,7 @@ class LayerConfiguration(ConfigurationBase):
                         versions = wms_conf.get('versions', ['1.3.0'])
                         versions.sort(key=Version)
                         legendurl = (f'{{base_url}}/service?service=WMS&amp;request=GetLegendGraphic&amp;'
-                                     f'version={versions[-1]}&amp;format=image%2Fpng&amp;layer={md['name']}')
+                                     f'version={versions[-1]}&amp;format=image%2Fpng&amp;layer={{layer_name}}')
                         if md['wmts_kvp_legendurl'] is None:
                             md['wmts_kvp_legendurl'] = legendurl
                         if md['wmts_rest_legendurl'] is None:

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -615,6 +615,8 @@ mapproxy_yaml_spec = {
             'name': str(),
             required('title'): str,
             'legendurl': str(),
+            'wmts_rest_legendurl': str(),
+            'wmts_kvp_legendurl': str(),
             'layers': recursive(),
             'md': wms_130_layer_md,
             'dimensions': {

--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -97,10 +97,10 @@
       <ows:Identifier>{{layer.name}}</ows:Identifier>
       <Style>
         <ows:Identifier>default</ows:Identifier>
-        {{if layer.legend_version}}
+        {{if legendurls[layer.name]}}
         <LegendURL
           format="image/png"
-          xlink:href="{{wms_service_url}}?service=WMS&amp;request=GetLegendGraphic&amp;version={{layer.legend_version}}&amp;format=image%2Fpng&amp;layer={{layer.name}}"
+          xlink:href="{{legendurls[layer.name]}}"
         />
         {{endif}}
       </Style>

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -281,8 +281,8 @@ class Capabilities(object):
             if layer.md['wmts_kvp_legendurl'] is not None:
                 legendurls[layer.name] = (
                     layer.md['wmts_kvp_legendurl']
-                        .replace('{base_url}', base_url)
-                        .replace('{layer_name}', layer.name)
+                    .replace('{base_url}', base_url)
+                    .replace('{layer_name}', layer.name)
                 )
             else:
                 legendurls[layer.name] = None
@@ -316,8 +316,8 @@ class RestfulCapabilities(Capabilities):
             if layer.md['wmts_rest_legendurl'] is not None:
                 legendurls[layer.name] = (
                     layer.md['wmts_rest_legendurl']
-                        .replace('{base_url}', base_url)
-                        .replace('{layer_name}', layer.name)
+                    .replace('{base_url}', base_url)
+                    .replace('{layer_name}', layer.name)
                 )
             else:
                 legendurls[layer.name] = None

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -275,12 +275,24 @@ class Capabilities(object):
 
     def template_context(self):
         service = bunch(default='', **self.service)
+        base_url = re.sub(r'/service$', '', service.url)
+        legendurls = {}
+        for layer in self.layers:
+            if layer.md['wmts_kvp_legendurl'] is not None:
+                legendurls[layer.name] = (
+                    layer.md['wmts_kvp_legendurl']
+                        .replace('{base_url}', base_url)
+                        .replace('{layer_name}', layer.name)
+                )
+            else:
+                legendurls[layer.name] = None
+
         return dict(service=service,
                     restful=False,
                     layers=self.layers,
                     info_formats=self.info_formats,
                     tile_matrix_sets=self.matrix_sets,
-                    wms_service_url=service.url)
+                    legendurls=legendurls)
 
     def _render_template(self, template):
         template = get_template(template)
@@ -298,6 +310,18 @@ class RestfulCapabilities(Capabilities):
 
     def template_context(self):
         service = bunch(default='', **self.service)
+        base_url = re.sub(r'/wmts$', '', service.url)
+        legendurls = {}
+        for layer in self.layers:
+            if layer.md['wmts_rest_legendurl'] is not None:
+                legendurls[layer.name] = (
+                    layer.md['wmts_rest_legendurl']
+                        .replace('{base_url}', base_url)
+                        .replace('{layer_name}', layer.name)
+                )
+            else:
+                legendurls[layer.name] = None
+
         return dict(service=service,
                     restful=True,
                     layers=self.layers,
@@ -310,7 +334,7 @@ class RestfulCapabilities(Capabilities):
                     dimension_keys=dict((k.lower(), k) for k in self.url_converter.dimensions),
                     format_resource_template=format_resource_template,
                     format_info_resource_template=format_info_resource_template,
-                    wms_service_url=re.sub(r'wmts$', 'service', service.url)
+                    legendurls=legendurls
                     )
 
 

--- a/mapproxy/util/ext/odict.py
+++ b/mapproxy/util/ext/odict.py
@@ -291,10 +291,10 @@ class odict(dict):
                 self[key] = val
 
     def values(self):
-        return map(self.get, self._keys)
+        return list(map(self.get, self._keys))
 
     def itervalues(self):
-        return map(self.get, self._keys)
+        return list(map(self.get, self._keys))
 
     def index(self, item):
         return self._keys.index(item)


### PR DESCRIPTION
Adds two new config parameters for layers: `wmts_kvp_legendurl` and `wmts_rest_legendurl`. If those are set, MapProxy will not try to generate a LegendURL on its own (if `legendurl` was provided), but will instead use this one (no matter if the `legendurl` was provided or not).

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
