### PR TITLE
Add improved logging on http error

### DIFF
--- a/mapproxy/source/tile.py
+++ b/mapproxy/source/tile.py
@@ -79,7 +79,7 @@ class TiledSource(MapLayer):
                 resp = self.error_handler.handle(e.response_code, query)
                 if resp:
                     return resp
-            log.warning('could not retrieve tile (client: %s)', self.client, exc_info=True)
+            log.warning('could not retrieve tile (client: %s): %s', self.client, e, exc_info=True)
             reraise_exception(SourceError(e.args[0]), sys.exc_info())
 
 


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

Closes #1205

Adds better logging on HTTPClientError:
* Includes the client, to differentiate between multiple clients fetching tiles
* Includes the entire exc_info stack trace in the log