### PR TITLE
Fix exception when trying to merge two configurations - one with named layer and one without

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -137,18 +137,23 @@ def merge_layers(conf, base):
     Return `base` dict with values from `conf` merged in.
     """
     out = []
-    remaining_conf = []
+    remaining_conf_named_layers = []
+    remaining_conf_unnamed_layers = []
     for conf_layer in conf:
-        remaining_conf.append(conf_layer['name'])
+        if 'name' in conf_layer:
+            remaining_conf_named_layers.append(conf_layer['name'])
+        else:
+            remaining_conf_unnamed_layers.append(conf_layer['title'])
+        
 
     for base_layer in base:
         found = False
         for conf_layer in conf:
             if 'name' in conf_layer and 'name' in base_layer:
-                if conf_layer['name'] in remaining_conf and base_layer['name'] == conf_layer['name']:
+                if conf_layer['name'] in remaining_conf_named_layers and base_layer['name'] == conf_layer['name']:
                     new_layer = merge_dict(conf_layer, base_layer)
                     out.append(new_layer)
-                    remaining_conf.remove(conf_layer['name'])
+                    remaining_conf_named_layers.remove(conf_layer['name'])
                     found = True
                     break
 
@@ -156,7 +161,11 @@ def merge_layers(conf, base):
             out.append(base_layer)
 
     for conf_layer in conf:
-        if conf_layer['name'] in remaining_conf:
-            out.append(conf_layer)
+        if 'name' in conf_layer:
+            if conf_layer['name'] in remaining_conf_named_layers:
+                out.append(conf_layer)
+        else:
+            if conf_layer['title'] in remaining_conf_unnamed_layers:
+                out.append(conf_layer)
 
     return out


### PR DESCRIPTION
Right now mapproxy throws an excpetion when trying to merge two layers using the following configuration in the mapproxy.yaml:

```
base: [config/only_named_layers.yaml, generated_config/named_and_unnamed_layers_mixed.yaml]
```

named_and_unnamed_layers.mixed
```
layers:
- layers:
  - name: earth.bluemarble.rgb
    sources:
    - earth.bluemarble.rgb_wms
    title: earth.bluemarble.rgb
  md:
    abstract: My Mixed Layers
  sources:
  - MyWms
  title: My Grouped Layers
```
only_named_layers.yaml
```
layers:
- layers:
  - name: earth.etopo.dem
    sources:
    - earth.etopo.dem_wms
    title: earth.etopo.rgb
  md:
    abstract: My only named layers
  sources:
  - MyWms
  name: ThisIsANamedLayer
  title: My only named Layers
```

This happens since, during the merge of the layer configurations we assume that base as well as conf layer are named layers. If one of these layers are not named layers we get this exception. This PR checks if the key `name` is present before trying to merge.