### PR TITLE
dev: prepare 3.1.0 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,19 @@
+3.1.0 2024-10-22
+~~~~~~~~~~~~~~~~
+
+Improvements:
+
+  - Add new config parameters `file_permissions` and `directory_permissions` to set file and directory
+  permissions on newly created cache files and directories.
+
+Maintenance:
+
+  - Dependency updates
+
+Fixes:
+
+  - Fix transparency in TMS demo page.
+
 3.0.1 2024-08-27
 ~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def long_description(changelog_releases=10):
 
 setup(
     name='MapProxy',
-    version="3.0.1",
+    version="3.1.0",
     description='An accelerating proxy for tile and web map services',
     long_description=long_description(7),
     author='Oliver Tonnhofer',


### PR DESCRIPTION
Prepare release **3.1.0**
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
