### PR TITLE
fix: only use chmod if the file was created

### DIFF
--- a/mapproxy/cache/compact.py
+++ b/mapproxy/cache/compact.py
@@ -347,8 +347,9 @@ class BundleIndexV1(object):
     @contextlib.contextmanager
     def readwrite(self):
         self._init_index()
+        set_permissions = self.file_permissions and not os.path.exists(self.filename)
         with open(self.filename, 'r+b') as fh:
-            if self.file_permissions:
+            if set_permissions:
                 permission = int(self.file_permissions, base=8)
                 log.info("setting file permissions on compact cache file: " + self.file_permissions)
                 os.chmod(self.filename, permission)

--- a/mapproxy/cache/legend.py
+++ b/mapproxy/cache/legend.py
@@ -65,9 +65,10 @@ class LegendCache(object):
 
         data = legend.source.as_buffer(ImageOptions(format='image/' + self.file_ext), seekable=True)
         data.seek(0)
+        set_permissions = self.file_permissions and not os.path.exists(legend.location)
         log.debug('writing to %s' % (legend.location))
         write_atomic(legend.location, data.read())
-        if self.file_permissions:
+        if set_permissions:
             permission = int(self.file_permissions, base=8)
             log.info("setting file permissions on compact cache file: " + self.file_permissions)
             os.chmod(legend.location, permission)

--- a/mapproxy/util/ext/lockfile.py
+++ b/mapproxy/util/ext/lockfile.py
@@ -117,13 +117,15 @@ class LockFile:
 
     def __init__(self, path, file_permissions):
         self._path = path
+        set_permissions = file_permissions and not os.path.exists(path)
         try:
             fp = open(path, 'w+')
-            if file_permissions:
-                permission = int(file_permissions, base=8)
-                os.chmod(path, permission)
         except IOError:
             raise Exception('Could not create Lock-file, wrong permissions on lock directory?')
+
+        if set_permissions:
+            permission = int(file_permissions, base=8)
+            os.chmod(path, permission)
 
         try:
             _lock_file(fp)

--- a/mapproxy/util/fs.py
+++ b/mapproxy/util/fs.py
@@ -119,7 +119,6 @@ def ensure_directory(file_name, directory_permissions=None):
             # call ensure_directory recursively
             ensure_directory(dir_name, directory_permissions)
 
-            # print("create dir" + dir + "with permission" + directory_permissions)
             os.mkdir(dir_name)
             if directory_permissions:
                 permission = int(directory_permissions, base=8)


### PR DESCRIPTION
chmod can fail if the user is not the owner of the file. So we call it only if the file was created. I scanned for all calls of chmod.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
