### PR TITLE
wms opts query_layers for featurinfo

### DIFF
--- a/mapproxy/client/wms.py
+++ b/mapproxy/client/wms.py
@@ -180,7 +180,8 @@ class WMSInfoClient(object):
         req.params.pos = query.pos
         if query.feature_count:
             req.params['feature_count'] = query.feature_count
-        req.params['query_layers'] = req.params['layers']
+        if not 'query_layers' in req.params:
+            req.params['query_layers'] = req.params['layers']
         if 'info_format' not in req.params and query.info_format:
             req.params['info_format'] = query.info_format
         if not req.params.format:

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -864,6 +864,8 @@ class WMSSourceConfiguration(SourceConfiguration):
             version = wms_opts.get('version', '1.1.1')
             if 'featureinfo_format' in wms_opts:
                 params['info_format'] = wms_opts['featureinfo_format']
+            if 'query_layers' in wms_opts:
+                params['query_layers'] = wms_opts['query_layers']
             fi_request = create_request(self.conf['req'], params,
                                         req_type='featureinfo', version=version,
                                         abspath=self.context.globals.abspath)


### PR DESCRIPTION
We would provide an wms_opts query_layers param for source of type wms. 
Under some circumstances we have to define a special Featurinfo layer of the source wms which we would cascade to wmts featureinfo. 

i.e. 

sources:
  BWASTR_wms:
    type: wms
    concurrent_requests: 4
    wms_opts:
       version: 1.1.1
       featureinfo: true
       query_layers: Gewaessernetz
       legendgraphic: true

https://via.bund.de/wsv/bwastr/wmts/1.0.0/WMTSCapabilities.xml

