### PR TITLE
Multiapp docker

### DIFF
--- a/doc/deployment.rst
+++ b/doc/deployment.rst
@@ -285,11 +285,11 @@ MultiMapProxy
 
 .. versionadded:: 1.2.0
 
-You can run multiple MapProxy instances (configurations) within one process with the MultiMapProxy application.
+You can run multiple MapProxy apps (configurations) within one process with MultiMapProxy.
 
 MultiMapProxy can dynamically load configurations. You can put all configurations into one directory and MapProxy maps each file to a URL: ``conf/proj1.yaml`` is available at ``http://hostname/proj1/``.
 
-Each configuration will be loaded on demand and MapProxy caches each loaded instance. The configuration will be reloaded if the file changes.
+Each configuration will be loaded on demand and MapProxy caches each loaded app. The configuration will be reloaded if the file changes.
 
 MultiMapProxy as the following options:
 
@@ -308,5 +308,5 @@ There is a ``make_wsgi_app`` function in the ``mapproxy.multiapp`` package that 
 .. code-block:: python
 
   from mapproxy.multiapp import make_wsgi_app
-  application = make_wsgi_app('/path/to.projects', allow_listing=True)
+  application = make_wsgi_app('/path/to.configs', allow_listing=True)
 

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -19,16 +19,19 @@ Currently we have 6 different images for every release, named e.g.
 
 The alpine variants use alpine base images and are functionally the same as the other images.
 
-The first ones comes with everything installed, but no HTTP WebServer running. These can be used for seeding tasks or as base images for implementing custom setups.
-As they have no WebServer running they are not used normally.
+The first ones comes with everything installed, but no HTTP WebServer running. These can be used for seeding tasks or as
+base images for implementing custom setups. As they have no WebServer running they are not used normally.
 
-The images ending with ``-dev``, start the integrated webserver mapproxy provides through ``mapproxy-util serve-develop``. These should not be used in a production environment!
+The images ending with ``-dev``, start the integrated webserver mapproxy provides through
+``mapproxy-util serve-develop``. These should not be used in a production environment!
 
-The images ending with ``-nginx``, come bundled with a preconfigured `nginx`_ HTTP Server, that lets you use MapProxy instantly in a production environment.
+The images ending with ``-nginx``, come bundled with a preconfigured `nginx`_ HTTP Server, that lets you use MapProxy
+instantly in a production environment.
 
 See the quickstart section below for a configuration / example on how to use those images.
 
-There are also several unofficial Docker images available on `Docker Hub`_ that provide ready-to-use containers for MapProxy.
+There are also several unofficial Docker images available on `Docker Hub`_ that provide ready-to-use containers for
+MapProxy.
 
 .. _`Docker Hub`: https://hub.docker.com/search?q=mapproxy
 
@@ -83,16 +86,18 @@ Volume-Mounts
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-- ``MULTIAPP_MAPPROXY``: If set to ``true``, MapProxy will start in multi app mode and will run all configurations simultaneously
-    that are in the ``/mapproxy/config/multiapp`` directory. Default is ``false``.
-- ``MULTIAPP_ALLOW_LISTINGS``: In multi app mode if set to ``true``, MapProxy lists all available configs on the root page. Default is ``false``.
+- ``MULTIAPP_MAPPROXY``: **This can only be used in nginx images.** If set to ``true``, MapProxy will start in multi app
+    mode and will run all configurations simultaneously that are in the ``/mapproxy/config/multiapp`` directory. Default
+    is ``false``.
+- ``MULTIAPP_ALLOW_LISTINGS``: In multi app mode if set to ``true``, MapProxy lists all available configs on the root
+    page. Default is ``false``.
 
 
 Build your own image
 --------------------
 
-There exist 2 docker files in this repository. One for the debian based images (`Dockerfile`) and one for the alpine based images (`Dockerfile-alpine`). Both
-are multistage and have different targets:
+There exist 2 docker files in this repository. One for the debian based images (`Dockerfile`) and one for the alpine
+based images (`Dockerfile-alpine`). Both are multistage and have different targets:
 
 - `base` for the plain image that does not start a webserver
 - `development` for the development image that starts the dev server

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -87,10 +87,10 @@ Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
 
 - ``MULTIAPP_MAPPROXY``: **This can only be used in nginx images.** If set to ``true``, MapProxy will start in multi app
-    mode and will run all configurations simultaneously that are in the ``/mapproxy/config/multiapp`` directory. Default
+    mode and will run all configurations in the ``/mapproxy/config/apps`` directory as different apps. Default
     is ``false``.
-- ``MULTIAPP_ALLOW_LISTINGS``: In multi app mode if set to ``true``, MapProxy lists all available configs on the root
-    page. Default is ``false``.
+- ``MULTIAPP_ALLOW_LISTINGS``: In multi app mode if set to ``true``, MapProxy lists all available apps on the root page.
+    Default is ``false``.
 
 
 Build your own image

