### PR TITLE
backport: github workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -32,6 +32,6 @@
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 * Version used:
-* Environment name and version (e.g. Python 3.8 with mod_wsgi 4.5.9):
+* Environment name and version (e.g. Python 3.9 with mod_wsgi 4.5.9):
 * Server type and version:
 * Operating System and version:

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -23,13 +23,13 @@ jobs:
       run: sphinx-build doc/ docs -D html_context.current_version=${{ github.ref_name }}
 
     - name: Deploy docs to folder `latest` to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.6.9
+      uses: JamesIves/github-pages-deploy-action@v4.7.2
       with:
         folder: docs
         target-folder: docs/latest
 
     - name: Deploy docs to a folder named after the new tag to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.6.9
+      uses: JamesIves/github-pages-deploy-action@v4.7.2
       with:
         folder: docs
         target-folder: docs/${{ github.ref_name }}
@@ -46,7 +46,7 @@ jobs:
         > config/versions.json
 
     - name: Deploy config folder to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.6.9
+      uses: JamesIves/github-pages-deploy-action@v4.7.2
       with:
         folder: config
         target-folder: docs/config


### PR DESCRIPTION
Backport of the current workflows into the 3.x.x branch.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
