### PR TITLE
feat: better exception logging in the seeding tasks

### DIFF
--- a/mapproxy/seed/config.py
+++ b/mapproxy/seed/config.py
@@ -163,6 +163,8 @@ class SeedingConfiguration(object):
             raise SeedConfigurationError("invalid geometry in coverage '%s'. %s" % (name, ex))
         except EmptyGeometryError as ex:
             raise EmptyCoverageError("coverage '%s' contains no geometries. %s" % (name, ex))
+        except Exception:
+            raise Exception(f"can't load coverage '{name}'")
 
         # without extend we have an empty coverage
         if not coverage.extent.llbbox:


### PR DESCRIPTION
This prints some additional information about where the exception occured. The handled exception `ex` will be set as cause for the new exception and both stack traces will be printed:

```
Traceback (most recent call last):
  File "./mapproxy/mapproxy/seed/config.py", line 159, in coverage
    coverage = load_coverage(coverage_conf)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/config/coverage.py", line 73, in load_coverage
    geom = load_polygons(abspath(conf['polygons'], base_path=base_path))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/util/geom.py", line 121, in load_polygons
    polygons.extend(load_polygon_lines(f, source=geom_files))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/util/geom.py", line 164, in load_polygon_lines
    for line in line_iter:
                ^^^^^^^^^
  File "<frozen codecs>", line 720, in __next__
  File "<frozen codecs>", line 648, in __next__
  File "<frozen codecs>", line 561, in readline
  File "<frozen codecs>", line 507, in read
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe8 in position 0: invalid continuation byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./venv/bin/mapproxy-seed", line 33, in <module>
    sys.exit(load_entry_point('MapProxy', 'console_scripts', 'mapproxy-seed')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/script.py", line 366, in main
    return SeedScript()()
           ^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/script.py", line 224, in __call__
    seed_tasks = seed_conf.seeds(seed_names)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 209, in seeds
    seed_conf = SeedConfiguration(seed_name, seed_conf, self)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 290, in __init__
    ConfigurationBase.__init__(self, name, conf, seeding_conf)
  File "./mapproxy/mapproxy/seed/config.py", line 236, in __init__
    self.coverage = self._coverages()
                    ^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 245, in _coverages
    coverages = [self.seeding_conf.coverage(c) for c in self.conf.get('coverages', {})]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/util/py.py", line 73, in wrapper
    cache[key] = func(self, *args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 167, in coverage
    raise Exception(f"can't load coverage '{name}'")
Exception: can't load coverage 'dop2011'
```

instead of just:

```
Traceback (most recent call last):
  File "./venv/bin/mapproxy-seed", line 33, in <module>
    sys.exit(load_entry_point('MapProxy', 'console_scripts', 'mapproxy-seed')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/script.py", line 366, in main
    return SeedScript()()
           ^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/script.py", line 224, in __call__
    seed_tasks = seed_conf.seeds(seed_names)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 209, in seeds
    seed_conf = SeedConfiguration(seed_name, seed_conf, self)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 290, in __init__
    ConfigurationBase.__init__(self, name, conf, seeding_conf)
  File "./mapproxy/mapproxy/seed/config.py", line 236, in __init__
    self.coverage = self._coverages()
                    ^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 245, in _coverages
    coverages = [self.seeding_conf.coverage(c) for c in self.conf.get('coverages', {})]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/util/py.py", line 73, in wrapper
    cache[key] = func(self, *args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/seed/config.py", line 159, in coverage
    coverage = load_coverage(coverage_conf)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/config/coverage.py", line 73, in load_coverage
    geom = load_polygons(abspath(conf['polygons'], base_path=base_path))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/util/geom.py", line 121, in load_polygons
    polygons.extend(load_polygon_lines(f, source=geom_files))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./mapproxy/mapproxy/util/geom.py", line 164, in load_polygon_lines
    for line in line_iter:
                ^^^^^^^^^
  File "<frozen codecs>", line 720, in __next__
  File "<frozen codecs>", line 648, in __next__
  File "<frozen codecs>", line 561, in readline
  File "<frozen codecs>", line 507, in read
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe8 in position 0: invalid continuation byte
```

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
