### PR TITLE
Removed pin of werkzeug version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'pyproj>=2',
     'jsonschema>=4',
     'importlib_resources;python_version<="3.8"',
-    'werkzeug==1.0.1'
+    'werkzeug'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'pyproj>=2',
     'jsonschema>=4',
     'importlib_resources;python_version<="3.8"',
-    'werkzeug'
+    'werkzeug<4'
 ]
 
 


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

This PR lifts the pin on the werkzeug version `1.0.1`, as currently found on `setup.py`. It would allow MapProxy to be installed with recent versions of werkzeug, thus making it easier to use together with other components of the Python ecosystem.

---

- fixes #1000