### PR TITLE
Skip permissions test for root

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@
 cd /mapproxy
 
 # create config files if they do not exist yet
-if [ ! -f /mapproxy/config/mapproxy.yaml ] && [ ${MULTIAPP_MAPPROXY} != "true" ]; then
+if [ ! -f /mapproxy/config/mapproxy.yaml ] && [ "$MULTIAPP_MAPPROXY" != "true" ]; then
   echo "No mapproxy configuration found. Creating one from template."
   mapproxy-util create -t base-config config
 fi

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -106,6 +106,7 @@ class TileCacheTestBase(object):
             assert self.cache.load_tile(tile) is True
             assert not tile.is_missing()
 
+    @pytest.mark.skipif(os.geteuid() == 0, reason="Test skipped for root user")
     def test_store_tiles_no_permissions(self):
         tiles = [self.create_tile((x, 589, 12)) for x in range(4)]
         tiles[0].stored = True


### PR DESCRIPTION
If running tests in `chroot` environment, the permissions tests will all fail, so we disable them if the running user is root. Normally all tests are run as non-root users.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
