### PR TITLE
add packaging dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ install_requires = [
     'pyproj>=2',
     'jsonschema>=4',
     'importlib_resources',
-    'werkzeug==1.0.1'
+    'werkzeug==1.0.1',
+    'packaging>=24.1',
 ]
 
 


### PR DESCRIPTION
Since [this commit last week](https://github.com/mapproxy/mapproxy/blame/93f933bbab0515313a7338022656f2dce0c77f12/mapproxy/config/loader.py#L34), [loader.py](https://github.com/mapproxy/mapproxy/blob/master/mapproxy/config/loader.py) depends on [packaging](https://pypi.org/project/packaging/). This commit specifies this dependency. Earlier versions than 24.1 might also work (I haven't run tests).