### PR TITLE
fix: using correct extension for mbtiles

### DIFF
--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -335,7 +335,7 @@ class MBTilesLevelCache(TileCacheBase):
 
         with self._mbtiles_lock:
             if level not in self._mbtiles:
-                mbtile_filename = os.path.join(self.cache_dir, '%s.mbtile' % level)
+                mbtile_filename = os.path.join(self.cache_dir, '%s.mbtiles' % level)
                 self._mbtiles[level] = MBTilesCache(
                     mbtile_filename,
                     with_timestamps=True,

--- a/mapproxy/test/system/test_seed.py
+++ b/mapproxy/test/system/test_seed.py
@@ -309,8 +309,8 @@ class TestSeed(SeedTestBase):
         assert cache.is_cached(Tile((0, 0, 3)))
 
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'sqlite_cache', 'GLOBAL_GEODETIC'),
-                            ['2.mbtile', '3.mbtile'],
-                            glob='*.mbtile')
+                            ['2.mbtiles', '3.mbtiles'],
+                            glob='*.mbtiles')
 
         # simulate that cleanup was called after creation of tiles
         time.sleep(1)
@@ -321,8 +321,8 @@ class TestSeed(SeedTestBase):
 
         # 3.mbtile file is still there
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'sqlite_cache', 'GLOBAL_GEODETIC'),
-                            ['2.mbtile', '3.mbtile'],
-                            glob='*.mbtile')
+                            ['2.mbtiles', '3.mbtiles'],
+                            glob='*.mbtiles')
         assert cache.is_cached(Tile((0, 0, 2)))
         assert not cache.is_cached(Tile((0, 0, 3)))
 
@@ -343,15 +343,15 @@ class TestSeed(SeedTestBase):
         cleanup_tasks = seed_conf.cleanups(['sqlite_cache_remove_all'])
 
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'sqlite_cache', 'GLOBAL_GEODETIC'),
-                            ['2.mbtile', '3.mbtile'],
-                            glob='*.mbtile')
+                            ['2.mbtiles', '3.mbtiles'],
+                            glob='*.mbtiles')
 
         cleanup(cleanup_tasks, verbose=False, dry_run=False)
 
         # 3.mbtile file should be removed completely
         assert_files_in_dir(os.path.join(self.dir, 'cache', 'sqlite_cache', 'GLOBAL_GEODETIC'),
-                            ['3.mbtile'],
-                            glob='*.mbtile')
+                            ['3.mbtiles'],
+                            glob='*.mbtiles')
         assert not cache.is_cached(Tile((0, 0, 2)))
         assert cache.is_cached(Tile((0, 0, 3)))
 

--- a/mapproxy/test/unit/test_cache_mbtile.py
+++ b/mapproxy/test/unit/test_cache_mbtile.py
@@ -109,24 +109,24 @@ class TestMBTileLevelCache(TileCacheTestBase):
         assert_files_in_dir(self.cache_dir, [])
 
         self.cache.store_tile(self.create_tile((0, 0, 1)))
-        assert_files_in_dir(self.cache_dir, ['1.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['1.mbtiles'], glob='*.mbtiles')
 
         self.cache.store_tile(self.create_tile((0, 0, 5)))
-        assert_files_in_dir(self.cache_dir, ['1.mbtile', '5.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['1.mbtiles', '5.mbtiles'], glob='*.mbtiles')
 
     def test_remove_level_files(self):
         self.cache.store_tile(self.create_tile((0, 0, 1)))
         self.cache.store_tile(self.create_tile((0, 0, 2)))
-        assert_files_in_dir(self.cache_dir, ['1.mbtile', '2.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['1.mbtiles', '2.mbtiles'], glob='*.mbtiles')
 
         self.cache.remove_level_tiles_before(1, remove_all=True)
-        assert_files_in_dir(self.cache_dir, ['2.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['2.mbtiles'], glob='*.mbtiles')
 
     def test_remove_level_tiles_before(self):
         self.cache.store_tile(self.create_tile((0, 0, 1)))
         self.cache.store_tile(self.create_tile((0, 0, 2)))
 
-        assert_files_in_dir(self.cache_dir, ['1.mbtile', '2.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['1.mbtiles', '2.mbtiles'], glob='*.mbtiles')
         assert self.cache.is_cached(Tile((0, 0, 1)))
 
         self.cache.remove_level_tiles_before(1, timestamp=time.time() - 60)
@@ -135,7 +135,7 @@ class TestMBTileLevelCache(TileCacheTestBase):
         self.cache.remove_level_tiles_before(1, timestamp=time.time() + 60)
         assert not self.cache.is_cached(Tile((0, 0, 1)))
 
-        assert_files_in_dir(self.cache_dir, ['1.mbtile', '2.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['1.mbtiles', '2.mbtiles'], glob='*.mbtiles')
         assert self.cache.is_cached(Tile((0, 0, 2)))
 
     def test_bulk_store_tiles_with_different_levels(self):
@@ -146,7 +146,7 @@ class TestMBTileLevelCache(TileCacheTestBase):
             self.create_tile((1, 0, 1)),
         ], dimensions=None)
 
-        assert_files_in_dir(self.cache_dir, ['1.mbtile', '2.mbtile'], glob='*.mbtile')
+        assert_files_in_dir(self.cache_dir, ['1.mbtiles', '2.mbtiles'], glob='*.mbtiles')
         assert self.cache.is_cached(Tile((0, 0, 1)))
         assert self.cache.is_cached(Tile((1, 0, 1)))
         assert self.cache.is_cached(Tile((0, 0, 2)))


### PR DESCRIPTION
BREAKING CHANGE: Existing files in the cache have to be renamed. This script can be used: `find . -type f -name "*.mbtile" -exec sh -c 'mv "$1" "${1%.mbtile}.mbtiles"' _ {} \;`

Fixes #1209 

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
