### PR TITLE
fix(logging): actually output argument for mapproxy config debug log

### DIFF
--- a/doc/mapproxy_util.rst
+++ b/doc/mapproxy_util.rst
@@ -109,6 +109,10 @@ You need to pass the MapProxy configuration as an argument. The server will auto
 
   The server outputs debug logging information to the console.
 
+.. cmdoption:: --log-config
+
+  Supply a logging config.
+
 
 Example
 -------

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -2405,7 +2405,7 @@ def load_configuration(mapproxy_conf, seed=False, ignore_warnings=True, renderd=
 
     try:
         conf_dict = load_configuration_file([os.path.basename(mapproxy_conf)], conf_base_dir)
-        log.debug('Loaded configuration file', json.dumps(conf_dict, indent=2, sort_keys=True, default=str))
+        log.debug('Loaded configuration file: %s', json.dumps(conf_dict, indent=2, sort_keys=True, default=str))
     except YAMLError as ex:
         raise ConfigurationError(ex)
     errors, informal_only = validate_options(conf_dict)


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
