### PR TITLE
ci: fix gh-pages workflow

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -43,7 +43,7 @@ jobs:
         | sort -V \
         | uniq \
         | jq -R -s -c 'split("\n")[:-1]' \
-        > docs/config/versions.json
+        > config/versions.json
 
     - name: Deploy config folder to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.5.0


### PR DESCRIPTION
And still something in the gh-pages workflow was broken.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
