### PR TITLE
Fix capabilities links in demo and config template

### DIFF
--- a/mapproxy/config_template/base_config/mapproxy.yaml
+++ b/mapproxy/config_template/base_config/mapproxy.yaml
@@ -10,7 +10,7 @@
 # Demo:
 #     http://localhost:8080/demo
 # WMS:
-#     capabilities: http://localhost:8080/service?REQUEST=GetCapabilities
+#     capabilities: http://localhost:8080/service?REQUEST=GetCapabilities&SERVICE=WMS
 # WMTS:
 #     capabilities: http://localhost:8080/wmts/1.0.0/WMTSCapabilities.xml
 #     first tile: http://localhost:8080/wmts/osm/webmercator/0/0/0.png

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -138,7 +138,7 @@ class DemoServer(Server):
         elif 'wmts_layer' in req.args:
             demo = self._render_wmts_template('demo/wmts_demo.html', req)
         elif 'wms_capabilities' in req.args:
-            internal_url = '%s/service?REQUEST=GetCapabilities' % (req.server_script_url)
+            internal_url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMS' % (req.server_script_url)
             if 'type' in req.args and req.args['type'] == 'external':
                 url = internal_url.replace(req.server_script_url, req.script_url)
             else:
@@ -146,7 +146,7 @@ class DemoServer(Server):
             capabilities = urllib2.urlopen(url)
             demo = self._render_capabilities_template('demo/capabilities_demo.html', capabilities, 'WMS', url)
         elif 'wmsc_capabilities' in req.args:
-            internal_url = '%s/service?REQUEST=GetCapabilities&tiled=true' % (req.server_script_url)
+            internal_url = '%s/service?REQUEST=GetCapabilities&SERVICE=WMS&tiled=true' % (req.server_script_url)
             if 'type' in req.args and req.args['type'] == 'external':
                 url = internal_url.replace(req.server_script_url, req.script_url)
             else:

--- a/mapproxy/service/templates/demo/demo.html
+++ b/mapproxy/service/templates/demo/demo.html
@@ -35,7 +35,7 @@ jscript_openlayers=None
             {{if 'wms' in services}}
             <div class="capabilities">
                 <span>Capabilities document</span>
-                <span><a href="../service?REQUEST=GetCapabilities">(download as xml)</a></span>
+                <span><a href="../service?REQUEST=GetCapabilities&SERVICE=WMS">(download as xml)</a></span>
                 <span><a href="../demo/?wms_capabilities">(view as html, internal)</a></span>
                 <span><a href="../demo/?wms_capabilities&type=external">(view as html, external)</a></span>
             </div>
@@ -83,7 +83,7 @@ jscript_openlayers=None
             {{if 'wms' in services}}
             <div class="capabilities">
                 <span>Capabilities document</span>
-                <span><a href="../service?REQUEST=GetCapabilities&tiled=true">(download as xml)</a></span>
+                <span><a href="../service?REQUEST=GetCapabilities&SERVICE=WMS&tiled=true">(download as xml)</a></span>
                 <span><a href="../demo/?wmsc_capabilities">(view as html, internal)</a></span>
                 <span><a href="../demo/?wmsc_capabilities&type=external">(view as html, external)</a></span>
             </div>

--- a/mapproxy/test/system/test_demo.py
+++ b/mapproxy/test/system/test_demo.py
@@ -29,8 +29,8 @@ class TestDemo(SysTest):
     def test_basic(self, app):
         resp = app.get("/demo/", status=200)
         assert resp.content_type == "text/html"
-        assert 'href="../service?REQUEST=GetCapabilities"' in resp
-        assert 'href="../service?REQUEST=GetCapabilities&tiled=true"' in resp
+        assert 'href="../service?REQUEST=GetCapabilities&SERVICE=WMS"' in resp
+        assert 'href="../service?REQUEST=GetCapabilities&SERVICE=WMS&tiled=true"' in resp
         assert 'href="../demo/?wmts_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
         assert 'href="../demo/?tms_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
 

--- a/mapproxy/test/system/test_demo_with_extra_service.py
+++ b/mapproxy/test/system/test_demo_with_extra_service.py
@@ -45,8 +45,8 @@ class TestDemoWithExtraService(SysTest):
     def test_basic(self, app):
         resp = app.get("/demo/", status=200)
         assert resp.content_type == "text/html"
-        assert 'href="../service?REQUEST=GetCapabilities"' in resp
-        assert 'href="../service?REQUEST=GetCapabilities&tiled=true"' in resp
+        assert 'href="../service?REQUEST=GetCapabilities&SERVICE=WMS"' in resp
+        assert 'href="../service?REQUEST=GetCapabilities&SERVICE=WMS&tiled=true"' in resp
         assert 'href="../demo/?wmts_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
         assert 'href="../demo/?tms_layer=wms_cache&format=jpeg&srs=EPSG%3A900913"' in resp
         assert '<h2>My extra service</h2>' in resp


### PR DESCRIPTION
As the capabilities now have to be requested with correct `service` parameter (see https://github.com/mapproxy/mapproxy/pull/967 for details), the demo page and template file now also needs to include it.