### PR TITLE
fix: use utf-8 in get feature info requests

### DIFF
--- a/mapproxy/client/http.py
+++ b/mapproxy/client/http.py
@@ -18,6 +18,7 @@ Tile retrieval (WMS, TMS, etc.).
 """
 import sys
 import time
+from typing import Any
 
 from mapproxy.version import version
 from mapproxy.image import ImageSource
@@ -160,9 +161,11 @@ class HTTPClient(object):
         self.header_list = headers.items() if headers else []
         self.hide_error_details = hide_error_details
 
-    def open(self, url, data=None, method=None):
+    def open(self, url, data=None, method=None) -> Any:
         code = None
         result = None
+        start_time = time.time()
+        req = None
         try:
             req = urllib2.Request(url, data=data)
         except ValueError as e:
@@ -173,7 +176,6 @@ class HTTPClient(object):
         if method:
             req.method = method
         try:
-            start_time = time.time()
             if self._timeout is not None:
                 result = self.opener.open(req, timeout=self._timeout)
             else:

--- a/mapproxy/client/wms.py
+++ b/mapproxy/client/wms.py
@@ -16,6 +16,8 @@
 """
 WMS clients for maps and information.
 """
+from codecs import decode
+
 from mapproxy.request.base import split_mime_type
 from mapproxy.layer import InfoQuery
 from mapproxy.source import SourceError
@@ -137,7 +139,7 @@ class WMSInfoClient(object):
         if not info_format:
             # otherwise from query
             info_format = query.info_format
-        return create_featureinfo_doc(resp.read(), info_format)
+        return create_featureinfo_doc(decode(resp.read()), info_format)
 
     def _get_transformed_query(self, query):
         """

--- a/mapproxy/test/system/test_wms.py
+++ b/mapproxy/test/system/test_wms.py
@@ -646,6 +646,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/plain"
             assert resp.body == b"info"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
     def test_get_featureinfo_coverage(self, app):
         self.common_fi_req.params["bbox"] = "-180.0,-90.0,180.0,90.0"
