### PR TITLE
restful encoding / style isdefault and urn:ogc:def:crs for SupportedCRS

### DIFF
--- a/mapproxy/service/templates/wmts100capabilities.xml
+++ b/mapproxy/service/templates/wmts100capabilities.xml
@@ -43,7 +43,6 @@
     </ows:ServiceContact>
   </ows:ServiceProvider>
 {{endif}}
-{{if restful}}
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>
@@ -51,7 +50,7 @@
           <ows:Get xlink:href="{{service.url}}?">
             <ows:Constraint name="GetEncoding">
               <ows:AllowedValues>
-                <ows:Value>RESTful</ows:Value>
+                <ows:Value>{{if restful}}RESTful{{else}}KVP{{endif}}</ows:Value>
               </ows:AllowedValues>
             </ows:Constraint>
           </ows:Get>
@@ -64,7 +63,7 @@
           <ows:Get xlink:href="{{service.url}}?">
             <ows:Constraint name="GetEncoding">
               <ows:AllowedValues>
-                <ows:Value>RESTful</ows:Value>
+                <ows:Value>{{if restful}}RESTful{{else}}KVP{{endif}}</ows:Value>
               </ows:AllowedValues>
             </ows:Constraint>
           </ows:Get>
@@ -77,7 +76,7 @@
           <ows:Get xlink:href="{{service.url}}?">
             <ows:Constraint name="GetEncoding">
               <ows:AllowedValues>
-                <ows:Value>RESTful</ows:Value>
+                <ows:Value>{{if restful}}RESTful{{else}}KVP{{endif}}</ows:Value>
               </ows:AllowedValues>
             </ows:Constraint>
           </ows:Get>
@@ -85,50 +84,6 @@
       </ows:DCP>
     </ows:Operation>
   </ows:OperationsMetadata>
-{{endif}}
-{{if not restful}}
-  <ows:OperationsMetadata>
-    <ows:Operation name="GetCapabilities">
-      <ows:DCP>
-        <ows:HTTP>
-          <ows:Get xlink:href="{{service.url}}?">
-            <ows:Constraint name="GetEncoding">
-              <ows:AllowedValues>
-                <ows:Value>KVP</ows:Value>
-              </ows:AllowedValues>
-            </ows:Constraint>
-          </ows:Get>
-        </ows:HTTP>
-      </ows:DCP>
-    </ows:Operation>
-    <ows:Operation name="GetTile">
-      <ows:DCP>
-        <ows:HTTP>
-          <ows:Get xlink:href="{{service.url}}?">
-            <ows:Constraint name="GetEncoding">
-              <ows:AllowedValues>
-                <ows:Value>KVP</ows:Value>
-              </ows:AllowedValues>
-            </ows:Constraint>
-          </ows:Get>
-        </ows:HTTP>
-      </ows:DCP>
-    </ows:Operation>
-    <ows:Operation name="GetFeatureInfo">
-      <ows:DCP>
-        <ows:HTTP>
-          <ows:Get xlink:href="{{service.url}}?">
-            <ows:Constraint name="GetEncoding">
-              <ows:AllowedValues>
-                <ows:Value>KVP</ows:Value>
-              </ows:AllowedValues>
-            </ows:Constraint>
-          </ows:Get>
-        </ows:HTTP>
-      </ows:DCP>
-    </ows:Operation>
-  </ows:OperationsMetadata>
-{{endif}}
   <Contents>
 {{for layer in layers}}
     <Layer>


### PR DESCRIPTION
We provide a bit enhanced wmts capabilities doc with following template since a few years for our mapproxy wmts services to solve compability issues with some wmts clients.

We provide the restful encoding, the isDefault=true declaration for the one style and the urn:ogc:def:crs: prefix for EPSG:XXXX declarations of srs for compability.

We changed the DeliveryPoint to the more correct {{service.contact.address}} property (in our opinion).

Maybe it's usefull in general for others too - hopefully.