### PR TITLE
Fix OGC API: use req.script_url so SCRIPT_NAME is respected behind re…

### DIFF
--- a/mapproxy/service/ogcapi/server.py
+++ b/mapproxy/service/ogcapi/server.py
@@ -35,6 +35,8 @@ from mapproxy.service.ogcapi.constants import (
 )
 from mapproxy.util.jinja2_templates import render_j2_template
 
+from mapproxy.util.escape import escape_html
+
 import logging
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### Fix: OGC API does not respect SCRIPT_NAME behind reverse proxies

This PR replaces `req.host_url` with `req.script_url` inside  
`OGCAPIServer.create_href()`.

`script_url` already includes:

- scheme  
- host  
- external prefix (`SCRIPT_NAME`)  

so OGC API links become consistent with WMS/WMTS URLs, which already respect `SCRIPT_NAME`.

This fixes deployments where MapProxy runs behind a reverse proxy under a path prefix (for example `/geo`), where OGC API currently produces incorrect URLs such as:


```text
https://example.com/ogcapi/collections/<id>

instead of:

https://example.com/<prefix>/ogcapi/collections/<id>
```
Minimal patch applied:
```python
def create_href(self, req, resource):
    return req.script_url + resource
```

Fixes #1344
