### PR TITLE
fix: return 404 instead of 500 if no legendgraphic is available for layer

### DIFF
--- a/mapproxy/service/wms.py
+++ b/mapproxy/service/wms.py
@@ -85,6 +85,7 @@ class WMSServer(Server):
 
         params = map_request.params
         query = MapQuery(params.bbox, params.size, SRS(params.srs), params.format, dimensions=map_request.dimensions)
+        offset = None
 
         if map_request.params.get('tiled', 'false').lower() == 'true':
             query.tiled_only = True
@@ -305,7 +306,7 @@ class WMSServer(Server):
         self.check_legend_request(request)
         layer = request.params.layer
         if not self.layers[layer].has_legend:
-            raise RequestError('layer %s has no legend graphic' % layer, request=request)
+            raise RequestError('layer %s has no legend graphic' % layer, request=request, status=404)
         legend = self.layers[layer].legend(request)
 
         [legends.append(i) for i in legend if i is not None]

--- a/mapproxy/test/system/test_legendgraphic.py
+++ b/mapproxy/test/system/test_legendgraphic.py
@@ -214,6 +214,7 @@ class TestWMSLegendgraphic(SysTest):
         self.common_lg_req_111.params["layer"] = "wms_no_legend"
         resp = app.get(self.common_lg_req_111, expect_errors=True)
         assert resp.content_type == "application/vnd.ogc.se_xml"
+        assert resp.status_code == 404
         xml = resp.lxml
         assert (
             "wms_no_legend has no legend graphic"
@@ -247,6 +248,7 @@ class TestWMSLegendgraphic(SysTest):
         self.common_lg_req_130.params["layer"] = "wms_no_legend"
         resp = app.get(self.common_lg_req_130, expect_errors=True)
         assert resp.content_type == "text/xml"
+        assert resp.status_code == 404
         xml = resp.lxml
         assert_xpath_wms130(xml, "/ogc:ServiceExceptionReport/@version", "1.3.0")
         assert_xpath_wms130(


### PR DESCRIPTION
title says it all

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
