### PR TITLE
AdminstrativeArea added to WMTS serviceprovider metadata.

### DIFF
--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -34,7 +34,7 @@
         <ows:Address>
           <ows:DeliveryPoint>{{service.contact.organization}}</ows:DeliveryPoint>
           <ows:City>{{service.contact.city}}</ows:City>
-          <ows:AdministrativeArea>{{service.contact.city}}</ows:AdministrativeArea>
+          <ows:AdministrativeArea>{{service.contact.state}}</ows:AdministrativeArea>
           <ows:PostalCode>{{service.contact.postcode}}</ows:PostalCode>
           <ows:Country>{{service.contact.country}}</ows:Country>
           <ows:ElectronicMailAddress>{{service.contact.email}}</ows:ElectronicMailAddress>


### PR DESCRIPTION
This PR adds support to provide the `AdminstrativeArea` metadata tag to the ServiceProvider contact information as specified in subclause 7.4.4 and owsServiceProvider.xsd of OWS Common [OGC 06-121r3].

Once I added `state` to the WMS `md` in the YAML, the templates populated the StateOrProvince metadata tag. Adding the `state` info to the WMTS `md` in the `mapproxy.yaml` did not change anything in the ServiceProvider contact information. Once I extended the template, the metadata returned the AdminstrativeArea metadata tag.