### PR TITLE
docs: correct docs for autodetect coverages

### DIFF
--- a/doc/coverages.rst
+++ b/doc/coverages.rst
@@ -41,7 +41,7 @@ All coverages are configured by defining the source of the coverage and the SRS.
 The configuration of the coverage depends on the type. The SRS can allways be configured with the ``srs`` option.
 
 .. versionadded:: 1.5.0
-    MapProxy can autodetect the type of the coverage. You can now use ``coverage`` instead of the ``bbox``, ``polygons`` or ``ogr_datasource`` option.
+    MapProxy can autodetect the type of the coverage. You can now use ``datasource`` instead of the ``bbox``, ``polygons`` or ``ogr_datasource`` option.
     The old options are still supported.
 
 Coverage Types


### PR DESCRIPTION
`coverages` is not valid, `datasource` is the magic property.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
