### PR TITLE
Add proper XML Exception when service parameter disabled / invalid or missing

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -24,6 +24,7 @@ from mapproxy.util.py import memoize
 from mapproxy.config.spec import validate_options, add_source_to_mapproxy_yaml_spec, add_service_to_mapproxy_yaml_spec
 from mapproxy.config.validator import validate
 from mapproxy.config import load_default_config, finish_base_config, defaults
+from mapproxy.service.ows import OWSServer
 
 import os
 import sys
@@ -2063,9 +2064,7 @@ class ServiceConfiguration(ConfigurationBase):
                 else:
                     services.append(new_service)
 
-        if ows_services:
-            from mapproxy.service.ows import OWSServer
-            services.append(OWSServer(ows_services))
+        services.append(OWSServer(ows_services))
         return services
 
     def tile_layers(self, conf, use_grid_names=False):

--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -93,7 +93,7 @@ class XMLExceptionHandler(ExceptionHandler):
     The content_type is sent as defined here.
     """
 
-    status_code = 200
+    status_code = 400
     """
     The HTTP status code.
     """

--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -97,7 +97,7 @@ class XMLExceptionHandler(ExceptionHandler):
     The content_type is sent as defined here.
     """
 
-    status_code = 400
+    status_code = 500
     """
     The HTTP status code.
     """
@@ -126,7 +126,11 @@ class XMLExceptionHandler(ExceptionHandler):
 
         :type request_error: `RequestError`
         """
-        status_code = self.status_codes.get(request_error.code, self.status_code)
+        if request_error.status is not None:
+            status_code = request_error.status
+        else:
+            status_code = self.status_codes.get(request_error.code, self.status_code)
+
         # escape &<> in error message (e.g. URL params)
         msg = escape(request_error.msg)
         result = self.template.substitute(exception=msg,
@@ -157,7 +161,11 @@ class OWSExceptionHandler(XMLExceptionHandler):
 
         :type request_error: `RequestError`
         """
