### PR TITLE
Explicitly use 'fork' instead of 'forkserver' to fix failure with python3.14

### DIFF
--- a/mapproxy/test/conftest.py
+++ b/mapproxy/test/conftest.py
@@ -1,3 +1,8 @@
+import multiprocessing
+
+import pytest
+
+
 def pytest_configure(config):
     import sys
     sys._called_from_pytest = True
@@ -6,3 +11,14 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     import sys
     del sys._called_from_pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def use_multiprocessing_fork_on_linux():
+    import sys
+    if sys.platform != "linux":
+        # Windows and macOS use 'spawn' by default
+        return
+
+    # 'forkserver' is default since Python 3.14, but can't pickle everything.
+    multiprocessing.set_start_method("fork")


### PR DESCRIPTION
The Debian package build fails with Python 3.14 due to test failures:
```
============================= test session starts ==============================
platform linux -- Python 3.14.2, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3.14
cachedir: .pytest_cache
rootdir: /build/mapproxy-6.0.1+dfsg/.pybuild/cpython3_3.14_mapproxy/build
configfile: pytest.ini
plugins: typeguard-4.4.4
collecting ... collected 881 items / 191 skipped
[...]
=================================== FAILURES ===================================
________________ TestCacheLock.test_locked_by_process_no_block _________________

self = <mapproxy.test.unit.test_seed_cachelock.TestCacheLock object at 0x7fd07c2c8410>
lock_file = '/tmp/pytest-of-pbuilder/pytest-0/test_locked_by_process_no_bloc0/lock'

    def test_locked_by_process_no_block(self, lock_file):
        proc_is_locked = multiprocessing.Event()
    
        def lock():
            locker = CacheLocker(lock_file)
            with locker.lock("foo"):
                proc_is_locked.set()
                time.sleep(10)
    
        p = multiprocessing.Process(target=lock)
>       p.start()

mapproxy/test/unit/test_seed_cachelock.py:48: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.14/multiprocessing/process.py:121: in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
/usr/lib/python3.14/multiprocessing/context.py:224: in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.14/multiprocessing/context.py:300: in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
/usr/lib/python3.14/multiprocessing/popen_forkserver.py:35: in __init__
    super().__init__(process_obj)
/usr/lib/python3.14/multiprocessing/popen_fork.py:20: in __init__
    self._launch(process_obj)
/usr/lib/python3.14/multiprocessing/popen_forkserver.py:47: in _launch
    reduction.dump(process_obj, buf)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = <Process name='Process-6' parent=2008859 initial>
file = <_io.BytesIO object at 0x7fd07b3b11c0>, protocol = None

    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       _pickle.PicklingError: Can't pickle local object <function TestCacheLock.test_locked_by_process_no_block.<locals>.lock at 0x7fd07b3c50c0>
E       when serializing dict item '_target'
E       when serializing multiprocessing.context.Process state
E       when serializing multiprocessing.context.Process object

/usr/lib/python3.14/multiprocessing/reduction.py:60: PicklingError
_________________ TestCacheLock.test_locked_by_process_waiting _________________

self = <mapproxy.test.unit.test_seed_cachelock.TestCacheLock object at 0x7fd07c32fbb0>
lock_file = '/tmp/pytest-of-pbuilder/pytest-0/test_locked_by_process_waiting0/lock'

    def test_locked_by_process_waiting(self, lock_file):
        proc_is_locked = multiprocessing.Event()
    
        def lock():
            locker = CacheLocker(lock_file)
            with locker.lock("foo"):
                proc_is_locked.set()
                time.sleep(.1)
    
        p = multiprocessing.Process(target=lock)
        start_time = time.time()
>       p.start()

mapproxy/test/unit/test_seed_cachelock.py:79: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.14/multiprocessing/process.py:121: in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
/usr/lib/python3.14/multiprocessing/context.py:224: in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.14/multiprocessing/context.py:300: in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
/usr/lib/python3.14/multiprocessing/popen_forkserver.py:35: in __init__
    super().__init__(process_obj)
/usr/lib/python3.14/multiprocessing/popen_fork.py:20: in __init__
    self._launch(process_obj)
/usr/lib/python3.14/multiprocessing/popen_forkserver.py:47: in _launch
    reduction.dump(process_obj, buf)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = <Process name='Process-7' parent=2008859 initial>
file = <_io.BytesIO object at 0x7fd07b3331a0>, protocol = None

    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       _pickle.PicklingError: Can't pickle local object <function TestCacheLock.test_locked_by_process_waiting.<locals>.lock at 0x7fd07b3c5bc0>
E       when serializing dict item '_target'
E       when serializing multiprocessing.context.Process state
E       when serializing multiprocessing.context.Process object

/usr/lib/python3.14/multiprocessing/reduction.py:60: PicklingError
=============================== warnings summary ===============================
mapproxy/srs.py:90
  /build/mapproxy-6.0.1+dfsg/.pybuild/cpython3_3.14_mapproxy/build/mapproxy/srs.py:90: DeprecationWarning: calling un-configured base_config
    if not _proj_initialized and 'proj_data_dir' in base_config().srs:

mapproxy/test/unit/test_cache_mbtile.py: 44 warnings
  /build/mapproxy-6.0.1+dfsg/.pybuild/cpython3_3.14_mapproxy/build/mapproxy/cache/mbtiles.py:67: DeprecationWarning: Passing more than 1 positional argument to sqlite3.connect() is deprecated. Parameters 'timeout', 'detect_types', 'isolation_level', 'check_same_thread', 'factory', 'cached_statements' and 'uri' will become keyword-only parameters in Python 3.15.
    self._db_conn_cache.db = sqlite3.connect(self.mbtile_file, self.timeout)

mapproxy/test/unit/test_cache_mbtile.py: 44 warnings
  /build/mapproxy-6.0.1+dfsg/.pybuild/cpython3_3.14_mapproxy/build/mapproxy/cache/mbtiles.py:67: DeprecationWarning: Passing more than 1 positional argument to _sqlite3.Connection() is deprecated. Parameters 'timeout', 'detect_types', 'isolation_level', 'check_same_thread', 'factory', 'cached_statements' and 'uri' will become keyword-only parameters in Python 3.15.
    self._db_conn_cache.db = sqlite3.connect(self.mbtile_file, self.timeout)

mapproxy/test/unit/test_geom.py::TestPolygonLoading::test_loading_polygon
mapproxy/test/unit/test_geom.py::TestPolygonLoading::test_loading_multipolygon
mapproxy/test/unit/test_geom.py::TestPolygonLoading::test_loading_broken
mapproxy/test/unit/test_geom.py::TestPolygonLoading::test_loading_skip_non_polygon
mapproxy/test/unit/test_geom.py::TestPolygonLoading::test_loading_intersecting_polygons
mapproxy/test/unit/test_geom.py::TestLoadDatasource::test_wkt
  /build/mapproxy-6.0.1+dfsg/.pybuild/cpython3_3.14_mapproxy/build/mapproxy/util/geom.py:111: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
    with codecs.open(geom_file, encoding='utf-8-sig') as f:

mapproxy/test/unit/test_image_mask.py::TestMaskImage::test_mask_outside_of_image_transparent
mapproxy/test/unit/test_image_mask.py::TestMaskImage::test_mask_outside_of_image_bgcolor
mapproxy/test/unit/test_image_mask.py::TestMaskImage::test_mask_partial_image_bgcolor
mapproxy/test/unit/test_image_mask.py::TestMaskImage::test_mask_partial_image_transparent
mapproxy/test/unit/test_image_mask.py::TestMaskImage::test_wkt_mask_partial_image_transparent
mapproxy/test/unit/test_image_mask.py::TestMaskImage::test_shapely_mask_with_transform_partial_image_transparent
mapproxy/test/unit/test_image_mask.py::TestLayerCoverageMerge::test_merge_single_coverage
mapproxy/test/unit/test_image_mask.py::TestLayerCoverageMerge::test_merge_overlapping_coverage
mapproxy/test/unit/test_image_mask.py::TestLayerCoverageMerge::test_merge_overlapping_coverage
  /usr/lib/python3/dist-packages/shapely/decorators.py:173: DeprecationWarning: The 'resolution' argument is deprecated. Use 'quad_segs' instead
    result = func(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED mapproxy/test/unit/test_seed_cachelock.py::TestCacheLock::test_locked_by_process_no_block - _pickle.PicklingError: Can't pickle local object <function TestCacheLock.test_locked_by_process_no_block.<locals>.lock at 0x7fd07b3c50c0>
when serializing dict item '_target'
when serializing multiprocessing.context.Process state
when serializing multiprocessing.context.Process object
FAILED mapproxy/test/unit/test_seed_cachelock.py::TestCacheLock::test_locked_by_process_waiting - _pickle.PicklingError: Can't pickle local object <function TestCacheLock.test_locked_by_process_waiting.<locals>.lock at 0x7fd07b3c5bc0>
when serializing dict item '_target'
when serializing multiprocessing.context.Process state
when serializing multiprocessing.context.Process object
= 2 failed, 770 passed, 293 skipped, 5 xfailed, 2 xpassed, 104 warnings in 11.69s =
```
These two tests succeed with Python 3.13.

Related change:
> On Unix platforms other than macOS, [‘forkserver’](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-method-forkserver) is now the default [start method](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods) (replacing [‘fork’](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-method-fork)). This change does not affect Windows or macOS, where [‘spawn’](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-method-spawn) remains the default start method.
>
> If the threading incompatible fork method is required, you must explicitly request it via a context from [`get_context()`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_context) (preferred) or change the default via [`set_start_method()`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method).
>
> See [forkserver restrictions](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming-forkserver) for information and differences with the fork method and how this change may affect existing code with mutable global shared variables and/or shared objects that can not be automatically [`pickled`](https://docs.python.org/3/library/pickle.html#module-pickle).

https://docs.python.org/3/whatsnew/3.14.html#multiprocessing