### PR TITLE
ci: update ubuntu version in github workflows

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -9,7 +9,7 @@ on:
       - "*.*.*"
 jobs:
   get-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
     steps:

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout sources

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-publish-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: pypi
       url: https://pypi.org/project/MapProxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       redis-server:
         image: redis
@@ -42,7 +42,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt update
-        sudo apt install proj-bin libgeos-dev libgdal-dev libxslt1-dev libxml2-dev build-essential python-dev libjpeg-dev zlib1g-dev libfreetype6-dev protobuf-compiler libprotoc-dev -y
+        sudo apt install proj-bin libgeos-dev libgdal-dev libxslt-dev libxml2-dev build-essential libjpeg-dev zlib1g-dev libfreetype6-dev protobuf-compiler libprotoc-dev -y
 
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/mapproxy/test/system/test_seed.py
+++ b/mapproxy/test/system/test_seed.py
@@ -144,13 +144,13 @@ class TestSeed(SeedTestBase):
     empty_ogrdata = 'empty_ogrdata.geojson'
 
     def test_cleanup_levels(self):
-        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
-        cleanup_tasks = seed_conf.cleanups(['cleanup'])
-
         self.make_tile((0, 0, 0))
         self.make_tile((0, 0, 1))
         self.make_tile((0, 0, 2))
         self.make_tile((0, 0, 3))
+
+        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+        cleanup_tasks = seed_conf.cleanups(['cleanup'])
 
         cleanup(cleanup_tasks, verbose=False, dry_run=False)
         assert not self.tile_exists((0, 0, 0))
@@ -162,9 +162,6 @@ class TestSeed(SeedTestBase):
                             ['02'])
 
     def test_cleanup_remove_all(self):
-        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
-        cleanup_tasks = seed_conf.cleanups(['remove_all'])
-
         self.make_tile((0, 0, 0))
         self.make_tile((0, 0, 1))
         self.make_tile((1, 0, 1))
@@ -172,6 +169,9 @@ class TestSeed(SeedTestBase):
         self.make_tile((1, 1, 1))
         self.make_tile((0, 0, 2))
         self.make_tile((0, 0, 3))
+
+        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+        cleanup_tasks = seed_conf.cleanups(['remove_all'])
 
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'one_EPSG4326'),
                             ['00', '01', '02', '03'])
@@ -191,9 +191,6 @@ class TestSeed(SeedTestBase):
                             ['00', '02', '03'])
 
     def test_cleanup_remove_all_with_coverage(self):
-        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
-        cleanup_tasks = seed_conf.cleanups(['remove_all_with_coverage'])
-
         self.make_tile((0, 0, 0))
         self.make_tile((0, 0, 1))
         self.make_tile((1, 0, 1))
@@ -201,6 +198,9 @@ class TestSeed(SeedTestBase):
         self.make_tile((1, 1, 1))
         self.make_tile((0, 0, 2))
         self.make_tile((0, 0, 3))
+
+        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+        cleanup_tasks = seed_conf.cleanups(['remove_all_with_coverage'])
 
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'one_EPSG4326'),
                             ['00', '01', '02', '03'])
@@ -216,14 +216,14 @@ class TestSeed(SeedTestBase):
         assert self.tile_exists((0, 0, 3))
 
     def test_cleanup_coverage(self):
-        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
-        cleanup_tasks = seed_conf.cleanups(['with_coverage'])
-
         self.make_tile((0, 0, 0))
         self.make_tile((1, 0, 1))
         self.make_tile((2, 0, 2))
         self.make_tile((2, 0, 3))
         self.make_tile((4, 0, 3))
+
+        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+        cleanup_tasks = seed_conf.cleanups(['with_coverage'])
 
         cleanup(cleanup_tasks, verbose=False, dry_run=False)
         assert not self.tile_exists((0, 0, 0))
@@ -335,6 +335,12 @@ class TestSeed(SeedTestBase):
         cache.store_tile(self.create_tile((0, 0, 3)))
         assert cache.is_cached(Tile((0, 0, 2)))
         assert cache.is_cached(Tile((0, 0, 3)))
+
+        # simulate that cleanup was called after creation of tiles
+        time.sleep(1)
+
+        seed_conf = load_seed_tasks_conf(self.seed_conf_file, self.mapproxy_conf)
+        cleanup_tasks = seed_conf.cleanups(['sqlite_cache_remove_all'])
 
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'sqlite_cache', 'GLOBAL_GEODETIC'),
                             ['2.mbtile', '3.mbtile'],


### PR DESCRIPTION
This updates the ubuntu versions in the workflows. Also it updates the tests in seed_test.py to make the timing of the cleanups more accurate and run reliably.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
