### PR TITLE
Remove python 3.8 and add 3.13 to tested versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     env:
       MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -40,7 +40,8 @@ more-itertools==10.1.0
 moto==5.0.13
 networkx==3.1;python_version<"3.10"
 networkx==3.4.2;python_version>="3.10"
-numpy==2.2.0
+numpy==2.2.0;python_version>"3.9"
+numpy==2.0.2;python_version<="3.9"
 packaging==24.2
 pluggy==1.5.0
 py==1.11.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,7 +1,7 @@
 azure-storage-blob>=12.9.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-Pillow==10.3.0
+Pillow==11.0.0
 WebOb==1.8.8
 Shapely==2.0.1
 WebTest==3.0.0
@@ -40,16 +40,14 @@ more-itertools==10.1.0
 moto==5.0.13
 networkx==3.1;python_version<"3.10"
 networkx==3.4.2;python_version>="3.10"
-numpy==1.26.0;python_version>="3.9"
-numpy==1.24.0;python_version=="3.8"
+numpy==2.2.0
 packaging==24.2
 pluggy==1.5.0
 py==1.11.0
 pyasn1==0.5.1
 pycparser==2.22
 pyparsing==3.1.1
-pyproj==2.6.1.post1;python_version=="3.8"
-pyproj==3.6.1;python_version>"3.8"
+pyproj==3.7.0
 pyrsistent==0.20.0
 pytest==8.3.2
 pytest-rerunfailures==13.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -48,7 +48,8 @@ py==1.11.0
 pyasn1==0.5.1
 pycparser==2.22
 pyparsing==3.1.1
-pyproj==3.7.0
+pyproj==3.7.0;python_version>"3.9"
+pyproj==3.6.1;python_version<="3.9"
 pyrsistent==0.20.0
 pytest==8.3.2
 pytest-rerunfailures==13.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -40,8 +40,7 @@ more-itertools==10.1.0
 moto==5.0.13
 networkx==3.1;python_version<"3.10"
 networkx==3.4.2;python_version>="3.10"
-numpy==2.2.0;python_version>"3.9"
-numpy==2.0.2;python_version<="3.9"
+numpy==1.26.4
 packaging==24.2
 pluggy==1.5.0
 py==1.11.0


### PR DESCRIPTION
Tackling EOL of 3.8 and new 3.13