### PR TITLE
chore: update mapproxy docker images when base images are updated

### DIFF
--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -1,0 +1,137 @@
+name: Dependabot Dockerfile Update
+
+permissions:
+  packages: write
+  security-events: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile'
+      - 'Dockerfile-alpine'
+
+jobs:
+  update-and-publish-ubuntu:
+    runs-on: ubuntu-latest
+
+    # Only run if the push was made by dependabot
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Get latest release tag
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          echo "Latest release tag: $LATEST_TAG"
+
+      - name: Use the tag in subsequent steps
+        run: |
+          echo "Using tag: ${{ env.LATEST_TAG }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile
+          push: true
+          target: base
+          tags: ${{ env.LATEST_TAG }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push development image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile
+          push: true
+          target: development
+          tags: ${{ env.LATEST_TAG }}-dev
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push nginx image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile
+          push: true
+          target: nginx
+          tags: ${{ env.LATEST_TAG }}-nginx
+          platforms: linux/amd64,linux/arm64
+
+  build-and-publish-alpine:
+      # Only run if the push was made by dependabot
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Get latest release tag
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          echo "Latest release tag: $LATEST_TAG"
+
+      - name: Use the tag in subsequent steps
+        run: |
+          echo "Using tag: ${{ env.LATEST_TAG }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base alpine image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile-alpine
+          push: true
+          target: base
+          tags: ${{ env.LATEST_TAG }}-alpine
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push alpine development image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile-alpine
+          push: true
+          target: development
+          tags: ${{ env.LATEST_TAG }}-alpine-dev
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push alpine based nginx image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile-alpine
+          push: true
+          target: nginx
+          tags: ${{ env.LATEST_TAG }}-alpine-nginx
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->


This PR fixes an issue in the Docker image build process where the mapproxy base image was only updated when a new release was triggered.
A new workflow, docker-update.yml, has been introduced to rebuild the images for the latest released tag when the docker base image was updated by `dependabot`.

This especially addresses the problems reported in issues
* https://github.com/mapproxy/mapproxy/issues/1217
* https://github.com/mapproxy/mapproxy/issues/1219