-        status_code = self.status_codes.get(request_error.code, self.status_code)
+        if request_error.status is not None:
+            status_code = request_error.status
+        else:
+            status_code = self.status_codes.get(request_error.code, self.status_code)
+
         # escape &<> in error message (e.g. URL params)
         msg = escape(request_error.msg)
         result = self.template.substitute(exception=msg,

--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -19,7 +19,9 @@ Service exception handling (WMS exceptions, XML, in_image, etc.).
 from html import escape
 
 from mapproxy.response import Response
-
+from mapproxy.template import template_loader
+import mapproxy.service
+get_template = template_loader(mapproxy.service.__package__, 'templates')
 
 class RequestError(Exception):
     """
@@ -29,13 +31,14 @@ class RequestError(Exception):
                     was valid (e.g. the source server is unreachable
     """
 
-    def __init__(self, message, code=None, request=None, internal=False, status=None):
+    def __init__(self, message, code=None, request=None, internal=False, status=None, locator=None):
         Exception.__init__(self, message)
         self.msg = message
         self.code = code
         self.request = request
         self.internal = internal
         self.status = status
+        self.locator = locator
 
     def render(self):
         """
@@ -136,6 +139,30 @@ class XMLExceptionHandler(ExceptionHandler):
         The template for this ExceptionHandler.
         """
         return self.template_func(self.template_file)
+
+
+class OWSExceptionHandler(XMLExceptionHandler):
+    """
+    Exception handler for generic OWS ServiceExceptionReports
+    """
+    template_file = 'ows_exception.xml'
+    template_func = get_template
+    mimetype = 'text/xml'
+
+    def render(self, request_error):
+        """
+        Render the template of this exception handler. Passes the
+        ``request_error.msg``, ``request_error.locator`` and ``request_error.code`` to the template.
+
+        :type request_error: `RequestError`
+        """
+        status_code = self.status_codes.get(request_error.code, self.status_code)
+        # escape &<> in error message (e.g. URL params)
+        msg = escape(request_error.msg)
+        result = self.template.substitute(exception=msg,
+                                          code=request_error.code, locator=request_error.locator)
+        return Response(result, mimetype=self.mimetype, content_type=self.content_type,
+                        status=status_code)
 
 
 class PlainExceptionHandler(ExceptionHandler):

--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -23,6 +23,7 @@ from mapproxy.template import template_loader
 import mapproxy.service
 get_template = template_loader(mapproxy.service.__package__, 'templates')
 
+
 class RequestError(Exception):
     """
     Exception for all request related errors.

--- a/mapproxy/service/ows.py
+++ b/mapproxy/service/ows.py
@@ -18,6 +18,7 @@ Wrapper service handler for all OWS services (/service?).
 """
 from mapproxy.exception import OWSExceptionHandler, RequestError
 
+
 class OWSServer(object):
     """
     Wraps all OWS services (/service?, /ows?, /wms?, /wmts?) and dispatches requests
@@ -44,10 +45,10 @@ class OWSServer(object):
 
         service = service.lower()
         if service not in self.services:
-          # returning a WMS 1.3.0 Exception as fallback
-          req.exception_handler = OWSExceptionHandler()
-          error = RequestError('The value of the service parameter "' + str(service) + '" is invalid',
+            # returning a WMS 1.3.0 Exception as fallback
+            req.exception_handler = OWSExceptionHandler()
+            error = RequestError('The value of the service parameter "' + str(service) + '" is invalid',
                         code='InvalidParameterValue', request=req, locator='service')
-          return error.render()
+            return error.render()
 
         return self.services[service].handle(req)

--- a/mapproxy/service/ows.py
+++ b/mapproxy/service/ows.py
@@ -16,8 +16,7 @@
 """
 Wrapper service handler for all OWS services (/service?).
 """
-from mapproxy.exception import RequestError
-from mapproxy.request.wms import exception
+from mapproxy.exception import OWSExceptionHandler, RequestError
 
 class OWSServer(object):
     """
@@ -37,17 +36,18 @@ class OWSServer(object):
         service = req.args.get('service')
         if not service:
             # returning a WMS 1.3.0 Exception as fallback
-            req.exception_handler = exception.WMS130ExceptionHandler()
+            req.exception_handler = OWSExceptionHandler()
+
             error = RequestError('The service parameter is missing',
-                        code='MissingParameterValue', request=req)
-            return error.render()
+                        code='MissingParameterValue', request=req, locator='service')
+            return req.exception_handler.render(error)
 
         service = service.lower()
         if service not in self.services:
           # returning a WMS 1.3.0 Exception as fallback
-          req.exception_handler = exception.WMS130ExceptionHandler()
-          error = RequestError('The parameter "' + str(service) + '" is invalid',
-                        code='InvalidParameterValue', request=req)
+          req.exception_handler = OWSExceptionHandler()
+          error = RequestError('The value of the service parameter "' + str(service) + '" is invalid',
+                        code='InvalidParameterValue', request=req, locator='service')
           return error.render()
 
         return self.services[service].handle(req)

--- a/mapproxy/service/templates/ows_exception.xml
+++ b/mapproxy/service/templates/ows_exception.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
+  version="1.0.0" xml:lang="en">
+  <ows:Exception{{if code is not None}} exceptionCode="{{code}}"{{endif}}
+     {{if locator is not None}} locator="{{locator}}"{{endif}}>
+    <ows:ExceptionText>{{exception}}</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/mapproxy/test/system/test_legendgraphic.py
+++ b/mapproxy/test/system/test_legendgraphic.py
@@ -212,7 +212,7 @@ class TestWMSLegendgraphic(SysTest):
 
     def test_get_legendgraphic_no_legend_111(self, app):
         self.common_lg_req_111.params["layer"] = "wms_no_legend"
