### PR TITLE
feat: add include_grid_name option for S3 cache configuration

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -480,6 +480,9 @@ Available options:
 ``use_http_get``:
   When set to ``true``, requests to S3 ``GetObject`` will be fetched via urllib2 instead of boto, which decreases response times. Defaults to ``false``.
 
+``include_grid_name``:
+  When set to ``true``, the grid name will be included in the path (``[directory]/[grid.name]/[z]/...``) . Defaults to ``false``.
+
 .. note::
   The hierarchical ``directory_layouts`` can hit limitations of AWS S3 if you are routinely processing 3500 or more requests per second. ``directory_layout: reverse_tms`` can work around this limitation. Please read `S3 Request Rate and Performance Considerations <http://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html>`_ for more information on this issue.
 

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1355,9 +1355,16 @@ class CacheConfiguration(ConfigurationBase):
                                                       global_key='cache.s3.use_http_get'
                                                       )
 
+        include_grid_name = self.context.globals.get_value('cache.include_grid_name', self.conf,
+                                                      global_key='cache.s3.include_grid_name')
+
         directory_layout = self.conf['cache'].get('directory_layout', 'tms')
 
         base_path = self.conf['cache'].get('directory', None)
+
+        if include_grid_name and base_path:
+            base_path = os.path.join(base_path, grid_conf.tile_grid().name)
+
         if base_path is None:
             base_path = os.path.join(self.conf['name'], grid_conf.tile_grid().name)
 

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -170,6 +170,7 @@ cache_types = {
         'access_control_list': str(),
         'tile_lock_dir': str(),
         'use_http_get': bool(),
+        'include_grid_name': bool(),
     }),
     'redis': combined(cache_commons, {
         'host': str(),

--- a/mapproxy/test/system/fixture/cache_s3.yaml
+++ b/mapproxy/test/system/fixture/cache_s3.yaml
@@ -5,6 +5,8 @@ globals:
 
 services:
   tms:
+  wmts:
+    restful: true
   wms:
     md:
       title: MapProxy S3
@@ -19,6 +21,9 @@ layers:
   - name: reverse
     title: Reverse
     sources: [reverse_cache]
+  - name: multiple_grids
+    title: Multiple Grids
+    sources: [multiple_grids_cache]
 
 caches:
   default_cache:
@@ -45,9 +50,21 @@ caches:
       directory: reversetiles
     sources: [tms]
 
+  multiple_grids_cache:
+    grids: [webmercator, webmercator2]
+    cache:
+      type: s3
+      bucket_name: tiles
+      directory: multiple_grids
+      include_grid_name: true
+    sources: [tms]
+
 grids:
   webmercator:
     name: WebMerc
+    base: GLOBAL_WEBMERCATOR
+  webmercator2:
+    name: WebMerc2
     base: GLOBAL_WEBMERCATOR
 
 


### PR DESCRIPTION
To support multiple grids per s3 cache it necessary to include the grid in the s3 directory.

This changes adds an option to include the grid.name in the path of the tiles.

In `[mapproxy/test/system/test_cache_s3.py](https://github.com/mapproxy/mapproxy/compare/master...djbulsink:mapproxy:s3-key-include-grid-name?expand=1#diff-877a6274c7e659696d37a87c8bdfcb8384c1c16f36c5acd8fc7382cc2f805fb9)` I have renamed mock_s3 to mock_aws because of https://github.com/getmoto/moto/blob/master/CHANGELOG.md#500
