### PR TITLE
Fix trivy result upload

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -128,9 +128,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.24.0
         with:
-          format: 'table'
+          format: 'sarif'
           ignore-unfixed: true
           image-ref: ${{ needs.get-version.outputs.version }}
           output: 'trivy-results.sarif'


### PR DESCRIPTION
This should hopefully fix the upload error we are currently getting (https://github.com/mapproxy/mapproxy/actions/runs/10575391161/job/29299574218) when running the trivy job:

![image](https://github.com/user-attachments/assets/30c88eef-cc9d-4a38-ae4f-cc952d1c7e73)

@ahennr please review