-        resp = app.get(self.common_lg_req_111)
+        resp = app.get(self.common_lg_req_111, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert (
@@ -227,7 +227,7 @@ class TestWMSLegendgraphic(SysTest):
             .replace("sld_version", "invalid")
             .replace("format", "invalid")
         )
-        resp = app.get(req)
+        resp = app.get(req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert "missing parameters" in xml.xpath("//ServiceException/text()")[0]
@@ -237,7 +237,7 @@ class TestWMSLegendgraphic(SysTest):
         req = str(self.common_lg_req_111).replace(
             "sld_version=1.1.0", "sld_version=1.0.0"
         )
-        resp = app.get(req)
+        resp = app.get(req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert "invalid sld_version" in xml.xpath("//ServiceException/text()")[0]
@@ -245,7 +245,7 @@ class TestWMSLegendgraphic(SysTest):
 
     def test_get_legendgraphic_no_legend_130(self, app):
         self.common_lg_req_130.params["layer"] = "wms_no_legend"
-        resp = app.get(self.common_lg_req_130)
+        resp = app.get(self.common_lg_req_130, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert_xpath_wms130(xml, "/ogc:ServiceExceptionReport/@version", "1.3.0")
@@ -258,7 +258,7 @@ class TestWMSLegendgraphic(SysTest):
 
     def test_get_legendgraphic_missing_params_130(self, app):
         req = str(self.common_lg_req_130).replace("format", "invalid")
-        resp = app.get(req)
+        resp = app.get(req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert_xpath_wms130(xml, "/ogc:ServiceExceptionReport/@version", "1.3.0")
@@ -271,7 +271,7 @@ class TestWMSLegendgraphic(SysTest):
         req = str(self.common_lg_req_130).replace(
             "sld_version=1.1.0", "sld_version=1.0.0"
         )
-        resp = app.get(req)
+        resp = app.get(req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert_xpath_wms130(xml, "/ogc:ServiceExceptionReport/@version", "1.3.0")

--- a/mapproxy/test/system/test_renderd_client.py
+++ b/mapproxy/test/system/test_renderd_client.py
@@ -179,14 +179,14 @@ class TestWMS111(SysTest):
 
         with mock_single_req_httpd(("localhost", 42423), req_handler):
             self.common_map_req.params["bbox"] = "0,0,9,9"
-            resp = app.get(self.common_map_req)
+            resp = app.get(self.common_map_req, expect_errors=True)
 
             assert resp.content_type == "application/vnd.ogc.se_xml"
             is_111_exception(resp.lxml, re_msg="Error from renderd: barf")
 
     def test_get_map_connection_error(self, app):
         self.common_map_req.params["bbox"] = "0,0,9,9"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
 
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, re_msg="Error while communicating with renderd:")
@@ -210,7 +210,7 @@ class TestWMS111(SysTest):
 
         with mock_single_req_httpd(("localhost", 42423), req_handler):
             self.common_map_req.params["bbox"] = "0,0,9,9"
-            resp = app.get(self.common_map_req)
+            resp = app.get(self.common_map_req, expect_errors=True)
 
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(

--- a/mapproxy/test/system/test_response_headers.py
+++ b/mapproxy/test/system/test_response_headers.py
@@ -46,7 +46,7 @@ class TestResponseHeaders(SysTest):
         assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
 
     def test_no_endpoint(self, app):
-        resp = app.get('http://localhost/service?')
+        resp = app.get('http://localhost/service?', expect_errors=True)
         assert resp.vary == ('X-Script-Name', 'X-Forwarded-Host', 'X-Forwarded-Proto')
 
     def test_image_response(self, app):

--- a/mapproxy/test/system/test_source_errors.py
+++ b/mapproxy/test/system/test_source_errors.py
@@ -129,7 +129,7 @@ class TestWMS(SysTest):
 
     def test_all_offline(self, app):
         self.common_map_req.params.layers = "all_offline"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, re_msg="no response from url")
 
@@ -175,12 +175,12 @@ class TestWMSRaise(SysTest):
 
         with mock_httpd(("localhost", 42423), expected_req):
             self.common_map_req.params.layers = "mixed"
-            resp = app.get(self.common_map_req)
+            resp = app.get(self.common_map_req, expect_errors=True)
             is_111_exception(resp.lxml, re_msg="no response from url")
 
     def test_all_offline(self, app):
         self.common_map_req.params.layers = "all_offline"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, re_msg="no response from url")
 
@@ -268,7 +268,7 @@ class TestTileErrors(SysTest):
         ]
 
         with mock_httpd(("localhost", 42423), expected_req):
-            resp = app.get(self.common_map_req)
+            resp = app.get(self.common_map_req, expect_errors=True)
             assert_no_cache(resp)
             assert resp.content_type == "application/vnd.ogc.se_xml"
             assert b"500" in resp.body

--- a/mapproxy/test/system/test_wms.py
+++ b/mapproxy/test/system/test_wms.py
@@ -141,7 +141,7 @@ class TestWMS111(SysTest):
 
     def test_invalid_request_type(self, app):
         req = str(self.common_map_req).replace("GetMap", "invalid")
-        resp = app.get(req)
+        resp = app.get(req, expect_errors=True)
         is_111_exception(resp.lxml, "unknown WMS request type 'invalid'")
 
     def test_endpoints(self, app):
@@ -220,20 +220,20 @@ class TestWMS111(SysTest):
 
     def test_invalid_layer(self, app):
         self.common_map_req.params["layers"] = "invalid"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, "unknown layer: invalid", "LayerNotDefined")
 
     def test_invalid_layer_img_exception(self, app):
         self.common_map_req.params["layers"] = "invalid"
         self.common_map_req.params["exceptions"] = "application/vnd.ogc.se_inimage"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "image/png"
         assert is_png(BytesIO(resp.body))
 
     def test_invalid_format(self, app):
         self.common_map_req.params["format"] = "image/ascii"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(
             resp.lxml, "unsupported image format: image/ascii", "InvalidFormat"
@@ -262,20 +262,20 @@ class TestWMS111(SysTest):
 
     def test_invalid_srs(self, app):
         self.common_map_req.params["srs"] = "EPSG:1234"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, "unsupported srs: EPSG:1234", "InvalidSRS")
 
     def test_get_map_unknown_style(self, app):
         self.common_map_req.params["styles"] = "unknown"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, "unsupported styles: unknown", "StyleNotDefined")
 
     def test_get_map_too_large(self, app):
         self.common_map_req.params.size = (5000, 5000)
         self.common_map_req.params["exceptions"] = "application/vnd.ogc.se_inimage"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         # is xml, even if inimage was requested
         assert resp.content_type == "application/vnd.ogc.se_xml"
         is_111_exception(resp.lxml, "image size too large")
@@ -371,7 +371,7 @@ class TestWMS111(SysTest):
 
     def test_get_map_xml_exception(self, app):
         self.common_map_req.params["bbox"] = "0,0,90,90"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/ServiceException/@code") == []
@@ -380,7 +380,7 @@ class TestWMS111(SysTest):
 
     def test_direct_layer_error(self, app):
         self.common_map_req.params["layers"] = "direct"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/ServiceException/@code") == []
@@ -403,7 +403,7 @@ class TestWMS111(SysTest):
             {"body": b"notanimage", "headers": {"content-type": "image/jpeg"}},
         )
         with mock_httpd(("localhost", 42423), [expected_req]):
