### PR TITLE
Optional tms metadata

### DIFF
--- a/mapproxy/service/templates/tms_capabilities.xml
+++ b/mapproxy/service/templates/tms_capabilities.xml
@@ -2,6 +2,28 @@
     <TileMapService version="1.0.0">
     <Title>{{service.title}}</Title>
     <Abstract>{{service.abstract}}</Abstract>
+{{if service.keyword_list}}
+    <KeywordList>{{service.keyword_list}}</KeywordList>
+{{endif}}
+{{if service.contact}}
+{{py:service.contact = bunch(default='', **service.contact)}}
+    <ContactInformation>
+        <ContactPersonPrimary>
+            <ContactPerson>{{service.contact.person}}</ContactPerson>
+            <ContactOrganization>{{service.contact.organization}}</ContactOrganization>
+        </ContactPersonPrimary>
+        <ContactPosition>{{service.contact.position}}</ContactPosition>
+        <ContactAddress>
+            <Address>{{service.contact.address}}</Address>
+            <City>{{service.contact.city}}</City>
+            <PostCode>{{service.contact.postcode}}</PostCode>
+            <Country>{{service.contact.country}}</Country>
+        </ContactAddress>
+        <ContactVoiceTelephone>{{service.contact.phone}}</ContactVoiceTelephone>
+        <ContactFacsimileTelephone>{{service.contact.fax}}</ContactFacsimileTelephone>
+        <ContactElectronicMailAddress>{{service.contact.email}}</ContactElectronicMailAddress>
+    </ContactInformation>
+{{endif}}    
     <TileMaps>
 {{for layer in layers.values()}}
         <TileMap title="{{layer.title}}"

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -37,8 +37,8 @@ from mapproxy.util.coverage import load_limited_to
 import logging
 log = logging.getLogger(__name__)
 
-
-get_template = template_loader(__package__, 'templates')
+env = {'bunch': bunch}
+get_template = template_loader(__package__, 'templates', namespace=env)
 
 
 class TileServer(Server):


### PR DESCRIPTION
We would provide optional tms metadata KeywordList and ContactInformation for tms capabilities.
(https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification)

We are doing it with code below since a few years for our customer.

i.e. https://via.bund.de/wsv/bwastr/tms/1.0.0