### PR TITLE
Update mbtiles.py

### DIFF
--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -117,7 +117,7 @@ class MBTilesCache(TileCacheBase):
 
         if self.file_permissions:
             permission = int(self.file_permissions, base=8)
-            log.info("setting file permissions on MBTile file: ", permission)
+            log.info("setting file permissions on MBTile file: %s", permission)
             os.chmod(self.mbtile_file, permission)
 
     def update_metadata(self, name='', description='', version=1, overlay=True, format='png'):


### PR DESCRIPTION
This log.info line is missing the %s placeholder to replace the argument, and an error occurs when creating .mbtile files:

log.info("setting file permissions on MBTile file: ", permission)

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
