### PR TITLE
Restful wmts demo

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -2349,12 +2349,9 @@ class ServiceConfiguration(ConfigurationBase):
             kvp = wmts_conf.get('kvp')
             restful = wmts_conf.get('restful')
 
-            if kvp is None and restful is None:
-                kvp = restful = True
-
-            if kvp:
+            if kvp or kvp is None:
                 services.append('wmts_kvp')
-            if restful:
+            if restful or restful is None:
                 services.append('wmts_restful')
 
         if 'wms' in self.context.services.conf:

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -317,6 +317,8 @@ class DemoServer(Server):
                 wmts_layer = layer
                 break
 
+        rest_enabled = 'wmts_restful' in self.services
+
         restful_url = self.restful_template.replace('{Layer}', wmts_layer.name, 1)
         if '{Format}' in restful_url:
             restful_url = restful_url.replace('{Format}', wmts_layer.format)
@@ -335,6 +337,7 @@ class DemoServer(Server):
                                    resolutions=wmts_layer.grid.resolutions,
                                    units=units,
                                    all_tile_layers=self.tile_layers,
+                                   rest_enabled=rest_enabled,
                                    restful_url=restful_url,
                                    background_url=background_url)
 

--- a/mapproxy/service/templates/demo/wmts_demo.html
+++ b/mapproxy/service/templates/demo/wmts_demo.html
@@ -46,13 +46,14 @@ jscript_functions=None
         const projection = ol.proj.get(srs);
 
         const source = new ol.source.WMTS({
-            url: '../service?',
+            url: {{if rest_enabled}}'../wmts{{restful_url}}'{{else}}'../service?'{{endif}},
             layer: "{{layer.name}}",
             matrixSet: '{{matrix_set}}',
             format: "{{format}}",
             projection: "{{srs}}",
             transparent: transparent,
             style: '',
+            {{if rest_enabled}}requestEncoding: 'REST',{{endif}}
             tileGrid: new ol.tilegrid.WMTS({
                 origin: ol.extent.getTopLeft(grid_extent),
                 resolutions: resolutions,

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -184,7 +184,7 @@ class WMTSServer(Server):
             if result['authorized'] == 'unauthenticated':
                 raise RequestError('unauthorized', status=401)
             if result['authorized'] == 'full':
-                return self.layers.values()
+                return list(self.layers.values())
             if result['authorized'] == 'none':
                 raise RequestError('forbidden', status=403)
             allowed_layers = []
@@ -193,7 +193,7 @@ class WMTSServer(Server):
                     allowed_layers.append(layer)
             return allowed_layers
         else:
-            return self.layers.values()
+            return list(self.layers.values())
 
     def check_request(self, request, info_formats=None):
         request.make_request()


### PR DESCRIPTION
Fixes the demo site for WMTS if kvp is disabled. Uses restful requests by default now.

Closes #1071 

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
