### PR TITLE
feat: use pip dependencies instead of system packages, make lxml mandatory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,8 @@ FROM python:3.12-slim-bookworm AS base-libs
 LABEL maintainer="mapproxy.org"
 
 RUN apt update && apt -y install --no-install-recommends \
-  python3-pil \
-  python3-yaml \
-  python3-pyproj \
   libgeos-dev \
-  python3-lxml \
   libgdal-dev \
-  python3-shapely \
   libxml2-dev \
   libxslt-dev && \
   apt-get -y --purge autoremove && \
@@ -48,7 +43,9 @@ ENV PATH="${PATH}:/mapproxy/.local/bin"
 RUN mkdir mapproxy-dist
 COPY --from=builder /mapproxy/dist/* mapproxy-dist/
 
-RUN pip install requests redis boto3 azure-storage-blob Shapely && \
+# Installing optional packages and MapProxy afterwards
+
+RUN pip install requests redis boto3 azure-storage-blob && \
   pip install --find-links=./mapproxy-dist --no-index MapProxy && \
   pip cache purge
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -5,9 +5,6 @@ LABEL maintainer="mapproxy.org"
 RUN apk -U upgrade --update \
     && apk add \
       g++ \
-      py3-pip  \
-      gdal \
-      gdal-dev \
       gdal \
       gdal-dev \
       libxslt-dev \
@@ -50,7 +47,9 @@ ENV PATH="${PATH}:/mapproxy/.local/bin"
 RUN mkdir mapproxy-dist
 COPY --from=builder /mapproxy/dist/* mapproxy-dist/
 
-RUN pip install requests redis boto3 azure-storage-blob Shapely && \
+# Installing optional packages and MapProxy afterwards
+
+RUN pip install requests redis boto3 azure-storage-blob && \
   pip install --find-links=./mapproxy-dist --no-index MapProxy && \
   pip cache purge
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -48,57 +48,8 @@ Installation
 
 On a Debian or Ubuntu system, you need to install the following packages::
 
-  sudo apt-get install python3-pil python3-yaml python3-pyproj
+  sudo apt-get install libgeos-dev libgdal-dev libxml2-dev libxslt-dev
 
-To get all optional packages::
-
-  sudo apt-get install libgeos-dev python3-lxml libgdal-dev python3-dev python3-shapely
-
-.. _dependency_details:
-
-Dependency details
-^^^^^^^^^^^^^^^^^^
-
-pyproj or libproj
-~~~~~~~~~~~~~~~~~
-
-MapProxy uses the PROJ C library for all coordinate transformation tasks. MapProxy can directly use the C library or via the pyproj Python package.
-The internal API of PROJ was updated with PROJ >=5. The old PROJ 4 API is now deprecated and will be removed from future PROJ releases. MapProxy only supports the new API via pyproj and it is therefore recommended to use a recent pyproj version.
-
-
-.. versionchanged:: 1.13
-  Support for new PROJ API via pyproj.
-
-
-.. _dependencies_pil:
-
-Pillow
-~~~~~~
-Pillow, the successor of the Python Image Library (PIL), is used for the image processing and it is included in most distributions as ``python-pil`` or ``python-imaging``. Please make sure that you have Pillow installed as MapProxy is no longer compatible with the original PIL. The version of ``python-imaging`` should be >=3.1.
-
-You can install a new version of Pillow from source with::
-
-  sudo apt-get install build-essential python-dev libjpeg-dev \
-    zlib1g-dev libfreetype6-dev
-  pip install Pillow
-
-
-Shapely and GEOS *(optional)*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You will need Shapely to use the :doc:`coverage feature <coverages>` of MapProxy. Shapely offers Python bindings for the GEOS library. You need Shapely (``python-shapely``) and GEOS (``libgeos-dev``). You can install Shapely as a Python package with ``pip install Shapely`` if you system does not provide a recent (>= 1.8) version of Shapely.
-
-GDAL *(optional)*
-~~~~~~~~~~~~~~~~~
-The :doc:`coverage feature <coverages>` allows you to read geometries from OGR datasources (Shapefiles, PostGIS, etc.). This package is optional and only required for OGR datasource support (BBOX, WKT and GeoJSON coverages are supported natively). OGR is part of GDAL (``libgdal-dev``).
-
-.. _lxml_install:
-
-lxml *(optional)*
-~~~~~~~~~~~~~~~~~
-
-`lxml`_ is used for more advanced WMS FeatureInformation operations like XSL transformation or the concatenation of multiple XML/HTML documents. It is available as ``python-lxml``.
-
-.. _`lxml`: http://lxml.de
 
 Install MapProxy
 ----------------

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -749,12 +749,10 @@ class WMSSourceConfiguration(SourceConfiguration):
         return WMSLegendSource([lg_client], legend_cache, static=True)
 
     def fi_xslt_transformer(self, conf, context):
-        from mapproxy.featureinfo import XSLTransformer, has_xslt_support
+        from mapproxy.featureinfo import XSLTransformer
         fi_transformer = None
         fi_xslt = conf.get('featureinfo_xslt')
         if fi_xslt:
-            if not has_xslt_support:
-                raise ValueError('featureinfo_xslt requires lxml. Please install.')
             fi_xslt = context.globals.abspath(fi_xslt)
             fi_format = conf.get('featureinfo_out_format')
             if not fi_format:
@@ -2098,12 +2096,10 @@ class LayerConfiguration(ConfigurationBase):
 
 
 def fi_xslt_transformers(conf, context):
-    from mapproxy.featureinfo import XSLTransformer, has_xslt_support
+    from mapproxy.featureinfo import XSLTransformer
     fi_transformers = {}
     fi_xslt = conf.get('featureinfo_xslt')
     if fi_xslt:
-        if not has_xslt_support:
-            raise ValueError('featureinfo_xslt requires lxml. Please install.')
         for info_type, fi_xslt in fi_xslt.items():
             fi_xslt = context.globals.abspath(fi_xslt)
             fi_transformers[info_type] = XSLTransformer(fi_xslt)

--- a/mapproxy/featureinfo.py
+++ b/mapproxy/featureinfo.py
@@ -21,13 +21,7 @@ from functools import reduce
 from io import StringIO
 from typing import List, Union
 
-try:
-    from lxml import etree, html
-
-    has_xslt_support = True
-except ImportError:
-    has_xslt_support = False
-    etree = html = None
+from lxml import etree, html
 
 
 class FeatureInfoDoc(object):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'Pillow>=9;python_version=="3.10"',
     'Pillow>=10;python_version=="3.11"',
     'Pillow>=10.1;python_version=="3.12"',
-    'Pillow>=11;python_version=="3.13"'
+    'Pillow>=11;python_version=="3.13"',
+    'lxml>=5',
+    'shapely>=2'
 ]
 
 


### PR DESCRIPTION
This PR removes the system installs of certain packages in the dockerfiles as these were not using the correct python version. Instead the setup.py now includes the needed libraries and they will always be installed via pip. This also removes the need to install these packages if doing a custom install on ubuntu. Additionally shapely, lxml, geos, gdal and pyproj are no longer optional.

This also makes it easier to rely on a certain version of the dependencies.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
