### PR TITLE
Update lxml

### DIFF
--- a/mapproxy/test/system/test_wms.py
+++ b/mapproxy/test/system/test_wms.py
@@ -753,7 +753,7 @@ class TestWMS111(SysTest):
             self.common_fi_req.params["info_format"] = "text/html"
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/html"
-            assert resp.body == b"<html><body><p>info</p></body></html>"
+            assert resp.body == b"<html><body>info</body></html>"
             assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_get_featureinfo_info_format_special_chars(self, app):
@@ -771,7 +771,7 @@ class TestWMS111(SysTest):
             self.common_fi_req.params["info_format"] = "text/html"
             resp = app.get(self.common_fi_req)
             assert resp.content_type == "text/html"
-            assert resp.body == encode(u"<html><body><p>äüß▼</p></body></html>")
+            assert resp.body == encode(u"<html><body>äüß▼</body></html>")
             assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_get_featureinfo_130(self, app):

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -160,7 +160,7 @@ class TestHTMLFeatureInfoDocs(object):
 
     def test_combine(self):
         docs = [
-            HTMLFeatureInfoDoc(b"<html><head><title>Hello<body><p>baz</p><p>baz2"),
+            HTMLFeatureInfoDoc(b"<html><head><title>Hello</title></head><body><p>baz</p><p>baz2</body></html>"),
             HTMLFeatureInfoDoc(b"<p>foo</p>"),
             HTMLFeatureInfoDoc(b"<body><p>bar</p></body>"),
         ]
@@ -176,7 +176,7 @@ class TestHTMLFeatureInfoDocs(object):
         docs = [
             HTMLFeatureInfoDoc("<p>foo</p>"),
             HTMLFeatureInfoDoc("<body><p>bar</p></body>"),
-            HTMLFeatureInfoDoc("<html><head><title>Hello<body><p>baz</p><p>baz2"),
+            HTMLFeatureInfoDoc("<html><head><title>Hello</title></head><body><p>baz</p><p>baz2</body></html>"),
         ]
         result = HTMLFeatureInfoDoc.combine(docs)
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -29,7 +29,7 @@ jsonpointer==2.4
 jsonschema==4.17;python_version<"3.10"
 jsonschema==4.20;python_version>="3.10"
 junit-xml==1.9
-lxml==5.3.0
+lxml==6.0.2
 MarkupSafe==1.1.1
 mock==5.1.0
 more-itertools==10.1.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'Pillow>=10;python_version=="3.11"',
     'Pillow>=10.1;python_version=="3.12"',
     'Pillow>=11;python_version=="3.13"',
-    'lxml>=4',
+    'lxml>=6',
     'shapely>=2'
 ]
 


### PR DESCRIPTION
The new lxml version seems to be much stricter in it's parsing.

It is used to merge multiple html feature info responses into one valid html response.

Before it was quite tolerant in it's inputs, which is actually a good thing. Especially considering that feature info services are often configured poorly.

Anyhow. This PR should also close #1231

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