--- a/doc/install_docker.rst
+++ b/doc/install_docker.rst
@@ -22,9 +22,9 @@ The alpine variants use alpine base images and are functionally the same as the 
 The first ones comes with everything installed, but no HTTP WebServer running. These can be used for seeding tasks or as base images for implementing custom setups.
 As they have no WebServer running they are not used normally.
 
-The images ending with `-dev`, start the integrated webserver mapproxy provides through `mapproxy-util serve-develop`. These should not be used in a production environment!
+The images ending with ``-dev``, start the integrated webserver mapproxy provides through ``mapproxy-util serve-develop``. These should not be used in a production environment!
 
-The images ending with `-nginx`, come bundled with a preconfigured `nginx`_ HTTP Server, that lets you use MapProxy instantly in a production environment.
+The images ending with ``-nginx``, come bundled with a preconfigured `nginx`_ HTTP Server, that lets you use MapProxy instantly in a production environment.
 
 See the quickstart section below for a configuration / example on how to use those images.
 
@@ -74,10 +74,18 @@ Configuration
 Volume-Mounts
 ~~~~~~~~~~~~~
 
-- `/mapproxy/config/mapproxy.yaml`: MapProxy Config
-- `/mapproxy/config/logging.ini`: Logging-Configuration
-- `/mapproxy/config/cache_data`: Cache Data dir. Make sure that this directory is writable for the mapproxy image.
+- ``/mapproxy/config/mapproxy.yaml``: MapProxy Config
+- ``/mapproxy/config/logging.ini``: Logging-Configuration
+- ``/mapproxy/config/cache_data``: Cache Data dir. Make sure that this directory is writable for the mapproxy image.
     This can be achieved with `chmod -R a+r cache_data`
+
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``MULTIAPP_MAPPROXY``: If set to ``true``, MapProxy will start in multi app mode and will run all configurations simultaneously
+    that are in the ``/mapproxy/config/multiapp`` directory. Default is ``false``.
+- ``MULTIAPP_ALLOW_LISTINGS``: In multi app mode if set to ``true``, MapProxy lists all available configs on the root page. Default is ``false``.
 
 
 Build your own image