@@ -676,6 +677,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.body == b"info"
             assert resp.content_type == "text/plain"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
     def test_get_featureinfo_float(self, app):
         expected_req = (
@@ -694,6 +696,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/plain"
             assert resp.body == b"info"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
     def test_get_featureinfo_transformed(self, app):
         expected_req = (
@@ -750,6 +753,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/html"
             assert resp.body == b"<html><body><p>info</p></body></html>"
+            assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_get_featureinfo_info_format_special_chars(self, app):
         expected_req = (
@@ -767,6 +771,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/html"
             assert resp.body == encode(u"<html><body><p>äüß▼</p></body></html>")
+            assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_get_featureinfo_130(self, app):
         expected_req = (
@@ -784,6 +789,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/plain"
             assert resp.body == b"info"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
     def test_get_featureinfo_missing_params(self, app):
         expected_req = (
@@ -801,6 +807,7 @@ class TestWMS111(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/plain"
             assert resp.body == b"info"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
     def test_get_featureinfo_missing_params_strict(self, app):
         request_parser = app.app.handlers["service"].services["wms"].request_parser
@@ -1468,6 +1475,7 @@ class TestWMS130(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/plain"
             assert resp.body == b"info"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
     def test_get_featureinfo_111(self, app):
         expected_req = (
@@ -1485,6 +1493,7 @@ class TestWMS130(SysTest):
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/plain"
             assert resp.body == b"info"
+            assert resp.headers['Content-Type'] == 'text/plain; charset=utf-8'
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="not supported on Windows")

--- a/mapproxy/test/unit/test_cache.py
+++ b/mapproxy/test/unit/test_cache.py
@@ -245,7 +245,7 @@ class TestTileManagerTiledSource(object):
 
     def test_create_tiles(self, tile_mgr, mock_file_cache, mock_tile_client):
         tile_mgr.creator().create_tiles([Tile((0, 0, 1)), Tile((1, 0, 1))])
-        assert mock_file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert sorted(mock_tile_client.requested_tiles) == [(0, 0, 1), (1, 0, 1)]
 
 
@@ -263,7 +263,7 @@ class TestTileManagerDifferentSourceGrid(object):
 
     def test_create_tiles(self, tile_mgr, mock_file_cache, mock_tile_client):
         tile_mgr.creator().create_tiles([Tile((1, 0, 1))])
-        assert mock_file_cache.stored_tiles == set([(1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(1, 0, 1)}
         assert mock_tile_client.requested_tiles == [(0, 0, 0)]
 
     def test_create_tiles_out_of_bounds(self, tile_mgr):
@@ -302,7 +302,7 @@ class TestTileManagerSource(object):
 
     def test_create_tile(self, tile_mgr, mock_file_cache, mock_source):
         tile_mgr.creator().create_tiles([Tile((0, 0, 1)), Tile((1, 0, 1))])
-        assert mock_file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert sorted(mock_source.requested) == \
             [((-180.0, -90.0, 0.0, 90.0), (256, 256), SRS(4326)),
              ((0.0, -90.0, 180.0, 90.0), (256, 256), SRS(4326))]
@@ -343,22 +343,21 @@ class TestTileManagerWMSSource(object):
 
     def test_create_tile_first_level(self, tile_mgr, mock_file_cache, mock_wms_client):
         tile_mgr.creator().create_tiles([Tile((0, 0, 1)), Tile((1, 0, 1))])
-        assert mock_file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert mock_wms_client.requested == \
             [((-180.0, -90.0, 180.0, 90.0), (512, 256), SRS(4326))]
 
     def test_create_tile(self, tile_mgr, mock_file_cache, mock_wms_client):
         tile_mgr.creator().create_tiles([Tile((0, 0, 2))])
         assert mock_file_cache.stored_tiles == \
-            set([(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2)])
+               {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2)}
         assert sorted(mock_wms_client.requested) == \
             [((-180.0, -90.0, 0.0, 90.0), (512, 512), SRS(4326))]
 
     def test_create_tiles(self, tile_mgr, mock_file_cache, mock_wms_client):
         tile_mgr.creator().create_tiles([Tile((0, 0, 2)), Tile((2, 0, 2))])
         assert mock_file_cache.stored_tiles == \
-            set([(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2),
-                 (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)])
+               {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2), (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)}
         assert sorted(mock_wms_client.requested) == \
             [((-180.0, -90.0, 0.0, 90.0), (512, 512), SRS(4326)),
              ((0.0, -90.0, 180.0, 90.0), (512, 512), SRS(4326))]
@@ -371,8 +370,7 @@ class TestTileManagerWMSSource(object):
         assert isinstance(tiles[1].source, ImageSource)
 
         assert mock_file_cache.stored_tiles == \
-            set([(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2),
-                 (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)])
+               {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2), (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)}
         assert sorted(mock_wms_client.requested) == \
             [((-180.0, -90.0, 0.0, 90.0), (512, 512), SRS(4326)),
              ((0.0, -90.0, 180.0, 90.0), (512, 512), SRS(4326))]
@@ -405,21 +403,21 @@ class TestTileManagerWMSSourceMinimalMetaRequests(object):
         # not enabled for single tile requests
         tile_mgr.creator().create_tiles([Tile((0, 0, 2))])
         assert mock_file_cache.stored_tiles == \
-            set([(0, 0, 2), (0, 1, 2), (1, 0, 2), (1, 1, 2)])
+               {(0, 0, 2), (0, 1, 2), (1, 0, 2), (1, 1, 2)}
         assert sorted(mock_wms_client.requested) == \
             [((-180.0, -90.0, 3.515625, 90.0), (522, 512), SRS(4326))]
 
     def test_create_tile_multiple(self, tile_mgr, mock_file_cache, mock_wms_client):
         tile_mgr.creator().create_tiles([Tile((4, 0, 3)), Tile((4, 1, 3)), Tile((4, 2, 3))])
         assert mock_file_cache.stored_tiles == \
-            set([(4, 0, 3), (4, 1, 3), (4, 2, 3)])
+               {(4, 0, 3), (4, 1, 3), (4, 2, 3)}
         assert sorted(mock_wms_client.requested) == \
             [((-1.7578125, -90, 46.7578125, 46.7578125), (276, 778), SRS(4326))]
 
     def test_create_tile_multiple_fragmented(self, tile_mgr, mock_file_cache, mock_wms_client):
         tile_mgr.creator().create_tiles([Tile((4, 0, 3)), Tile((5, 2, 3))])
         assert mock_file_cache.stored_tiles == \
-            set([(4, 0, 3), (4, 1, 3), (4, 2, 3), (5, 0, 3), (5, 1, 3), (5, 2, 3)])
+               {(4, 0, 3), (4, 1, 3), (4, 2, 3), (5, 0, 3), (5, 1, 3), (5, 2, 3)}
         assert sorted(mock_wms_client.requested) == \
             [((-1.7578125, -90, 91.7578125, 46.7578125), (532, 778), SRS(4326))]
 
@@ -474,7 +472,7 @@ class TestTileManagerLocking(object):
 
     def test_get_single(self, tile_mgr, file_cache, slow_source):
         tile_mgr.creator().create_tiles([Tile((0, 0, 1)), Tile((1, 0, 1))])
-        assert file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert slow_source.requested == \
             [((-180.0, -90.0, 180.0, 90.0), (512, 256), SRS(4326))]
 
@@ -486,7 +484,7 @@ class TestTileManagerLocking(object):
         [t.start() for t in threads]
         [t.join() for t in threads]
 
-        assert file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert file_cache.loaded_tiles == counting_set([(0, 0, 1), (1, 0, 1), (0, 0, 1), (1, 0, 1)])
         assert slow_source.requested == \
             [((-180.0, -90.0, 180.0, 90.0), (512, 256), SRS(4326))]
@@ -532,7 +530,7 @@ class TestTileManagerMultipleSources(object):
 
     def test_get_single(self, tile_mgr, mock_file_cache, source_base, source_overlay):
         tile_mgr.creator().create_tiles([Tile((0, 0, 1))])
-        assert mock_file_cache.stored_tiles == set([(0, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 1)}
         assert source_base.requested == \
             [((-180.0, -90.0, 0.0, 90.0), (256, 256), SRS(4326))]
         assert source_overlay.requested == \
@@ -574,7 +572,7 @@ class TestTileManagerMultipleSourcesWithMetaTiles(object):
 
     def test_merged_tiles(self, tile_mgr, mock_file_cache, source_base, source_overlay):
         tiles = tile_mgr.creator().create_tiles([Tile((0, 0, 1)), Tile((1, 0, 1))])
-        assert mock_file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert source_base.requested == \
             [((-180.0, -90.0, 180.0, 90.0), (512, 256), SRS(4326))]
         assert source_overlay.requested == \
@@ -634,14 +632,12 @@ class TestTileManagerBulkMetaTiles(object):
     def test_bulk_get(self, tile_mgr, mock_file_cache, source_base, source_overlay):
         tiles = tile_mgr.creator().create_tiles([Tile((0, 0, 2))])
         assert len(tiles) == 2*2
-        assert mock_file_cache.stored_tiles == set([(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2)}
         for requested in [source_base.requested, source_overlay.requested]:
-            assert set(requested) == set([
-                ((-180.0, 0.0, -90.0, 90.0), (256, 256), SRS(4326)),
-                ((-90.0, 0.0, 0.0, 90.0), (256, 256), SRS(4326)),
-                ((-180.0, -90.0, -90.0, 0.0), (256, 256), SRS(4326)),
-                ((-90.0, -90.0, 0.0, 0.0), (256, 256), SRS(4326)),
-            ])
+            assert set(requested) == {((-180.0, 0.0, -90.0, 90.0), (256, 256), SRS(4326)),
+                                      ((-90.0, 0.0, 0.0, 90.0), (256, 256), SRS(4326)),
+                                      ((-180.0, -90.0, -90.0, 0.0), (256, 256), SRS(4326)),
+                                      ((-90.0, -90.0, 0.0, 0.0), (256, 256), SRS(4326))}
 
     def test_bulk_get_error(self, tile_mgr, source_base):
         tile_mgr.sources = [source_base, ErrorSource()]
@@ -653,10 +649,8 @@ class TestTileManagerBulkMetaTiles(object):
     def test_bulk_get_multiple_meta_tiles(self, tile_mgr, mock_file_cache):
         tiles = tile_mgr.creator().create_tiles([Tile((1, 0, 2)), Tile((2, 0, 2))])
         assert len(tiles) == 2*2*2
-        assert mock_file_cache.stored_tiles, set([
-            (0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2),
-            (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2),
-        ])
+        assert mock_file_cache.stored_tiles, {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2), (2, 0, 2), (3, 0, 2),
+                                              (2, 1, 2), (3, 1, 2)}
 
 
 class TestTileManagerBulkMetaTilesConcurrent(TestTileManagerBulkMetaTiles):
@@ -699,15 +693,14 @@ class TestCacheMapLayer(object):
 
     def test_get_map_small(self, layer, mock_file_cache):
         result = layer.get_map(MapQuery((-180, -90, 180, 90), (300, 150), SRS(4326), 'png'))
-        assert mock_file_cache.stored_tiles == set([(0, 0, 1), (1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(0, 0, 1), (1, 0, 1)}
         assert result.size == (300, 150)
 
     def test_get_map_large(self, layer, mock_file_cache):
         # gets next resolution layer
         result = layer.get_map(MapQuery((-180, -90, 180, 90), (600, 300), SRS(4326), 'png'))
         assert mock_file_cache.stored_tiles == \
-            set([(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2),
-                 (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)])
+               {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2), (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)}
         assert result.size == (600, 300)
 
     def test_transformed(self, layer, mock_file_cache):
@@ -715,15 +708,14 @@ class TestCacheMapLayer(object):
             (-20037508.34, -20037508.34, 20037508.34, 20037508.34), (500, 500),
             SRS(900913), 'png'))
         assert mock_file_cache.stored_tiles == \
-            set([(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2),
-                 (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)])
+               {(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2), (2, 0, 2), (3, 0, 2), (2, 1, 2), (3, 1, 2)}
         assert result.size == (500, 500)
 
     def test_single_tile_match(self, layer, mock_file_cache):
         result = layer.get_map(MapQuery(
             (0.001, 0, 90, 90), (256, 256), SRS(4326), 'png', tiled_only=True))
         assert mock_file_cache.stored_tiles == \
-            set([(3, 0, 2), (2, 0, 2), (3, 1, 2), (2, 1, 2)])
+               {(3, 0, 2), (2, 0, 2), (3, 1, 2), (2, 1, 2)}
         assert result.size == (256, 256)
 
     def test_single_tile_no_match(self, layer):
@@ -753,7 +745,7 @@ class TestCacheMapLayer(object):
             (0, 0, 10000, 10000), (50, 50),
             SRS(900913), 'png'))
         assert mock_file_cache.stored_tiles == \
-            set([(512, 257, 10), (513, 256, 10), (512, 256, 10), (513, 257, 10)])
+               {(512, 257, 10), (513, 256, 10), (512, 256, 10), (513, 257, 10)}
         assert result.size == (50, 50)
 
 
@@ -779,7 +771,7 @@ class TestCacheMapLayerWithExtent(object):
 
     def test_get_map_small(self, layer, mock_file_cache, mock_wms_client):
         result = layer.get_map(MapQuery((-180, -90, 180, 90), (300, 150), SRS(4326), 'png'))
-        assert mock_file_cache.stored_tiles == set([(1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(1, 0, 1)}
         # source requests one tile (no meta-tiling configured)
         assert mock_wms_client.requested == [((0.0, -90.0, 180.0, 90.0), (256, 256), SRS('EPSG:4326'))]
         assert result.size == (300, 150)
@@ -787,7 +779,7 @@ class TestCacheMapLayerWithExtent(object):
     def test_get_map_small_with_source_extent(self, source, layer, mock_file_cache, mock_wms_client):
         source.extent = BBOXCoverage([0, 0, 90, 45], SRS(4326)).extent
         result = layer.get_map(MapQuery((-180, -90, 180, 90), (300, 150), SRS(4326), 'png'))
-        assert mock_file_cache.stored_tiles == set([(1, 0, 1)])
+        assert mock_file_cache.stored_tiles == {(1, 0, 1)}
         # source requests one tile (no meta-tiling configured) limited to source.extent
         assert mock_wms_client.requested == [((0, 0, 90, 45), (128, 64), (SRS(4326)))]
         assert result.size == (300, 150)
@@ -836,21 +828,29 @@ class TestDirectMapLayerWithSupportedSRS(object):
 
 
 class MockHTTPClient(object):
-    def __init__(self):
+    def __init__(self, response_type='image'):
         self.requested = []
+        self.response_type = response_type
 
     def open(self, url, data=None):
         self.requested.append(url)
-        w = int(re.search(r'width=(\d+)', url, re.IGNORECASE).group(1))
-        h = int(re.search(r'height=(\d+)', url, re.IGNORECASE).group(1))
-        format = re.search(r'format=image(/|%2F)(\w+)', url, re.IGNORECASE).group(2)
-        transparent = re.search(r'transparent=(\w+)', url, re.IGNORECASE)
-        transparent = True if transparent and transparent.group(1).lower() == 'true' else False
-        result = BytesIO()
-        create_debug_img((int(w), int(h)), transparent).save(result, format=format)
-        result.seek(0)
-        result.headers = {'Content-type': 'image/'+format}
-        return result
+        if self.response_type == 'image':
+            w = int(re.search(r'width=(\d+)', url, re.IGNORECASE).group(1))
+            h = int(re.search(r'height=(\d+)', url, re.IGNORECASE).group(1))
+            format = re.search(r'format=image(/|%2F)(\w+)', url, re.IGNORECASE).group(2)
+            transparent = re.search(r'transparent=(\w+)', url, re.IGNORECASE)
+            transparent = True if transparent and transparent.group(1).lower() == 'true' else False
+            result = BytesIO()
+            create_debug_img((int(w), int(h)), transparent).save(result, format=format)
+            result.seek(0)
+            result.headers = {'Content-type': 'image/'+format}
+            return result
+        elif self.response_type == 'text':
+            result = BytesIO(b'text')
+            result.headers = {'Content-type': 'text/plain'}
+            return result
+        else:
+            raise Exception('Unknown response type')
 
 
 @pytest.fixture
@@ -1105,7 +1105,7 @@ def test_srs_conditional_layers():
     ['low_3857', MapQuery((0, 0, 10000, 10000), (100, 100), SRS(31467)), False, True, False],
     ['low_projected', MapQuery((0, 0, 10000, 10000), (100, 100), SRS(31467)), False, True, False],
 ])
-def test_neasted_conditional_layers(case, map_query, is_direct, is_l3857, is_l4326):
+def test_nested_conditional_layers(case, map_query, is_direct, is_l3857, is_l4326):
     direct = MockLayer()
     l3857 = MockLayer()
     l4326 = MockLayer()
@@ -1207,7 +1207,7 @@ class TestTileManagerRescaleTiles(object):
             -99, [(16, 8, 5)], [], [(16, 8, 5), (8, 4, 4), (4, 2, 3), (2, 1, 2), (1, 0, 1), (0, 0, 0)], "blank",
         ),
         (
-            "upscale: unregular grid, partial match",
+            "upscale: irregular grid, partial match",
             -2, [(201, 101, 10)], [(78, 40, 8), (79, 40, 8), (79, 39, 8)], [
                 (201, 101, 10), (100, 50, 9),
                 # check all four tiles above 100/50/9
@@ -1215,7 +1215,7 @@ class TestTileManagerRescaleTiles(object):
             ], "partial",
         ),
         (
-            "upscale: unregular grid, multiple tiles, partial match",
+            "upscale: irregular grid, multiple tiles, partial match",
             -2, [(200, 100, 10), (201, 100, 10), (200, 101, 10), (201, 101, 10)],
             [(78, 40, 8), (79, 40, 8), (79, 39, 8)], [
                 (200, 100, 10), (201, 100, 10), (200, 101, 10), (201, 101, 10),
@@ -1224,7 +1224,7 @@ class TestTileManagerRescaleTiles(object):
             ], "partial",
         ),
         (
-            "upscale: unregular grid",
+            "upscale: irregular grid",
             -3, [(200, 100, 10)], [], [
                 (200, 100, 10), (100, 50, 9),
                 # check all four tiles above 100/50/9
@@ -1251,7 +1251,7 @@ class TestTileManagerRescaleTiles(object):
             0.0439453125,          # 5
             0.02197265625,         # 6
             0.010986328125,        # 7
-            0.007,                 # 8 additional resolution to test unregular grids
+            0.007,                 # 8 additional resolution to test irregular grids
             0.0054931640625,       # 9
             0.00274658203125,      # 10
         ]

--- a/mapproxy/test/unit/test_client.py
+++ b/mapproxy/test/unit/test_client.py
@@ -411,7 +411,7 @@ class TestCombinedWMSClient(object):
 class TestWMSInfoClient(object):
     def test_transform_fi_request_supported_srs(self):
         req = WMS111FeatureInfoRequest(url=TESTSERVER_URL + '/service?map=foo', param={'layers': 'foo'})
-        http = MockHTTPClient()
+        http = MockHTTPClient(response_type='text')
         wms = WMSInfoClient(req, http_client=http, supported_srs=SupportedSRS([SRS(25832)]))
         fi_req = InfoQuery((8, 50, 9, 51), (512, 512),
                            SRS(4326), (128, 64), 'text/plain')
@@ -428,7 +428,7 @@ class TestWMSInfoClient(object):
     def test_transform_fi_request(self):
         req = WMS111FeatureInfoRequest(
             url=TESTSERVER_URL + '/service?map=foo', param={'layers': 'foo', 'srs': 'EPSG:25832'})
-        http = MockHTTPClient()
+        http = MockHTTPClient(response_type='text')
         wms = WMSInfoClient(req, http_client=http)
         fi_req = InfoQuery((8, 50, 9, 51), (512, 512),
                            SRS(4326), (128, 64), 'text/plain')

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -58,7 +58,7 @@ class TestXSLTransformer(object):
     def test_transformer(self):
         t = XSLTransformer(self.xsl_script)
         doc = t.transform(XMLFeatureInfoDoc("<a><b>Text</b></a>"))
-        assert strip_whitespace(doc.as_string()) == b"<root><foo>Text</foo></root>"
+        assert strip_whitespace(doc.as_string()) == "<root><foo>Text</foo></root>"
 
     def test_multiple(self):
         t = XSLTransformer(self.xsl_script)
@@ -75,12 +75,13 @@ class TestXSLTransformer(object):
             )
         )
         assert strip_whitespace(doc.as_string()) == strip_whitespace(
-            b"""
+            """
             <root>
               <foo>ab</foo>
               <foo>ab1</foo><foo>ab2</foo><foo>ab3</foo>
               <foo>ab1</foo><foo>ab2</foo>
-            </root>"""
+            </root>
+            """
         )
         assert doc.info_type == "xml"
 
@@ -90,7 +91,7 @@ class TestXMLFeatureInfoDocs(object):
     def test_as_string(self):
         input_tree = etree.fromstring("<root></root>")
         doc = XMLFeatureInfoDoc(input_tree)
-        assert strip_whitespace(doc.as_string()) == b"<root/>"
+        assert strip_whitespace(doc.as_string()) == "<root/>"
 
     def test_as_etree(self):
         doc = XMLFeatureInfoDoc("<root>hello</root>")
@@ -100,9 +101,9 @@ class TestXMLFeatureInfoDocs(object):
         doc = XMLFeatureInfoDoc('<root>öäüß</root>')
         assert doc.as_etree().getroot().text == 'öäüß'
 
-        input_tree = etree.fromstring('<root>öäüß</root>'.encode('utf-8'))
+        input_tree = etree.fromstring(u'<root>öäüß</root>')
         doc = XMLFeatureInfoDoc(input_tree)
-        assert doc.as_string().decode("utf-8") == '<root>öäüß</root>'
+        assert doc.as_string() == '<root>öäüß</root>'
 
     def test_combine(self):
         docs = [
@@ -113,7 +114,7 @@ class TestXMLFeatureInfoDocs(object):
         result = XMLFeatureInfoDoc.combine(docs)
 
         assert strip_whitespace(result.as_string()) == strip_whitespace(
-            b"<root><a>foo</a><b>bar</b><a>baz</a></root>"
+            "<root><a>foo</a><b>bar</b><a>baz</a></root>"
         )
         assert result.info_type == "xml"
 
@@ -140,7 +141,7 @@ class TestXMLFeatureInfoDocsNoLXML(object):
         result = XMLFeatureInfoDoc.combine(docs)
 
         assert (
-            b"<root><a>foo</a></root>\n<root><b>bar</b></root>\n<other_root><a>baz</a></other_root>"
+            "<root><a>foo</a></root>\n<root><b>bar</b></root>\n<other_root><a>baz</a></other_root>"
             == result.as_string()
         )
         assert result.info_type == "text"
@@ -151,7 +152,7 @@ class TestHTMLFeatureInfoDocs(object):
     def test_as_string(self):
         input_tree = html.fromstring("<p>Foo")
         doc = HTMLFeatureInfoDoc(input_tree)
-        assert b"<body><p>Foo</p></body>" in strip_whitespace(doc.as_string())
+        assert "<body><p>Foo</p></body>" in strip_whitespace(doc.as_string())
 
     def test_as_etree(self):
         doc = HTMLFeatureInfoDoc("<p>hello</p>")
@@ -164,9 +165,9 @@ class TestHTMLFeatureInfoDocs(object):
             HTMLFeatureInfoDoc(b"<body><p>bar</p></body>"),
         ]
         result = HTMLFeatureInfoDoc.combine(docs)
-        assert b"<title>Hello</title>" in result.as_string()
+        assert "<title>Hello</title>" in result.as_string()
         assert (
-            b"<body><p>baz</p><p>baz2</p><p>foo</p><p>bar</p></body>"
+            "<body><p>baz</p><p>baz2</p><p>foo</p><p>bar</p></body>"
             in result.as_string()
         )
         assert result.info_type == "html"
@@ -180,7 +181,7 @@ class TestHTMLFeatureInfoDocs(object):
         result = HTMLFeatureInfoDoc.combine(docs)
 
         assert (
-            b"<body><p>foo</p><p>bar</p><p>baz</p><p>baz2</p></body>"
+            "<body><p>foo</p><p>bar</p><p>baz</p><p>baz2</p></body>"
             in result.as_string()
         )
         assert result.info_type == "html"
@@ -208,8 +209,8 @@ class TestHTMLFeatureInfoDocsNoLXML(object):
         result = HTMLFeatureInfoDoc.combine(docs)
 
         assert (
-            b"<html><head><title>Hello<body><p>baz</p>"
-            b"<p>baz2\n<p>foo</p>\n<body><p>bar</p></body>" == result.as_string()
+            "<html><head><title>Hello<body><p>baz</p>"
+            "<p>baz2\n<p>foo</p>\n<body><p>bar</p></body>" == result.as_string()
         )
         assert result.info_type == "text"
 
@@ -270,7 +271,7 @@ class TestCombineDocs(object):
         ]
         result, infotype = combine_docs(docs, None)
 
-        assert b"""<root><a>foo</a><b>bar</b></root>""" == result
+        assert """<root><a>foo</a><b>bar</b></root>""" == result
         assert infotype == "xml"
 
     def test_combine_transform_xml(self, tmpdir):
@@ -296,7 +297,7 @@ class TestCombineDocs(object):
         ]
         result, infotype = combine_docs(docs, transf)
 