-            resp = app.get(self.common_map_req)
+            resp = app.get(self.common_map_req, expect_errors=True)
             assert resp.content_type == "application/vnd.ogc.se_xml"
             xml = resp.lxml
             assert xml.xpath("/ServiceExceptionReport/ServiceException/@code") == []
@@ -428,7 +428,7 @@ class TestWMS111(SysTest):
             ("localhost", 42423), [expected_req], bbox_aware_query_comparator=True
         ):
             self.common_map_req.params["bbox"] = "0,0,180,90"
-            resp = app.get(self.common_map_req)
+            resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
 
         xml = resp.lxml
@@ -545,7 +545,7 @@ class TestWMS111(SysTest):
         url = (
             """/service?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&BBOX=7,2,-9,10&SRS=EPSG:4326&WIDTH=164&HEIGHT=388&LAYERS=wms_cache&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE"""  # noqa
         )
-        resp = app.get(url)
+        resp = app.get(url, expect_errors=True)
         is_111_exception(resp.lxml, "invalid bbox 7,2,-9,10")
 
     def test_get_map_invalid_bbox2(self, app):
@@ -553,7 +553,7 @@ class TestWMS111(SysTest):
         url = (
             """/service?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&BBOX=-72988843.697212,-255661507.634227,142741550.188860,255661507.634227&SRS=EPSG:25833&WIDTH=164&HEIGHT=388&LAYERS=wms_cache_100&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE"""  # noqa
         )
