### PR TITLE
Fix test failure with jsonschema 4.25.

### DIFF
--- a/mapproxy/test/unit/test_conf_validator.py
+++ b/mapproxy/test/unit/test_conf_validator.py
@@ -80,8 +80,13 @@ class TestValidator(object):
         ''')
 
         errors = validate(conf)
-        assert errors == [
-            "[] is too short in root.layers[0].sources"
+        assert errors in [
+            [
+                "[] is too short in root.layers[0].sources"
+            ],
+            [
+                "[] should be non-empty in root.layers[0].sources"
+            ]
         ]
 
     def test_missing_cache_source(self):


### PR DESCRIPTION
The tests fail with jsonschema as reported in [Debian Bug #1113852](https://bugs.debian.org/1113852):
```python
=================================== FAILURES ===================================
____________________ TestValidator.test_empty_layer_sources ____________________

self = <test.unit.test_conf_validator.TestValidator object at 0x7f987a201810>

    def test_empty_layer_sources(self):
        conf = self._test_conf('''
            layers:
                - name: one
                  title: One
                  sources: []
        ''')
    
        errors = validate(conf)
>       assert errors == [
            "[] is too short in root.layers[0].sources"
        ]
E       AssertionError: assert ['[] should b...s[0].sources'] == ['[] is too s...s[0].sources']
E         
E         At index 0 diff: '[] should be non-empty in root.layers[0].sources' != '[] is too short in root.layers[0].sources'
E         Use -v to get more diff

mapproxy/test/unit/test_conf_validator.py:83: AssertionError
```
https://ci.debian.net/packages/m/mapproxy/unstable/amd64/63842620/

The error changed to: `[] should be non-empty in root.layers[0].sources`