### PR TITLE
docs: add docs for use of mapproxy with pygeoapi

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,6 +27,7 @@ MapProxy Documentation
    mapproxy_util_autoconfig
    deployment
    configuration_examples
+   ogc_api
    inspire
    labeling
    auth

--- a/doc/ogc_api.rst
+++ b/doc/ogc_api.rst
@@ -1,0 +1,12 @@
+OGC API Support
+===============
+
+MapProxy does not support the OGC APIs natively. There are ways to combine MapProxy with pygeoapi via docker to be able
+to use MapProxy through the OGC API of pygeoapi. An example project exists here:
+https://github.com/mapproxy/mapproxy-pygeoapi.
+
+Call for sponsors
+-----------------
+
+This feature is important to make MapProxy future-proof and it is desirable to integrate OGC APIs directly into
+MapProxy. If you are interested in sponsoring this feature please contact sales@terrestris.de.


### PR DESCRIPTION
Note: The repository needs to be created. At the moment it can be found here: https://github.com/simonseyock/mapproxy-pygeoapi-example

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
