### PR TITLE
Remove packaging import

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -31,7 +31,6 @@ import hashlib
 import warnings
 from copy import deepcopy, copy
 from functools import partial
-from packaging.version import Version
 
 import logging
 from urllib.parse import urlparse
@@ -1957,7 +1956,7 @@ class LayerConfiguration(ConfigurationBase):
                     wms_conf = self.context.services.conf.get('wms')
                     if wms_conf is not None:
                         versions = wms_conf.get('versions', ['1.3.0'])
-                        versions.sort(key=Version)
+                        versions.sort(key=lambda s: [int(u) for u in s.split('.')])
                         legendurl = (f'{{base_url}}/service?service=WMS&amp;request=GetLegendGraphic&amp;'
                                      f'version={versions[-1]}&amp;format=image%2Fpng&amp;layer={{layer_name}}')
                         if md['wmts_kvp_legendurl'] is None:


### PR DESCRIPTION
This removes the import from packaging and fixes the dependencies this way. Thanks @zabop for reporting and analysis!

Closes #959

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