-        resp = app.get(url)
+        resp = app.get(url, expect_errors=True)
         # result depends on proj version
         is_111_exception(
             resp.lxml,
@@ -562,9 +562,9 @@ class TestWMS111(SysTest):
 
     def test_get_map_broken_bbox(self, app):
         url = (
-            """/service?VERSION=1.1.11&REQUEST=GetMap&SRS=EPSG:31468&BBOX=-20000855.0573254,2847125.18913603,-19329367.42767611,4239924.78564583&WIDTH=130&HEIGHT=62&LAYERS=wms_cache&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE"""  # noqa
+            """/service?SERVICE=WMS&VERSION=1.1.11&REQUEST=GetMap&SRS=EPSG:31468&BBOX=-20000855.0573254,2847125.18913603,-19329367.42767611,4239924.78564583&WIDTH=130&HEIGHT=62&LAYERS=wms_cache&STYLES=&FORMAT=image/png&TRANSPARENT=TRUE"""  # noqa
         )
-        resp = app.get(url)
+        resp = app.get(url, expect_errors=True)
         is_111_exception(resp.lxml, "Could not transform BBOX: Invalid result.")
 
     def test_get_map100(self, app, base_dir, cache_dir):
@@ -808,7 +808,7 @@ class TestWMS111(SysTest):
 
             del self.common_fi_req.params["format"]
             del self.common_fi_req.params["styles"]
-            resp = app.get(self.common_fi_req)
+            resp = app.get(self.common_fi_req, expect_errors=True)
             xml = resp.lxml
             assert "missing parameters" in xml.xpath("//ServiceException/text()")[0]
             assert validate_with_dtd(xml, "wms/1.1.1/exception_1_1_1.dtd")
@@ -819,7 +819,7 @@ class TestWMS111(SysTest):
     def test_get_featureinfo_not_queryable(self, app):
         self.common_fi_req.params["query_layers"] = "tms_cache"
         self.common_fi_req.params["exceptions"] = "application/vnd.ogc.se_xml"
-        resp = app.get(self.common_fi_req)
+        resp = app.get(self.common_fi_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/ServiceException/@code") == []
@@ -912,7 +912,7 @@ class TestWMS110(SysTest):
 
     def test_invalid_layer(self, app):
         self.common_map_req.params["layers"] = "invalid"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/@version")[0] == "1.1.0"
@@ -925,7 +925,7 @@ class TestWMS110(SysTest):
 
     def test_invalid_format(self, app):
         self.common_map_req.params["format"] = "image/ascii"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/@version")[0] == "1.1.0"
@@ -955,7 +955,7 @@ class TestWMS110(SysTest):
 
     def test_invalid_srs(self, app):
         self.common_map_req.params["srs"] = "EPSG:1234"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/@version")[0] == "1.1.0"
@@ -980,7 +980,7 @@ class TestWMS110(SysTest):
 
     def test_get_map_xml_exception(self, app):
         self.common_map_req.params["bbox"] = "0,0,90,90"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/ServiceException/@code") == []
@@ -1053,7 +1053,7 @@ class TestWMS110(SysTest):
     def test_get_featureinfo_not_queryable(self, app):
         self.common_fi_req.params["query_layers"] = "tms_cache"
         self.common_fi_req.params["exceptions"] = "application/vnd.ogc.se_xml"
-        resp = app.get(self.common_fi_req)
+        resp = app.get(self.common_fi_req, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
         xml = resp.lxml
         assert xml.xpath("/ServiceExceptionReport/ServiceException/@code") == []
@@ -1167,7 +1167,7 @@ class TestWMS100(SysTest):
 
     def test_invalid_layer(self, app):
         self.common_map_req.params["layers"] = "invalid"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert xml.xpath("/WMTException/@version")[0] == "1.0.0"
@@ -1175,7 +1175,7 @@ class TestWMS100(SysTest):
 
     def test_invalid_format(self, app):
         self.common_map_req.params["format"] = "image/ascii"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert xml.xpath("/WMTException/@version")[0] == "1.0.0"
@@ -1201,7 +1201,7 @@ class TestWMS100(SysTest):
     def test_invalid_srs(self, app):
         self.common_map_req.params["srs"] = "EPSG:1234"
         print(self.common_map_req.complete_url)
-        resp = app.get(self.common_map_req.complete_url)
+        resp = app.get(self.common_map_req.complete_url, expect_errors=True)
         xml = resp.lxml
         assert xml.xpath("//WMTException/text()")[0].strip() == "unsupported srs: EPSG:1234"
 
@@ -1234,7 +1234,7 @@ class TestWMS100(SysTest):
 
     def test_get_map_xml_exception(self, app):
         self.common_map_req.params["bbox"] = "0,0,90,90"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         xml = resp.lxml
         assert "No response from URL" in xml.xpath("//WMTException/text()")[0]
 
@@ -1278,7 +1278,7 @@ class TestWMS100(SysTest):
     def test_get_featureinfo_not_queryable(self, app):
         self.common_fi_req.params["query_layers"] = "tms_cache"
         self.common_fi_req.params["exceptions"] = "application/vnd.ogc.se_xml"
-        resp = app.get(self.common_fi_req)
+        resp = app.get(self.common_fi_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert "tms_cache is not queryable" in xml.xpath("//WMTException/text()")[0]
@@ -1383,7 +1383,7 @@ class TestWMS130(SysTest):
 
     def test_invalid_layer(self, app):
         self.common_map_req.params["layers"] = "invalid"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert_xpath_wms130(xml, "/ogc:ServiceExceptionReport/@version", "1.3.0")
@@ -1397,7 +1397,7 @@ class TestWMS130(SysTest):
 
     def test_invalid_format(self, app):
         self.common_map_req.params["format"] = "image/ascii"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert_xpath_wms130(xml, "/ogc:ServiceExceptionReport/@version", "1.3.0")
@@ -1431,7 +1431,7 @@ class TestWMS130(SysTest):
         self.common_map_req.params["srs"] = "EPSG:1234"
         self.common_map_req.params["exceptions"] = "text/xml"
 
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert_xpath_wms130(
@@ -1457,7 +1457,7 @@ class TestWMS130(SysTest):
 
     def test_get_map_xml_exception(self, app):
         self.common_map_req.params["bbox"] = "0,0,90,90"
-        resp = app.get(self.common_map_req)
+        resp = app.get(self.common_map_req, expect_errors=True)
         assert resp.content_type == "text/xml"
         xml = resp.lxml
         assert (

--- a/mapproxy/test/system/test_wmsc.py
+++ b/mapproxy/test/system/test_wmsc.py
@@ -99,18 +99,18 @@ class TestWMSC(SysTest):
 
     def test_get_tile_wrong_bbox(self, app):
         self.common_map_req.params.bbox = "-20037508,0.0,200000.0,20037508"
-        resp = app.get(str(self.common_map_req) + "&tiled=true")
+        resp = app.get(str(self.common_map_req) + "&tiled=true", expect_errors=True)
         assert_no_cache(resp)
         is_111_exception(resp.lxml, re_msg=".*invalid bbox")
 
     def test_get_tile_wrong_fromat(self, app):
         self.common_map_req.params.format = "image/png"
-        resp = app.get(str(self.common_map_req) + "&tiled=true")
+        resp = app.get(str(self.common_map_req) + "&tiled=true", expect_errors=True)
         assert_no_cache(resp)
         is_111_exception(resp.lxml, re_msg="Invalid request: invalid.*format.*jpeg")
 
     def test_get_tile_wrong_size(self, app):
         self.common_map_req.params.size = (256, 255)
-        resp = app.get(str(self.common_map_req) + "&tiled=true")
+        resp = app.get(str(self.common_map_req) + "&tiled=true", expect_errors=True)
         assert_no_cache(resp)
         is_111_exception(resp.lxml, re_msg="Invalid request: invalid.*size.*256x256")

--- a/mapproxy/test/unit/test_exceptions.py
+++ b/mapproxy/test/unit/test_exceptions.py
@@ -39,6 +39,7 @@ REQUEST=GetMap&STYLES=&EXCEPTIONS=application%2Fvnd.ogc.se_xml&SRS=EPSG%3A900913
 BBOX=8,4,9,5&WIDTH=150&HEIGHT=100""".replace('\n', ''))
         self.req = req
 
+
 class TestWMS111ExceptionHandler(Mocker):
     def test_render(self):
         req = self.mock(WMSMapRequest)
@@ -169,14 +170,15 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 
     def test_missing_service_request(self):
         reqString = "REQUEST=GetCapabilities"
-        conf = {'QUERY_STRING': reqString,
-           'wsgi.url_scheme': 'http',
-           'HTTP_HOST': 'localhost',
+        conf = {
+            'QUERY_STRING': reqString,
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'localhost',
         }
         req = Request(conf)
         ows_services = []
-        server = OWSServer(ows_services);
-        response = server.handle(req);
+        server = OWSServer(ows_services)
+        response = server.handle(req)
 
         expected_resp = """
 <?xml version="1.0"?>
@@ -198,14 +200,15 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 
     def test_invalid_service_request(self):
         reqString = "REQUEST=GetCapabilities&SERVICE=wms"
-        conf = {'QUERY_STRING': reqString,
-           'wsgi.url_scheme': 'http',
-           'HTTP_HOST': 'localhost',
+        conf = {
+            'QUERY_STRING': reqString,
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'localhost',
         }
         req = Request(conf)
         ows_services = []
-        server = OWSServer(ows_services);
-        response = server.handle(req);
+        server = OWSServer(ows_services)
+        response = server.handle(req)
 
         expected_resp = """
 <?xml version="1.0"?>
@@ -227,19 +230,24 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 
     def test_valid_service_request(self):
         reqString = "REQUEST=GetCapabilities&SERVICE=wms"
-        conf = {'QUERY_STRING': reqString,
-           'wsgi.url_scheme': 'http',
-           'HTTP_HOST': 'localhost',
+        conf = {
+            'QUERY_STRING': reqString,
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'localhost',
         }
         req = Request(conf)
+
         class Service(object):
+
             def __init__(self, service):
                 self.service = service
-            def handle(a,b):
+
+            def handle():
                 return 'all good'
+
         ows_services = [Service('wms')]
-        server = OWSServer(ows_services);
-        response = server.handle(req);
+        server = OWSServer(ows_services)
+        response = server.handle(req)
 
         expected_resp = 'all good'
         assert expected_resp == response

--- a/mapproxy/test/unit/test_exceptions.py
+++ b/mapproxy/test/unit/test_exceptions.py
@@ -180,19 +180,21 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 
         expected_resp = """
 <?xml version="1.0"?>
-<ServiceExceptionReport version="1.3.0"
-  xmlns="http://www.opengis.net/ogc"
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.opengis.net/ogc
-http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
-    <ServiceException code="MissingParameterValue">The service parameter is missing</ServiceException>
-</ServiceExceptionReport>
+  xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
+  version="1.0.0" xml:lang="en">
+  <ows:Exception exceptionCode="MissingParameterValue"
+      locator="service">
+    <ows:ExceptionText>The service parameter is missing</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>
 """
 
-        assert expected_resp.strip() == response.response
+        assert expected_resp.strip() == response.response.strip()
         assert response.content_type == 'text/xml; charset=utf-8'
         assert response.status == '400 Bad Request'
-        assert validate_with_xsd(response.data, 'wms/1.3.0/exceptions_1_3_0.xsd')
+        assert validate_with_xsd(response.response, 'ows/1.1.0/owsExceptionReport.xsd')
 
     def test_invalid_service_request(self):
         reqString = "REQUEST=GetCapabilities&SERVICE=wms"
@@ -207,19 +209,21 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 
         expected_resp = """
 <?xml version="1.0"?>
-<ServiceExceptionReport version="1.3.0"
-  xmlns="http://www.opengis.net/ogc"
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.opengis.net/ogc
-http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
-    <ServiceException code="InvalidParameterValue">The parameter &quot;wms&quot; is invalid</ServiceException>
-</ServiceExceptionReport>
+  xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
+  version="1.0.0" xml:lang="en">
+  <ows:Exception exceptionCode="InvalidParameterValue"
+      locator="service">
+    <ows:ExceptionText>The value of the service parameter &quot;wms&quot; is invalid</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>
 """
 
         assert expected_resp.strip() == response.response
         assert response.content_type == 'text/xml; charset=utf-8'
         assert response.status == '400 Bad Request'
-        assert validate_with_xsd(response.data, 'wms/1.3.0/exceptions_1_3_0.xsd')
+        assert validate_with_xsd(response.response, 'ows/1.1.0/owsExceptionReport.xsd')
 
     def test_valid_service_request(self):
         reqString = "REQUEST=GetCapabilities&SERVICE=wms"
@@ -239,6 +243,7 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 
         expected_resp = 'all good'
         assert expected_resp == response
+
 
 class TestWMS100ExceptionHandler(Mocker):
     def test_render(self):

--- a/mapproxy/test/unit/test_exceptions.py
+++ b/mapproxy/test/unit/test_exceptions.py
@@ -242,7 +242,7 @@ http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
             def __init__(self, service):
                 self.service = service
 
-            def handle():
+            def handle(self, req):
                 return 'all good'
 
         ows_services = [Service('wms')]


### PR DESCRIPTION
This adds OWS Exceptions to requests that are invalid:
- If the `service` parameter is missing, an Exception like this is thrown (with status code 400):
    ```
    <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
      version="1.0.0" xml:lang="en">
      <ows:Exception exceptionCode="MissingParameterValue"
          locator="service">
        <ows:ExceptionText>The service parameter is missing</ows:ExceptionText>
      </ows:Exception>
    </ows:ExceptionReport>
    ```
  - old behaviour was either `internal error` or redirect to WMS Capabilities
- If the `service` parameter has an unsupported value (service is disabled or non existent), an Exception like this is thrown (with status code 400):
    ```
    <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
      version="1.0.0" xml:lang="en">
      <ows:Exception exceptionCode="InvalidParameterValue"
          locator="service">
        <ows:ExceptionText>The value of the service parameter &quot;test&quot; is invalid</ows:ExceptionText>
      </ows:Exception>
    </ows:ExceptionReport>
    ```

XML-based Exceptions in general will now return with status code 500 as default instead of 200, which is the better choice in terms of conformity. This is a breaking change and needs a major version increase
