### PR TITLE
fix(deps): increase minimum version of pillow to 9.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,15 +51,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Cache python deps 💾
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.OS }}-python-${{ hashFiles('**/requirements-tests.txt') }}
-        restore-keys: |
-          ${{ runner.OS }}-python-
-          ${{ runner.OS }}-
+        cache: 'pip'
 
     - name: Install dependencies ⏬
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        pillow-version: ["11.2.1"]
+        include:
+          - python-version: "3.9"
+            pillow-version: "9.4.0"
 
     env:
       MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'
@@ -57,6 +61,7 @@ jobs:
       run: |
         pip install .
         pip install -r requirements-tests.txt
+        pip install Pillow==${{ matrix.pillow-version }}
         pip freeze
 
     - name: Run tests 🏗️

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         pillow-version: ["11.2.1"]
         include:
           - python-version: "3.9"
-            pillow-version: "9.4.0"
+            pillow-version: "8.1.2"
 
     env:
       MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1302,10 +1302,9 @@ The following encoding options are available:
 
 ``quantizer``
   The algorithm used to quantize (reduce) the image colors. Quantizing is used for GIF and paletted PNG images. Available quantizers are ``mediancut`` and ``fastoctree``. ``fastoctree`` is much faster and also supports 8bit PNG with full alpha support, but the image quality can be better with ``mediancut`` in some cases.
-  The quantizing is done by the Python Image Library (PIL). ``fastoctree`` is a `new quantizer <http://mapproxy.org/blog/improving-the-performance-for-png-requests/>`_ that is only available in Pillow >=2.0. See :ref:`installation of PIL<dependencies_pil>`.
 
 ``tiff_compression``
-  Enable compression for TIFF images. Available compression methods are `tiff_lzw` for lossless LZW compression, `jpeg` for JPEG compression and `raw` for no compression (default). You can use the ``jpeg_quality`` option to tune the image quality for JPEG compressed TIFFs. Requires Pillow >= 6.1.0.
+  Enable compression for TIFF images. Available compression methods are `tiff_lzw` for lossless LZW compression, `jpeg` for JPEG compression and `raw` for no compression (default). You can use the ``jpeg_quality`` option to tune the image quality for JPEG compressed TIFFs.
 
   .. versionadded:: 1.12.0
 

--- a/mapproxy/image/merge.py
+++ b/mapproxy/image/merge.py
@@ -211,10 +211,14 @@ class BandMerger(object):
         for op in self.ops:
             chan = src_img_bands[op.src_img][op.src_band]
             if op.factor != 1.0:
-                chan = ImageMath.lambda_eval(
-                    lambda args: args["convert"](args["int"](args["float"](args["a"]) * op.factor), 'L'),
-                    a=chan
-                )
+                # eval is deprecated since Pillow==10.3.0, lambda_eval is the replacement
+                if hasattr(ImageMath, 'lambda_eval'):
+                    chan = ImageMath.lambda_eval(
+                        lambda args: args["convert"](args["int"](args["float"](args["a"]) * op.factor), 'L'),
+                        a=chan
+                    )
+                else:
+                    chan = ImageMath.eval("convert(int(float(a) * %f), 'L')" % op.factor, a=chan)
                 if result_bands[op.dst_band] is None:
                     result_bands[op.dst_band] = chan
                 else:

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -126,7 +126,7 @@ class DemoServer(Server):
         if pattern.match(url):
             return True
         else:
-            logging.warn(f"A request was blocked that was trying to access a non-http resource: {url}")
+            logging.warning(f"A request was blocked that was trying to access a non-http resource: {url}")
             return False
 
     @staticmethod

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -44,7 +44,8 @@ py==1.11.0
 pyasn1==0.5.1
 pycparser==2.22
 pyparsing==3.2.3
-pyproj==3.6.1
+pyproj==3.6.1;python_version<"3.10"
+pyproj==3.7.1;python_version>="3.10"
 pyrsistent==0.20.0
 pytest-rerunfailures==13.0
 pytest==8.3.2

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -38,7 +38,7 @@ networkx==3.1;python_version<"3.10"
 networkx==3.4.2;python_version>="3.10"
 numpy==1.26.4
 packaging==24.2
-Pillow==11.2.1
+Pillow==11.2.1 # This version is overwritten in the test workflow, please adjust there as well
 pluggy==1.5.0
 py==1.11.0
 pyasn1==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ install_requires = [
     'pyproj>=2',
     'jsonschema>=4',
     'werkzeug<4',
-    'Pillow>=8.1.2,!=8.3.0,!=8.3.1'
+    'Pillow>=9.4.0;python_version<="3.11"',
+    'Pillow>=10.4.0;python_version=="3.12"',
+    'Pillow>=11.2.1;python_version=="3.13"'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-import platform
-import importlib.metadata
-
 from setuptools import setup, find_packages
 
 
@@ -9,33 +6,9 @@ install_requires = [
     'future',
     'pyproj>=2',
     'jsonschema>=4',
-    'werkzeug<4'
+    'werkzeug<4',
+    'Pillow>=8.1.2'
 ]
-
-
-def package_installed(pkg):
-    """Check if package is installed"""
-    try:
-        importlib.metadata.version(pkg)
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    else:
-        return True
-
-
-# depend on Pillow if it is installed, otherwise
-# depend on PIL if it is installed, otherwise
-# require Pillow
-if package_installed('Pillow'):
-    install_requires.append('Pillow !=2.4.0,!=8.3.0,!=8.3.1')
-elif package_installed('PIL'):
-    install_requires.append('PIL>=1.1.6,<1.2.99')
-else:
-    install_requires.append('Pillow !=2.4.0,!=8.3.0,!=8.3.1')
-
-if platform.python_version_tuple() < ('2', '6'):
-    # for mapproxy-seed
-    install_requires.append('multiprocessing>=2.6')
 
 
 def long_description(changelog_releases=10):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     'pyproj>=2',
     'jsonschema>=4',
     'werkzeug<4',
-    'Pillow>=8.1.2'
+    'Pillow>=8.1.2,!=8.3.0,!=8.3.1'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,11 @@ install_requires = [
     'pyproj>=2',
     'jsonschema>=4',
     'werkzeug<4',
-    'Pillow>=9.4.0;python_version<="3.11"',
-    'Pillow>=10.4.0;python_version=="3.12"',
-    'Pillow>=11.2.1;python_version=="3.13"'
+    'Pillow>=8,!=8.3.0,!=8.3.1;python_version=="3.9"',
+    'Pillow>=9;python_version=="3.10"',
+    'Pillow>=10;python_version=="3.11"',
+    'Pillow>=10.1;python_version=="3.12"',
+    'Pillow>=11;python_version=="3.13"'
 ]
 
 
@@ -61,6 +63,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
We replaced the use of the (deprecated) `PIL.ImageMath.eval` with `PIL.ImageMath.lambda_eval`. This function is only available since Pillow 10.3.0, so I added a switch to detect the presence of the function.

Also dropping the support of using PIL instead of Pillow.

And making the tests work for python 3.13 by using a newer pyproj version.

Pillow 9.4.0 is the version that is packaged in `python3-pil` in debian bookworm.

Added matrix testing for Pillow 9.4.0 to the test workflow.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
