### PR TITLE
use_direct_from_level: fix schema datatype to integer

### DIFF
--- a/mapproxy/config/config-schema.json
+++ b/mapproxy/config/config-schema.json
@@ -578,7 +578,7 @@
         },
         "use_direct_from_level": {
           "description": "Requests below this level will not be stored",
-          "type": "boolean"
+          "type": "integer"
         },
         "use_direct_from_res": {
           "description": "Requests below this resolution will not be stored",


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
