### PR TITLE
fix(dockerbuild): use github.ref_name as mapproxy version

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -54,7 +54,7 @@ jobs:
           file: ./docker/Dockerfile
           push: true
           build-args: |
-            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+            MAPPROXY_VERSION=${{ github.ref_name }}
           target: base
           tags: ${{ needs.get-version.outputs.version }}
 
@@ -65,7 +65,7 @@ jobs:
           file: ./docker/Dockerfile
           push: true
           build-args: |
-            MAPPROXY_VERSION=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+            MAPPROXY_VERSION=${{ github.ref_name }}
           target: development
           tags: ${{ needs.get-version.outputs.version }}-dev
 
@@ -76,6 +76,6 @@ jobs:
           file: ./docker/Dockerfile
           push: true
           build-args: |
-            MAPPROXY_VERSION=${{ needs.get-version.outputs.version }}
+            MAPPROXY_VERSION=${{ github.ref_name }}
           target: nginx
           tags: ${{ needs.get-version.outputs.version }}-nginx


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