-        assert b"""<root><foo>foo1</foo><foo>foo2</foo></root>""" == result
+        assert """<root><foo>foo1</foo><foo>foo2</foo></root>""" == result
         assert infotype is None
 
     def test_combine_mixed(self):
@@ -306,5 +307,5 @@ class TestCombineDocs(object):
         ]
         result, infotype = combine_docs(docs, None)
 
-        assert b"""{"results": [{"foo": 1}]}\nPlain Text""" == result
+        assert """{"results": [{"foo": 1}]}\nPlain Text""" == result
         assert infotype == "text"

--- a/mapproxy/test/unit/test_request_wmts.py
+++ b/mapproxy/test/unit/test_request_wmts.py
@@ -45,7 +45,7 @@ class DummyRequest(object):
 
 
 def test_tile_request():
-    args = """requeST=GetTile&service=wmts&tileMatrixset=EPSG900913&
+    args = """request=GetTile&service=wmts&tileMatrixset=EPSG900913&
 tilematrix=2&tileROW=4&TILECOL=2&FORMAT=image/png&Style=&layer=Foo&version=1.0.0"""
     req = wmts_request(dummy_req(args))
 
@@ -56,7 +56,7 @@ tilematrix=2&tileROW=4&TILECOL=2&FORMAT=image/png&Style=&layer=Foo&version=1.0.0
 
 
 def test_featureinfo_request():
-    args = """requeST=GetFeatureInfo&service=wmts&tileMatrixset=EPSG900913&
+    args = """request=GetFeatureInfo&service=wmts&tileMatrixset=EPSG900913&
 tilematrix=2&tileROW=4&TILECOL=2&FORMAT=image/png&Style=&layer=Foo&version=1.0.0&
 i=5&j=10&infoformat=application/json"""
     req = wmts_request(dummy_req(args))
@@ -70,7 +70,7 @@ i=5&j=10&infoformat=application/json"""
 
 
 def test_capabilities_request():
-    args = """requeST=GetCapabilities&service=wmts"""
+    args = """request=GetCapabilities&service=wmts"""
     req = wmts_request(dummy_req(args))
 
     assert isinstance(req, WMTS100CapabilitiesRequest)


### PR DESCRIPTION
The GFI requests returned improperly html encoded strings. This should fix this.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
