### PR TITLE
Use correct command for Waitress serve

### DIFF
--- a/doc/deployment.rst
+++ b/doc/deployment.rst
@@ -149,7 +149,7 @@ You need a server script that creates the MapProxy application (see :ref:`above 
 To start MapProxy with Waitress and our server script (without ``.py``)::
 
   cd /path/of/config.py/
-  waitress --listen 127.0.0.1:8080 config:application
+  waitress-serve --listen 127.0.0.1:8080 config:application
 
 
 uWSGI


### PR DESCRIPTION
The actual command is `waitress-serve` not `waitress`

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
