### PR TITLE
ci: add coverage reports to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -73,6 +74,67 @@ jobs:
       run: |
         export LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6:$LD_PRELOAD
         pytest mapproxy
+
+  coverage:
+    runs-on: ubuntu-24.04
+    services:
+      redis-server:
+        image: redis
+        ports:
+          - 6379:6379
+      couchdb:
+        image: couchdb:2
+        ports:
+          - 5984:5984
+      azure-blob:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+
+    env:
+      MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'
+      MAPPROXY_TEST_REDIS: '127.0.0.1:6379'
+      MAPPROXY_TEST_AZURE_BLOB: 'http://localhost:10000'
+      # do not load /etc/boto.cfg with Python 3 incompatible plugin
+      # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
+      BOTO_CONFIG: '/doesnotexist'
+
+    steps:
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install proj-bin libgeos-dev libgdal-dev libxslt-dev libxml2-dev build-essential libjpeg-dev zlib1g-dev libfreetype6-dev protobuf-compiler libprotoc-dev -y
+
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Use python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies ⏬
+        run: |
+          pip install .
+          pip install -r requirements-tests.txt
+          pip freeze
+
+      - name: Run tests with coverage 🏗️
+        run: |
+          export LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6:$LD_PRELOAD
+          coverage run -m pytest mapproxy
+
+      - name: Create coverage report
+        run: |
+          coverage report -m --format markdown > coverage-report.md
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: coverage-report.md
 
   doc:
     runs-on: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,11 @@ markers = [
 exclude = [".git", ".idea", "build", "dist", "MapProxy.egg-info"]
 max-line-length = 120
 extend-ignore = ["E128"]
+
+[tool.coverage.run]
+source = [
+    "mapproxy"
+]
+omit = [
+    "mapproxy/test/*"
+]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,6 +10,7 @@ certifi==2025.4.26
 cffi==2.0.0;
 cfn-lint==0.80.3
 chardet==5.2.0
+coverage==7.11.3;python_version>="3.10"
 cryptography==44.0.2
 decorator==5.2.1
 docker==7.1.0


### PR DESCRIPTION
This adds an additional coverage job to the github action. The coverage results are posted as comments on PRs.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
