### PR TITLE
fix: split supported layers if they are given as a string

### DIFF
--- a/mapproxy/config/validator.py
+++ b/mapproxy/config/validator.py
@@ -172,7 +172,7 @@ def _validate_tagged_layer_source(
         name: str, supported_layers: Union[str, List[str]], requested_layers: List[str]) -> List[str]:
     errors = []
     if isinstance(supported_layers, str):
-        supported_layers = [supported_layers]
+        supported_layers = supported_layers.split(',')
     if not set(requested_layers).issubset(set(supported_layers)):
         return [
             f"Supported layers for source '{name}' are '{', '.join(supported_layers)}' but tagged source requested"


### PR DESCRIPTION
Closes #989 

This does not allow for whitespace in the layers property. But this would fail in the request anyways.

It might be better to enforce the layers property to be an array. This way we can rely on the yaml parsing instead of doing our own. This would break existing configs and would need a major release. I could open an issue for this and maybe add a `milestone v4` label to it.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