@@ -87,7 +95,7 @@ There exist 2 docker files in this repository. One for the debian based images (
 are multistage and have different targets:
 
 - `base` for the plain image that does not start a webserver
-- `development` for the development image that starts the dev mapserver
+- `development` for the development image that starts the dev server
 - `nginx` for the nginx image that uses nginx to run mapproxy
 
 So if you want to build the alpine nginx image, the command would look like this:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -98,8 +98,8 @@ services:
       MULTIAPP_ALLOW_LISTINGS: true
     volumes:
       # for multiapp mode, mount multiple mapproxy config files to this location:
-      - ./docker/mapproxy-example.yaml:/mapproxy/config/multiapp/mapproxy1.yaml
-      - ./docker/mapproxy-example.yaml:/mapproxy/config/multiapp/mapproxy2.yaml
+      - ./docker/mapproxy-example.yaml:/mapproxy/config/apps/mapproxy1.yaml
+      - ./docker/mapproxy-example.yaml:/mapproxy/config/apps/mapproxy2.yaml
       # the cache_data folder needs to be writable for the container
       # this can be ensured by running `sudo chmod -R a+w cache_data`
       - ./cache_data:/mapproxy/config/cache_data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,3 +83,28 @@ services:
     ports:
       # the application will run at http://localhost/mapproxy/demo/
       - "80:80"
+
+  mapproxy-multiapp:
+    profiles:
+      - multiapp
+      - nginx
+      - debian
+    image: ghcr.io/mapproxy/mapproxy/mapproxy:latest-nginx
+    build:
+      context: .
+      target: nginx
+    environment:
+      MULTIAPP_MAPPROXY: true
+      MULTIAPP_ALLOW_LISTINGS: true
+    volumes:
+      # for multiapp mode, mount multiple mapproxy config files to this location:
+      - ./docker/mapproxy-example.yaml:/mapproxy/config/multiapp/mapproxy1.yaml
+      - ./docker/mapproxy-example.yaml:/mapproxy/config/multiapp/mapproxy2.yaml
+      # the cache_data folder needs to be writable for the container
+      # this can be ensured by running `sudo chmod -R a+w cache_data`
+      - ./cache_data:/mapproxy/config/cache_data
+      # to use a logging config that differs from a default one, mount it to this location:
+      - ./docker/logging.ini:/mapproxy/config/logging.ini
+    ports:
+      # the application will run at http://localhost/mapproxy/
+      - "80:80"

--- a/docker/app.py
+++ b/docker/app.py
@@ -18,7 +18,7 @@ if multiapp_mapproxy:
     multiapp_allow_listings = os.environ.get('MULTIAPP_ALLOW_LISTINGS', False)
 
     print('Starting MapProxy in multi app mode')
-    application = make_wsgi_app(r'/mapproxy/config/multiapp/', allow_listing=multiapp_allow_listings)
+    application = make_wsgi_app(r'/mapproxy/config/apps/', allow_listing=multiapp_allow_listings)
 else:
     from mapproxy.wsgiapp import make_wsgi_app
 

--- a/docker/app.py
+++ b/docker/app.py
@@ -1,11 +1,26 @@
 # WSGI module for use with Apache mod_wsgi or gunicorn
 
 from logging.config import fileConfig
-import os.path
-from mapproxy.wsgiapp import make_wsgi_app
+import os
+
 
 log_config = r'/mapproxy/config/logging.ini'
+
 if os.path.isfile(log_config):
+    print('Loading log config')
     fileConfig(log_config, {'here': os.path.dirname(__file__)})
 
-application = make_wsgi_app(r'/mapproxy/config/mapproxy.yaml', reloader=True)
+multiapp_mapproxy = os.environ.get('MULTIAPP_MAPPROXY', False)
+
+if multiapp_mapproxy:
+    from mapproxy.multiapp import make_wsgi_app
+
+    multiapp_allow_listings = os.environ.get('MULTIAPP_ALLOW_LISTINGS', False)
+
+    print('Starting MapProxy in multi app mode')
+    application = make_wsgi_app(r'/mapproxy/config/multiapp/', allow_listing=multiapp_allow_listings)
+else:
+    from mapproxy.wsgiapp import make_wsgi_app
+
+    print('Starting MapProxy in single app mode')
+    application = make_wsgi_app(r'/mapproxy/config/mapproxy.yaml', reloader=True)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@
 cd /mapproxy
 
 # create config files if they do not exist yet
-if [ ! -f /mapproxy/config/mapproxy.yaml ]; then
+if [ ! -f /mapproxy/config/mapproxy.yaml ] && [ ${MULTIAPP_MAPPROXY} != "true" ]; then
   echo "No mapproxy configuration found. Creating one from template."
   mapproxy-util create -t base-config config
 fi

--- a/docker/mapproxy-example.yaml
+++ b/docker/mapproxy-example.yaml
@@ -21,18 +21,18 @@ services:
       abstract: This is a minimal MapProxy example.
 
 layers:
-  - name: basemap
-    title: basemap
-    sources: [basemap_cache]
+  - name: ows
+    title: ows
+    sources: [ows_cache]
 
 caches:
-  basemap_cache:
+  ows_cache:
     grids: [webmercator]
-    sources: [basemap_wms]
+    sources: [ows]
     meta_size: [1, 1]
 
 sources:
-  basemap_wms:
+  ows:
     type: wms
     req:
       url: https://ows.terrestris.de/osm/service

--- a/docker/nginx-alpine-default.conf
+++ b/docker/nginx-alpine-default.conf
@@ -20,10 +20,10 @@ http {
 
         root /var/www/html/;
 
-        rewrite ^/?(mapproxy)?/?$ /mapproxy/demo permanent;
+        rewrite ^/?$ /mapproxy/ permanent;
 
         location /mapproxy/ {
-            rewrite /mapproxy/(.+) /$1 break;
+            rewrite ^/mapproxy/(.*) /$1 break;
             uwsgi_param SCRIPT_NAME /mapproxy;
             uwsgi_pass 0.0.0.0:8080;
             include uwsgi_params;

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -4,6 +4,7 @@ access_log /dev/stdout;
 upstream mapproxy {
     server 0.0.0.0:8080;
 }
+
 server {
     listen 80;
 
@@ -20,10 +21,10 @@ server {
 
     root /var/www/html/;
 
-    rewrite ^/?(mapproxy)?/?$ /mapproxy/demo permanent;
+    rewrite ^/?$ /mapproxy/ permanent;
 
     location /mapproxy/ {
-        rewrite /mapproxy/(.+) /$1 break;
+        rewrite ^/mapproxy/(.*) /$1 break;
         uwsgi_param SCRIPT_NAME /mapproxy;
         uwsgi_pass mapproxy;
         include uwsgi_params;

--- a/docker/uwsgi.conf
+++ b/docker/uwsgi.conf
@@ -10,4 +10,3 @@ threads = 10
 chmod-socket = 777
 uid = mapproxy
 gid = mapproxy
-plugin = python3


### PR DESCRIPTION
This allows the mapproxy nginx images to be run in multi app mode. This is controlled by the `MULTIAPP_MAPPROXY` variable.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
