### PR TITLE
fix: migrate to modern Logger API

### DIFF
--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -126,7 +126,7 @@ class DemoServer(Server):
         if pattern.match(url):
             return True
         else:
-            logging.warn(f"A request was blocked that was trying to access a non-http resource: {url}")
+            logging.warning(f"A request was blocked that was trying to access a non-http resource: {url}")
             return False
 
     @staticmethod


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
See [CI logs](https://github.com/mapproxy/mapproxy/actions/runs/14915218078/job/41899054111#step:8:211) for more information.