### PR TITLE
Use multiprocessing.get_context() instead of multiprocessing.set_start_method().

### DIFF
--- a/mapproxy/test/conftest.py
+++ b/mapproxy/test/conftest.py
@@ -1,8 +1,3 @@
-import multiprocessing
-
-import pytest
-
-
 def pytest_configure(config):
     import sys
     sys._called_from_pytest = True
@@ -11,14 +6,3 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     import sys
     del sys._called_from_pytest
-
-
-@pytest.fixture(scope="session", autouse=True)
-def use_multiprocessing_fork_on_linux():
-    import sys
-    if sys.platform != "linux":
-        # Windows and macOS use 'spawn' by default
-        return
-
-    # 'forkserver' is default since Python 3.14, but can't pickle everything.
-    multiprocessing.set_start_method("fork")

--- a/mapproxy/test/unit/test_seed_cachelock.py
+++ b/mapproxy/test/unit/test_seed_cachelock.py
@@ -36,7 +36,9 @@ class TestCacheLock(object):
             assert True
 
     def test_locked_by_process_no_block(self, lock_file):
-        proc_is_locked = multiprocessing.Event()
+        ctx = multiprocessing.get_context('fork')
+
+        proc_is_locked = ctx.Event()
 
         def lock():
             locker = CacheLocker(lock_file)
@@ -44,7 +46,7 @@ class TestCacheLock(object):
                 proc_is_locked.set()
                 time.sleep(10)
 
-        p = multiprocessing.Process(target=lock)
+        p = ctx.Process(target=lock)
         p.start()
         # wait for process to start
         proc_is_locked.wait()
@@ -66,7 +68,9 @@ class TestCacheLock(object):
             p.join()
 
     def test_locked_by_process_waiting(self, lock_file):
-        proc_is_locked = multiprocessing.Event()
+        ctx = multiprocessing.get_context('fork')
+
+        proc_is_locked = ctx.Event()
 
         def lock():
             locker = CacheLocker(lock_file)
@@ -74,7 +78,7 @@ class TestCacheLock(object):
                 proc_is_locked.set()
                 time.sleep(.1)
 
-        p = multiprocessing.Process(target=lock)
+        p = ctx.Process(target=lock)
         start_time = time.time()
         p.start()
         # wait for process to start


### PR DESCRIPTION
Follow-up to #1355.

Instead of globally reverting back to the `fork` start method, use `multiprocessing.get_context()` in the tests that need it.