### PR TITLE
fix(ows): make service non mandatory for WMS GetMap requests

### DIFF
--- a/mapproxy/service/ows.py
+++ b/mapproxy/service/ows.py
@@ -36,9 +36,11 @@ class OWSServer(object):
     def handle(self, req):
         service = req.args.get('service')
         wmtver = req.args.get('wmtver')
+        request_arg = req.args.get('request')
         if not service:
-            if wmtver == '1.0.0':
+            if wmtver == '1.0.0' or request_arg == 'GetMap':
                 # WMS version 1.0.0 did not have a mandatory service parameter
+                # and for the `GetMap` request the service also is not mandatory
                 service = 'wms'
             else:
                 req.exception_handler = OWSExceptionHandler()


### PR DESCRIPTION
According to spec the service parameter is not mandatory for WMS GetMap requests.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
