### PR TITLE
Fix transparency in TMS demo page

### DIFF
--- a/mapproxy/service/templates/demo/tms_demo.html
+++ b/mapproxy/service/templates/demo/tms_demo.html
@@ -42,7 +42,7 @@ jscript_functions=None
         // Define TMS as specialized XYZ service: origin lower-left and may have custom grid
         const source = new ol.source.XYZ({
             url: '../tms/1.0.0/{{"/".join(layer.md["name_path"])}}/{z}/{x}/{-y}.' + format,
-            opaque: transparent,
+            opaque: !transparent,
             projection: "{{srs}}",
             maxResolution: {{resolutions[0]}},
             tileGrid: new  ol.tilegrid.TileGrid({


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

The logic for the demo page using TMS doesn't currently support transparency due to incorrect logic