### PR TITLE
fix: use file permissions also for lock files

### DIFF
--- a/mapproxy/cache/base.py
+++ b/mapproxy/cache/base.py
@@ -98,11 +98,12 @@ if sys.platform == 'win32':
 
 
 class TileLocker(object):
-    def __init__(self, lock_dir, lock_timeout, lock_cache_id, directory_permissions=None):
+    def __init__(self, lock_dir, lock_timeout, lock_cache_id, directory_permissions=None, file_permissions=None):
         self.lock_dir = lock_dir
         self.lock_timeout = lock_timeout
         self.lock_cache_id = lock_cache_id
         self.directory_permissions = directory_permissions
+        self.file_permissions = file_permissions
 
     def lock_filename(self, tile):
         return os.path.join(self.lock_dir, self.lock_cache_id + '-' +
@@ -118,4 +119,5 @@ class TileLocker(object):
         cleanup_lockdir(self.lock_dir, max_lock_time=self.lock_timeout + 10,
                         force=False)
         return FileLock(lock_filename, timeout=self.lock_timeout,
-                        remove_on_unlock=REMOVE_ON_UNLOCK, directory_permissions=self.directory_permissions)
+                        remove_on_unlock=REMOVE_ON_UNLOCK, directory_permissions=self.directory_permissions,
+                        file_permissions=self.file_permissions)

--- a/mapproxy/cache/compact.py
+++ b/mapproxy/cache/compact.py
@@ -192,7 +192,8 @@ class BundleV1(object):
                 data = buf.read()
             tiles_data.append((t.coord, data))
 
-        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions, remove_on_unlock=True):
+        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions,
+                      file_permissions=self.file_permissions, remove_on_unlock=True):
             with self.data().readwrite() as bundle:
                 with self.index().readwrite() as idx:
                     for tile_coord, data in tiles_data:
@@ -236,7 +237,8 @@ class BundleV1(object):
         if tile.coord is None:
             return True
 
-        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions, remove_on_unlock=True):
+        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions,
+                      file_permissions=self.file_permissions, remove_on_unlock=True):
             with self.index().readwrite() as idx:
                 x, y = self._rel_tile_coord(tile.coord)
                 idx.remove_tile_offset(x, y)
@@ -634,7 +636,8 @@ class BundleV2(object):
                 data = buf.read()
             tiles_data.append((t.coord, data))
 
-        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions, remove_on_unlock=True):
+        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions,
+                      file_permissions=self.file_permissions, remove_on_unlock=True):
             with self._readwrite() as fh:
                 for tile_coord, data in tiles_data:
                     self._store_tile(fh, tile_coord, data, dimensions=dimensions)
@@ -646,7 +649,8 @@ class BundleV2(object):
             return True
 
         self._init_index()
-        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions, remove_on_unlock=True):
+        with FileLock(self.lock_filename, directory_permissions=self.directory_permissions,
+                      file_permissions=self.file_permissions, remove_on_unlock=True):
             with self._readwrite() as fh:
                 x, y = self._rel_tile_coord(tile.coord)
                 self._update_tile_offset(fh, x, y, 0, 0)

--- a/mapproxy/cache/geopackage.py
+++ b/mapproxy/cache/geopackage.py
@@ -112,8 +112,8 @@ class GeopackageCache(TileCacheBase):
 
     def ensure_gpkg(self):
         if not os.path.isfile(self.geopackage_file):
-            with FileLock(self.geopackage_file + '.init.lck',
-                          remove_on_unlock=REMOVE_ON_UNLOCK, directory_permissions=self.directory_permissions):
+            with FileLock(self.geopackage_file + '.init.lck', remove_on_unlock=REMOVE_ON_UNLOCK,
+                          directory_permissions=self.directory_permissions, file_permissions=self.file_permissions):
                 ensure_directory(self.geopackage_file, self.directory_permissions)
                 self._initialize_gpkg()
         else:

--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -77,8 +77,8 @@ class MBTilesCache(TileCacheBase):
 
     def ensure_mbtile(self):
         if not os.path.exists(self.mbtile_file):
-            with FileLock(self.mbtile_file + '.init.lck',
-                          remove_on_unlock=REMOVE_ON_UNLOCK, directory_permissions=self.directory_permissions):
+            with FileLock(self.mbtile_file + '.init.lck', remove_on_unlock=REMOVE_ON_UNLOCK,
+                          directory_permissions=self.directory_permissions, file_permissions=self.file_permissions):
                 if not os.path.exists(self.mbtile_file):
                     ensure_directory(self.mbtile_file, self.directory_permissions)
                     self._initialize_mbtile()

--- a/mapproxy/util/ext/lockfile.py
+++ b/mapproxy/util/ext/lockfile.py
@@ -115,10 +115,13 @@ class LockFile:
 
     _fp = None
 
-    def __init__(self, path):
+    def __init__(self, path, file_permissions):
         self._path = path
         try:
             fp = open(path, 'w+')
+            if file_permissions:
+                permission = int(file_permissions, base=8)
+                os.chmod(path, permission)
         except IOError:
             raise Exception('Could not create Lock-file, wrong permissions on lock directory?')
 

--- a/mapproxy/util/lock.py
+++ b/mapproxy/util/lock.py
@@ -118,11 +118,10 @@ def cleanup_lockdir(lockdir, suffix='.lck', max_lock_time=300, force=True):
         try:
             if os.path.isfile(name) and name.endswith(suffix):
                 if os.path.getmtime(name) < expire_time:
-                    if os.stat(name).st_uid == os.getuid():
-                        try:
-                            os.unlink(name)
-                        except IOError as ex:
-                            log.warning('could not remove old lock file %s: %s', name, ex)
+                    try:
+                        os.unlink(name)
+                    except IOError as ex:
+                        log.warning('could not remove old lock file %s: %s', name, ex)
         except OSError as e:
             # some one might have removed the file (ENOENT)
             # or we don't have permissions to remove it (EACCES)


### PR DESCRIPTION
The lock files were missing file permissions if set. This adds the functionality and adds a test for it.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
