### PR TITLE
Type get map

### DIFF
--- a/mapproxy/cache/renderd.py
+++ b/mapproxy/cache/renderd.py
@@ -33,7 +33,7 @@ def has_renderd_support():
 
 class RenderdTileCreator(TileCreator):
     def __init__(self, renderd_address, tile_mgr, dimensions=None, priority=100, tile_locker=None):
-        TileCreator.__init__(self, tile_mgr, dimensions)
+        super().__init__(tile_mgr, dimensions)
         self.tile_locker = tile_locker.lock or self.tile_mgr.lock
         self.renderd_address = renderd_address
         self.priority = priority

--- a/mapproxy/client/http.py
+++ b/mapproxy/client/http.py
@@ -37,7 +37,7 @@ import ssl
 
 class HTTPClientError(Exception):
     def __init__(self, arg, response_code=None, full_msg=None):
-        Exception.__init__(self, arg)
+        super().__init__(arg)
         self.response_code = response_code
         self.full_msg = full_msg
 
@@ -57,7 +57,7 @@ def build_https_handler(ssl_ca_certs, insecure):
 class VerifiedHTTPSConnection(httplib.HTTPSConnection):
     def __init__(self, *args, **kw):
         self._ca_certs = kw.pop('ca_certs', None)
-        httplib.HTTPSConnection.__init__(self, *args, **kw)
+        super().__init__(*args, **kw)
 
     def connect(self):
         # overrides the version in httplib so that we do
@@ -99,7 +99,7 @@ def verified_https_connection_with_ca_certs(ca_certs):
 class VerifiedHTTPSHandler(urllib2.HTTPSHandler):
     def __init__(self, connection_class=VerifiedHTTPSConnection):
         self.specialized_conn_class = connection_class
-        urllib2.HTTPSHandler.__init__(self)
+        super().__init__()
 
     def https_open(self, req):
         return self.do_open(self.specialized_conn_class, req)

--- a/mapproxy/config/configuration/global_conf.py
+++ b/mapproxy/config/configuration/global_conf.py
@@ -26,7 +26,7 @@ def preferred_srs(conf):
 
 class GlobalConfiguration(ConfigurationBase):
     def __init__(self, conf_base_dir, conf, context):
-        ConfigurationBase.__init__(self, conf, context)
+        super().__init__(conf, context)
         self.base_config = load_default_config()
         self._copy_conf_values(self.conf, self.base_config)
         self.base_config.conf_base_dir = conf_base_dir

--- a/mapproxy/config/configuration/image_options.py
+++ b/mapproxy/config/configuration/image_options.py
@@ -11,7 +11,7 @@ default_image_options: dict = {
 
 class ImageOptionsConfiguration(ConfigurationBase):
     def __init__(self, conf, context):
-        ConfigurationBase.__init__(self, conf, context)
+        super().__init__(conf, context)
         self._init_formats()
 
     def _init_formats(self):

--- a/mapproxy/config/configuration/proxy.py
+++ b/mapproxy/config/configuration/proxy.py
@@ -15,6 +15,8 @@ from mapproxy.config.configuration.grid import GridConfiguration
 
 
 class ProxyConfiguration(object):
+    wms_root_layer: WMSLayerConfiguration
+
     def __init__(self, conf, conf_base_dir=None, seed=False, renderd=False):
         self.configuration = conf
         self.seed = seed

--- a/mapproxy/config/configuration/service.py
+++ b/mapproxy/config/configuration/service.py
@@ -43,7 +43,7 @@ class ServiceConfiguration(ConfigurationBase):
             if 'md' not in conf['wms']:
                 conf['wms']['md'] = {'title': 'MapProxy WMS'}
 
-        ConfigurationBase.__init__(self, conf, context)
+        super().__init__(conf, context)
 
     def services(self):
         services = []

--- a/mapproxy/config/configuration/source.py
+++ b/mapproxy/config/configuration/source.py
@@ -167,7 +167,7 @@ class ArcGISSourceConfiguration(SourceConfiguration):
     source_type = ('arcgis',)
 
     def __init__(self, conf, context):
-        SourceConfiguration.__init__(self, conf, context)
+        super().__init__(conf, context)
 
     def source(self, params=None):
         from mapproxy.client.arcgis import ArcGISClient
@@ -451,7 +451,7 @@ class MapServerSourceConfiguration(WMSSourceConfiguration):
     source_type = ('mapserver',)
 
     def __init__(self, conf, context):
-        WMSSourceConfiguration.__init__(self, conf, context)
+        super().__init__(conf, context)
         self.script = self.context.globals.get_path('mapserver.binary',
                                                     self.conf)
         if not self.script:

--- a/mapproxy/exception.py
+++ b/mapproxy/exception.py
@@ -34,7 +34,7 @@ class RequestError(Exception):
     """
 
     def __init__(self, message, code=None, request=None, internal=False, status=None, locator=None):
-        Exception.__init__(self, message)
+        super().__init__(message)
         self.msg = message
         self.code = code
         self.request = request

--- a/mapproxy/extent.py
+++ b/mapproxy/extent.py
@@ -130,7 +130,7 @@ class DefaultMapExtent(MapExtent):
     is_default = True
 
     def __init__(self):
-        MapExtent.__init__(self, (-180, -90, 180, 90), SRS(4326))
+        super().__init__((-180, -90, 180, 90), SRS(4326))
 
 
 def merge_layer_extents(layers) -> MapExtent:

--- a/mapproxy/grid/tile_grid.py
+++ b/mapproxy/grid/tile_grid.py
@@ -22,7 +22,7 @@ class NamedGridList(ImmutableDictList):
             else:
                 name = str('%02d' % i)
             tmp.append((name, value))
-        ImmutableDictList.__init__(self, tmp)
+        super().__init__(tmp)
 
 
 def tile_grid_for_epsg(epsg, bbox=None, tile_size=(256, 256), res=None):
@@ -89,7 +89,7 @@ def tile_grid(srs=None, bbox=None, bbox_srs=None, tile_size=(256, 256),
 
 class UnsupportedException(Exception):
     def __init__(self, arg):
-        Exception.__init__(self, arg)
+        super().__init__(arg)
 
 
 def tile_grid_from_ogc_tile_matrix_set(ogc_tile_matrix_set):

--- a/mapproxy/image/message.py
+++ b/mapproxy/image/message.py
@@ -169,7 +169,7 @@ class ExceptionImage(MessageImage):
     font_size = 9
 
     def __init__(self, message, image_opts):
-        MessageImage.__init__(self, message, image_opts=image_opts.copy())
+        super().__init__(message, image_opts=image_opts.copy())
         if not self.image_opts.bgcolor:
             self.image_opts.bgcolor = '#ffffff'
 
@@ -194,7 +194,7 @@ class WatermarkImage(MessageImage):
     font_color = (128, 128, 128)
 
     def __init__(self, message, image_opts, placement='c', opacity=None, font_color=None, font_size=None):
-        MessageImage.__init__(self, message, image_opts=image_opts)
+        super().__init__(message, image_opts=image_opts)
         if opacity is None:
             opacity = 30
         if font_size:
@@ -226,7 +226,7 @@ class AttributionImage(MessageImage):
     placement = 'lr'
 
     def __init__(self, message, image_opts, inverse=False):
-        MessageImage.__init__(self, message, image_opts=image_opts)
+        super().__init__(message, image_opts=image_opts)
         self.inverse = inverse
 
     @property

--- a/mapproxy/layer/__init__.py
+++ b/mapproxy/layer/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import division
 
 from functools import reduce
+from typing import Protocol, Optional, Sequence
 
-from mapproxy.grid.resolutions import merge_resolution_range
+from mapproxy.grid.resolutions import merge_resolution_range, ResolutionRange
 
 
-class BlankImage(Exception):
+class BlankImageError(Exception):
     pass
 
 
@@ -28,14 +29,20 @@ class Dimension(list):
         if not default and values:
             default = values[0]
         self.default = default
-        list.__init__(self, values)
+        super().__init__(values)
 
 
-def merge_layer_res_ranges(layers):
+class WithResRange(Protocol):
+    @property
+    def res_range(self) -> Optional[ResolutionRange]:
+        pass
+
+
+def merge_layer_res_ranges(layers: Sequence[WithResRange]) -> Optional[ResolutionRange]:
     ranges = [s.res_range for s in layers
               if hasattr(s, 'res_range')]
 
-    if ranges:
-        ranges = reduce(merge_resolution_range, ranges)
+    if not ranges:
+        return None
 
-    return ranges
+    return reduce(merge_resolution_range, ranges)

--- a/mapproxy/layer/cache_map_layer.py
+++ b/mapproxy/layer/cache_map_layer.py
@@ -2,9 +2,9 @@ from __future__ import division
 
 from mapproxy.extent import map_extent_from_grid, MapExtent
 from mapproxy.grid import NoTiles, GridError
-from mapproxy.image import bbox_position_in_image, sub_image_source
+from mapproxy.image import bbox_position_in_image, sub_image_source, BaseImageSource
 from mapproxy.image.tile import TiledImage
-from mapproxy.layer import merge_layer_res_ranges, BlankImage, MapError, MapBBOXError
+from mapproxy.layer import merge_layer_res_ranges, BlankImageError, MapError, MapBBOXError
 from mapproxy.layer.map_layer import MapLayer
 from mapproxy.proj import ProjError
 from mapproxy.query import MapQuery
@@ -16,7 +16,7 @@ class CacheMapLayer(MapLayer):
 
     def __init__(self, tile_manager, extent=None, image_opts=None,
                  max_tile_limit=None):
-        MapLayer.__init__(self, image_opts=image_opts)
+        super().__init__(image_opts=image_opts)
         self.tile_manager = tile_manager
         self.grid = tile_manager.grid
         self.extent = extent or map_extent_from_grid(self.grid)
@@ -25,7 +25,7 @@ class CacheMapLayer(MapLayer):
             self.res_range = merge_layer_res_ranges(self.tile_manager.sources)
         self.max_tile_limit = max_tile_limit
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         self.check_res_range(query)
 
         if query.tiled_only:
@@ -34,10 +34,10 @@ class CacheMapLayer(MapLayer):
         query_extent = MapExtent(query.bbox, query.srs)
         if not query.tiled_only and self.extent and not self.extent.contains(query_extent):
             if not self.extent.intersects(query_extent):
-                raise BlankImage()
+                raise BlankImageError()
             size, offset, bbox = bbox_position_in_image(query.bbox, query.size, self.extent.bbox_for(query.srs))
             if size[0] == 0 or size[1] == 0:
-                raise BlankImage()
+                raise BlankImageError()
             src_query = MapQuery(bbox, size, query.srs, query.format, dimensions=query.dimensions)
             resp = self._image(src_query)
             result = sub_image_source(resp, size=query.size, offset=offset, image_opts=self.image_opts,
@@ -52,13 +52,13 @@ class CacheMapLayer(MapLayer):
         if query.size != self.grid.tile_size:
             raise MapError("invalid tile size (use %dx%d)" % self.grid.tile_size)
 
-    def _image(self, query):
+    def _image(self, query: MapQuery) -> BaseImageSource:
         try:
             src_bbox, tile_grid, affected_tile_coords = \
                 self.grid.get_affected_tiles(query.bbox, query.size,
                                              req_srs=query.srs)
         except NoTiles:
-            raise BlankImage()
+            raise BlankImageError()
         except GridError as ex:
             raise MapBBOXError(ex.args[0])
 
@@ -80,7 +80,7 @@ class CacheMapLayer(MapLayer):
                 affected_tile_coords, with_metadata=query.tiled_only, dimensions=query.dimensions)
 
         if tile_collection.empty:
-            raise BlankImage()
+            raise BlankImageError()
 
         if query.tiled_only:
             tile = tile_collection[0].source

--- a/mapproxy/layer/direct_map_layer.py
+++ b/mapproxy/layer/direct_map_layer.py
@@ -1,6 +1,8 @@
 from __future__ import division
 
+from mapproxy.image import BaseImageSource
 from mapproxy.layer.map_layer import MapLayer
+from mapproxy.query import MapQuery
 from mapproxy.source.wms import WMSSource
 
 
@@ -8,11 +10,11 @@ class DirectMapLayer(MapLayer):
     supports_meta_tiles = True
 
     def __init__(self, source: WMSSource, extent):
-        MapLayer.__init__(self)
+        super().__init__()
         self.source = source
         self.res_range = getattr(source, 'res_range', None)
         self.extent = extent
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         self.check_res_range(query)
         return self.source.get_map(query)

--- a/mapproxy/layer/limited_layer.py
+++ b/mapproxy/layer/limited_layer.py
@@ -1,5 +1,8 @@
 from __future__ import division
 
+from mapproxy.util.coverage import Coverage
+from mapproxy.layer.map_layer import MapLayer
+
 
 class LimitedLayer:
     """
@@ -7,7 +10,7 @@ class LimitedLayer:
     attributes for geographical limits.
     """
 
-    def __init__(self, layer, coverage):
+    def __init__(self, layer: MapLayer, coverage: Coverage):
         self._layer = layer
         self.coverage = coverage
 

--- a/mapproxy/layer/map_layer.py
+++ b/mapproxy/layer/map_layer.py
@@ -1,16 +1,20 @@
 from __future__ import division
 
+from abc import ABC, abstractmethod
 from typing import Optional
 
-from mapproxy.layer import BlankImage
+from mapproxy.image import BaseImageSource
+from mapproxy.grid.resolutions import ResolutionRange
+from mapproxy.layer import BlankImageError
 from mapproxy.image.opts import ImageOptions
 from mapproxy.util.coverage import Coverage
+from mapproxy.query import MapQuery
 
 
-class MapLayer:
+class MapLayer(ABC):
     supports_meta_tiles = False
 
-    res_range = None
+    res_range: Optional[ResolutionRange] = None
 
     coverage: Optional[Coverage] = None
 
@@ -40,10 +44,11 @@ class MapLayer:
     def check_res_range(self, query):
         if (self.res_range and
                 not self.res_range.contains(query.bbox, query.size, query.srs)):
-            raise BlankImage()
+            raise BlankImageError()
 
-    def get_map(self, query):
-        raise NotImplementedError
+    @abstractmethod
+    def get_map(self, query: MapQuery) -> BaseImageSource:
+        pass
 
     def combined_layer(self, other, query):
         return None

--- a/mapproxy/layer/resolution_conditional.py
+++ b/mapproxy/layer/resolution_conditional.py
@@ -2,8 +2,10 @@ from __future__ import division
 
 import logging
 
+from mapproxy.image import BaseImageSource
 from mapproxy.layer import merge_layer_res_ranges
 from mapproxy.layer.map_layer import MapLayer
+from mapproxy.query import MapQuery
 
 log = logging.getLogger(__name__)
 
@@ -12,7 +14,7 @@ class ResolutionConditional(MapLayer):
     supports_meta_tiles = True
 
     def __init__(self, one, two, resolution, srs, extent, opacity=None):
-        MapLayer.__init__(self)
+        super().__init__()
         self.one = one
         self.two = two
         self.res_range = merge_layer_res_ranges([one, two])
@@ -22,7 +24,7 @@ class ResolutionConditional(MapLayer):
         self.opacity = opacity
         self.extent = extent
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         self.check_res_range(query)
         bbox = query.bbox
         if query.srs != self.srs:

--- a/mapproxy/layer/srs_conditional.py
+++ b/mapproxy/layer/srs_conditional.py
@@ -1,16 +1,19 @@
 from __future__ import division
 
+from mapproxy.image import BaseImageSource
+from mapproxy.extent import MapExtent
 from mapproxy.layer import merge_layer_res_ranges
 from mapproxy.layer.map_layer import MapLayer
-from mapproxy.srs import SupportedSRS
+from mapproxy.srs import SupportedSRS, _SRS
+from mapproxy.query import MapQuery
 
 
 class SRSConditional(MapLayer):
     supports_meta_tiles = True
 
-    def __init__(self, layers, extent, opacity=None, preferred_srs=None):
-        MapLayer.__init__(self)
-        self.srs_map = {}
+    def __init__(self, layers: list[tuple[MapLayer, _SRS]], extent: MapExtent, opacity=None, preferred_srs=None):
+        super().__init__()
+        self.srs_map: dict[_SRS, MapLayer] = {}
         self.res_range = merge_layer_res_ranges([x[0] for x in layers])
 
         supported_srs = []
@@ -21,11 +24,11 @@ class SRSConditional(MapLayer):
         self.extent = extent
         self.opacity = opacity
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         self.check_res_range(query)
         layer = self._select_layer(query.srs)
         return layer.get_map(query)
 
-    def _select_layer(self, query_srs):
+    def _select_layer(self, query_srs: _SRS) -> MapLayer:
         srs = self.supported_srs.best_srs(query_srs)
         return self.srs_map[srs]

--- a/mapproxy/request/arcgis.py
+++ b/mapproxy/request/arcgis.py
@@ -175,7 +175,7 @@ class ArcGISRequest(BaseRequest):
     fixed_params = {"f": "image"}
 
     def __init__(self, param=None, url='', validate=False, http=None):
-        BaseRequest.__init__(self, param, url, validate, http)
+        super().__init__(param, url, validate, http)
 
         self.url = rest_endpoint(url)
 
@@ -195,7 +195,7 @@ class ArcGISIdentifyRequest(BaseRequest):
     fixed_params = {'geometryType': 'esriGeometryPoint'}
 
     def __init__(self, param=None, url='', validate=False, http=None):
-        BaseRequest.__init__(self, param, url, validate, http)
+        super().__init__(param, url, validate, http)
 
         self.url = rest_identify_endpoint(url)
 

--- a/mapproxy/request/base.py
+++ b/mapproxy/request/base.py
@@ -55,7 +55,7 @@ class NoCaseMultiDict(dict):
         """A `NoCaseMultiDict` can be constructed from an iterable of
         ``(key, value)`` tuples or a dict.
         """
-        dict.__init__(self, self._gen_dict(mapping))
+        super().__init__(self._gen_dict(mapping))
 
     def update(self, mapping=(), append=False):
         """A `NoCaseMultiDict` can be updated from an iterable of

--- a/mapproxy/request/wms/__init__.py
+++ b/mapproxy/request/wms/__init__.py
@@ -158,7 +158,7 @@ class WMSRequest(BaseRequest):
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
         self.non_strict = non_strict
-        BaseRequest.__init__(self, param=param, url=url, validate=validate, **kw)
+        super().__init__(param=param, url=url, validate=validate, **kw)
         self.adapt_to_111()
 
     def adapt_to_111(self):
@@ -198,8 +198,7 @@ class WMSMapRequest(WMSRequest):
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
         self.dimensions = self._get_dimensions(param)
-        WMSRequest.__init__(self, param=param, url=url, validate=validate,
-                            non_strict=non_strict, **kw)
+        super().__init__(param=param, url=url, validate=validate, non_strict=non_strict, **kw)
 
     def _get_dimensions(self, param):
         if param:
@@ -613,7 +612,7 @@ class WMSCapabilitiesRequest(WMSRequest):
     fixed_params = {}
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
-        WMSRequest.__init__(self, param=param, url=url, validate=validate, **kw)
+        super().__init__(param=param, url=url, validate=validate, **kw)
 
     def adapt_to_111(self):
         pass

--- a/mapproxy/request/wmts.py
+++ b/mapproxy/request/wmts.py
@@ -117,7 +117,7 @@ class WMTSRequest(BaseRequest):
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
         self.non_strict = non_strict
-        BaseRequest.__init__(self, param=param, url=url, validate=validate, **kw)
+        super().__init__(param=param, url=url, validate=validate, **kw)
 
     def validate(self):
         pass
@@ -144,8 +144,7 @@ class WMTS100TileRequest(WMTSRequest):
                       'tilematrix', 'tilerow', 'tilecol', 'format']
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
-        WMTSRequest.__init__(self, param=param, url=url, validate=validate,
-                             non_strict=non_strict, **kw)
+        super().__init__(param=param, url=url, validate=validate, non_strict=non_strict, **kw)
 
     def make_request(self):
         self.layer = self.params.layer
@@ -225,7 +224,7 @@ class WMTS100CapabilitiesRequest(WMTSRequest):
     fixed_params = {}
 
     def __init__(self, param=None, url='', validate=False, non_strict=False, **kw):
-        WMTSRequest.__init__(self, param=param, url=url, validate=validate, **kw)
+        super().__init__(param=param, url=url, validate=validate, **kw)
 
 
 request_mapping = {'featureinfo': WMTS100FeatureInfoRequest,

--- a/mapproxy/seed/config.py
+++ b/mapproxy/seed/config.py
@@ -206,7 +206,7 @@ class ConfigurationBase(object):
 
 class SeedConfiguration(ConfigurationBase):
     def __init__(self, name, conf, seeding_conf):
-        ConfigurationBase.__init__(self, name, conf, seeding_conf)
+        super().__init__(name, conf, seeding_conf)
 
         self.refresh_all = False
         self.refresh_timestamp = None
@@ -254,7 +254,7 @@ class SeedConfiguration(ConfigurationBase):
 
 class CleanupConfiguration(ConfigurationBase):
     def __init__(self, name, conf, seeding_conf):
-        ConfigurationBase.__init__(self, name, conf, seeding_conf)
+        super().__init__(name, conf, seeding_conf)
         self.init_time = time.time()
 
         self.remove_all = False

--- a/mapproxy/seed/seeder.py
+++ b/mapproxy/seed/seeder.py
@@ -128,7 +128,7 @@ class TileWorkerPool(object):
 
 class TileWorker(proc_class):
     def __init__(self, task, tiles_queue, conf):
-        proc_class.__init__(self)
+        super().__init__()
         proc_class.daemon = True
         self.task = task
         self.tile_mgr = task.tile_manager

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -100,7 +100,7 @@ class DemoServer(Server):
 
     def __init__(self, layers, md, tile_layers=None,
                  srs=None, image_formats=None, services=None, restful_template=None, background=None):
-        Server.__init__(self)
+        super().__init__()
         self.layers = layers
         self.tile_layers = tile_layers or {}
         self.md = md

--- a/mapproxy/service/kml.py
+++ b/mapproxy/service/kml.py
@@ -38,7 +38,7 @@ class KMLRequest(TileRequest):
             (?P<y>-?\d+)\.(?P<format>\w+)''', re.VERBOSE)
 
     def __init__(self, request):
-        TileRequest.__init__(self, request)
+        super().__init__(request)
         if self.format == 'kml':
             self.request_handler_name = 'kml'
 
@@ -86,7 +86,7 @@ class KMLServer(Server):
     request_methods = ('map', 'kml')
 
     def __init__(self, layers, md, max_tile_age=None, use_dimension_layers=False):
-        Server.__init__(self)
+        super().__init__()
         self.layers = layers
         self.md = md
         self.max_tile_age = max_tile_age

--- a/mapproxy/service/ogcapi/server.py
+++ b/mapproxy/service/ogcapi/server.py
@@ -53,7 +53,7 @@ def static_filename(name):
 
 class OGCAPIException(Exception):
     def __init__(self, type, detail, status):
-        Exception.__init__(self)
+        super().__init__()
         self.type = type
         self.detail = detail
         self.status = status
@@ -78,7 +78,7 @@ class OGCAPIServer(Server):
         map_srs=None,
         default_dataset_layers=None,
     ):
-        Server.__init__(self)
+        super().__init__()
         self.enable_tiles = enable_tiles
         self.enable_maps = enable_maps
         self.image_formats = image_formats

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -59,7 +59,7 @@ class TileServer(Server):
     root_resource_template_file = 'tms_root_resource.xml'
 
     def __init__(self, layers, md, max_tile_age=None, use_dimension_layers=False, origin=None):
-        Server.__init__(self)
+        super().__init__()
         self.layers = layers
         self.md = md
         self.max_tile_age = max_tile_age

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -47,7 +47,7 @@ class WMTSServer(Server):
     service: Optional[str] = 'wmts'
 
     def __init__(self, layers, md, max_tile_age=None, info_formats=None):
-        Server.__init__(self)
+        super().__init__()
         self.md = md
         self.max_tile_age = max_tile_age
         self.layers, self.matrix_sets = self._matrix_sets(layers)
@@ -241,7 +241,7 @@ class WMTSRestServer(WMTSServer):
     default_info_template = '/{Layer}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}/{I}/{J}.{InfoFormat}'
 
     def __init__(self, layers, md, max_tile_age=None, template=None, fi_template=None, info_formats=None):
-        WMTSServer.__init__(self, layers, md)
+        super().__init__(layers, md)
         self.max_tile_age = max_tile_age
         self.template = template or self.default_template
         self.fi_template = fi_template or self.default_info_template
@@ -310,7 +310,7 @@ class Capabilities(object):
 
 class RestfulCapabilities(Capabilities):
     def __init__(self, server_md, layers, matrix_sets, url_converter, fi_url_converter, info_formats=None):
-        Capabilities.__init__(self, server_md, layers, matrix_sets, info_formats=info_formats)
+        super().__init__(server_md, layers, matrix_sets, info_formats=info_formats)
         self.url_converter = url_converter
         self.fi_url_converter = fi_url_converter
 

--- a/mapproxy/source/__init__.py
+++ b/mapproxy/source/__init__.py
@@ -18,12 +18,14 @@ Map/information sources for layers or tile cache.
 """
 from typing import Optional
 
+from mapproxy.image import BaseImageSource
 from mapproxy.layer.map_layer import MapLayer
-from mapproxy.layer import MapError, MapBBOXError, BlankImage, InfoLayer
+from mapproxy.layer import MapError, MapBBOXError, BlankImageError, InfoLayer
 from mapproxy.extent import MapExtent, DefaultMapExtent
 from mapproxy.image.message import message_image
 from mapproxy.image.opts import ImageOptions
 from mapproxy.srs import SRS
+from mapproxy.query import MapQuery
 from mapproxy.util.coverage import Coverage
 
 
@@ -51,11 +53,11 @@ class LegendSource(object):
 
 class DebugSource(MapLayer):
     def __init__(self):
-        MapLayer.__init__(self)
+        super().__init__()
         self.extent = DefaultMapExtent()
         self.res_range = None
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         bbox = query.bbox
         w = bbox[2] - bbox[0]
         h = bbox[3] - bbox[1]
@@ -76,10 +78,10 @@ class DummySource(MapLayer):
     """
 
     def __init__(self, coverage: Optional[Coverage] = None):
-        MapLayer.__init__(self)
+        super().__init__()
         self.image_opts.transparent = True
         self.extent = MapExtent((-180, -90, 180, 90), SRS(4326))
         self.extent = MapExtent(coverage.bbox, coverage.srs) if coverage else DefaultMapExtent()
 
-    def get_map(self, query):
-        raise BlankImage()
+    def get_map(self, query: MapQuery) -> BaseImageSource:
+        raise BlankImageError()

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -25,14 +25,15 @@ from typing import Optional
 
 from mapproxy.layer.map_layer import MapLayer
 from mapproxy.grid.tile_grid import tile_grid
-from mapproxy.image import ImageSource
+from mapproxy.image import ImageSource, BaseImageSource
 from mapproxy.image.opts import ImageOptions
-from mapproxy.layer import BlankImage
+from mapproxy.layer import BlankImageError
 from mapproxy.extent import MapExtent, DefaultMapExtent
 from mapproxy.source import SourceError
 from mapproxy.client.log import log_request
 from mapproxy.util.py import reraise_exception
 from mapproxy.util.async_ import run_non_blocking
+from mapproxy.query import MapQuery
 from mapproxy.util.coverage import Coverage
 
 try:
@@ -111,12 +112,12 @@ class MapnikSource(MapLayer):
             return _map_objs_lock
         return self._map_objs_lock
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         if self.res_range and not self.res_range.contains(query.bbox, query.size,
                                                           query.srs):
-            raise BlankImage()
+            raise BlankImageError()
         if self.coverage and not self.coverage.intersects(query.bbox, query.srs):
-            raise BlankImage()
+            raise BlankImageError()
 
         try:
             resp = self.render(query)

--- a/mapproxy/source/ogcapimaps.py
+++ b/mapproxy/source/ogcapimaps.py
@@ -20,6 +20,7 @@ import sys
 from threading import Lock
 from typing import Optional
 
+from mapproxy.image import BaseImageSource
 from mapproxy.client.http import HTTPClientError
 from mapproxy.request.base import BaseRequest
 from mapproxy.source import SourceError
@@ -31,10 +32,11 @@ from mapproxy.util.ogcapi import (
     build_absolute_url,
 )
 from mapproxy.util.py import reraise_exception
+from mapproxy.query import MapQuery
+from mapproxy.util.coverage import Coverage
 
 import logging
 
-from mapproxy.util.coverage import Coverage
 
 log = logging.getLogger("mapproxy.source.ogcapimaps")
 
@@ -167,9 +169,9 @@ class OGCAPIMapsSource(WMSLikeSource):
             else:
                 self.supported_srs = SupportedSRS([SRS(crs) for crs in supported_srs])
 
-    def get_map(self, query):
+    def get_map(self, query: MapQuery) -> BaseImageSource:
         self._get_maps_list()
-        return WMSLikeSource.get_map(self, query)
+        return super().get_map(query)
 
     def _retrieve(self, query, format):
         url = self.map_format_to_href[format]

--- a/mapproxy/source/wms.py
+++ b/mapproxy/source/wms.py
@@ -24,7 +24,7 @@ from mapproxy.cache.legend import Legend, legend_identifier
 from mapproxy.image import make_transparent, ImageSource, sub_image_source, bbox_position_in_image
 from mapproxy.image.merge import concat_legends, concat_json_legends
 from mapproxy.image.transform import ImageTransformer
-from mapproxy.layer import BlankImage
+from mapproxy.layer import BlankImageError
 from mapproxy.extent import MapExtent, DefaultMapExtent
 from mapproxy.query import MapQuery, LegendQuery
 from mapproxy.source import InfoSource, SourceError, LegendSource
@@ -66,9 +66,9 @@ class WMSLikeSource(MapLayer):
     def get_map(self, query):
         if self.res_range and not self.res_range.contains(query.bbox, query.size,
                                                           query.srs):
-            raise BlankImage()
+            raise BlankImageError()
         if self.coverage and not self.coverage.intersects(query.bbox, query.srs):
-            raise BlankImage()
+            raise BlankImageError()
         try:
             resp = self._get_map(query)
             if self.transparent_color:
@@ -111,7 +111,7 @@ class WMSLikeSource(MapLayer):
     def _get_sub_query(self, query, format):
         size, offset, bbox = bbox_position_in_image(query.bbox, query.size, self.extent.bbox_for(query.srs))
         if size[0] == 0 or size[1] == 0:
-            raise BlankImage()
+            raise BlankImageError()
         src_query = MapQuery(bbox, size, query.srs, format, dimensions=query.dimensions)
         resp = self._retrieve(src_query, format)
         return sub_image_source(resp, size=query.size, offset=offset, image_opts=self.image_opts)

--- a/mapproxy/test/helper.py
+++ b/mapproxy/test/helper.py
@@ -104,7 +104,7 @@ class TempFiles(object):
 
 class TempFile(TempFiles):
     def __init__(self, suffix='', no_create=False):
-        TempFiles.__init__(self, suffix=suffix, no_create=no_create)
+        super().__init__(suffix=suffix, no_create=no_create)
 
     def __enter__(self):
         return TempFiles.__enter__(self)[0]

--- a/mapproxy/test/http.py
+++ b/mapproxy/test/http.py
@@ -79,7 +79,7 @@ class HTTPServer(HTTPServer_):
 
 class ThreadedStopableHTTPServer(threading.Thread):
     def __init__(self, address, requests_responses, unordered=False, query_comparator=None):
-        threading.Thread.__init__(self, **{'group': None})
+        super().__init__(**{'group': None})
         self.requests_responses = requests_responses
         self.daemon = True
         self.sucess = False
@@ -111,7 +111,7 @@ class ThreadedStopableHTTPServer(threading.Thread):
 
 class ThreadedSingleRequestHTTPServer(threading.Thread):
     def __init__(self, address, request_handler):
-        threading.Thread.__init__(self, **{'group': None})
+        super().__init__(**{'group': None})
         self.daemon = True
         self.sucess = False
         self.shutdown = False

--- a/mapproxy/test/mocker.py
+++ b/mapproxy/test/mocker.py
@@ -187,7 +187,7 @@ class MockerTestCase(unittest.TestCase):
         self.__cleanup_funcs = []
         self.__cleanup_paths = []
 
-        super(MockerTestCase, self).__init__(methodName)
+        super().__init__(methodName)
 
     def __cleanup(self):
         for path in self.__cleanup_paths:
@@ -1189,7 +1189,7 @@ class Mock(object):
 
     def __getattribute__(self, name):
         if name.startswith("__mocker_"):
-            return super(Mock, self).__getattribute__(name)
+            return super().__getattribute__(name)
         if name == "__class__":
             if self.__mocker__.is_recording() or self.__mocker_type__ is None:
                 return type(self)
@@ -1202,7 +1202,7 @@ class Mock(object):
 
     def __setattr__(self, name, value):
         if name.startswith("__mocker_"):
-            return super(Mock, self).__setattr__(name, value)
+            return super().__setattr__(name, value)
         return self.__mocker_act__("setattr", (name, value))
 
     def __delattr__(self, name):
@@ -2134,7 +2134,7 @@ Undefined = Undefined()
 class Patcher(Task):
 
     def __init__(self):
-        super(Patcher, self).__init__()
+        super().__init__()
         self._monitored = {}  # {kind: {id(object): object}}
         self._patched = {}
 

--- a/mapproxy/test/unit/test_auth.py
+++ b/mapproxy/test/unit/test_auth.py
@@ -37,7 +37,7 @@ class DummyLayer(MapLayer):
     queryable = False
 
     def __init__(self, name):
-        MapLayer.__init__(self)
+        super().__init__()
         self.name = name
         self.requested = False
         self.queried = False

--- a/mapproxy/test/unit/test_cache.py
+++ b/mapproxy/test/unit/test_cache.py
@@ -39,7 +39,7 @@ from mapproxy.grid.tile_grid import TileGrid
 from mapproxy.grid.resolutions import resolution_range
 from mapproxy.image import ImageSource, BlankImageSource
 from mapproxy.image.opts import ImageOptions
-from mapproxy.layer import BlankImage, MapBBOXError
+from mapproxy.layer import BlankImageError, MapBBOXError
 from mapproxy.layer.cache_map_layer import CacheMapLayer
 from mapproxy.layer.direct_map_layer import DirectMapLayer
 from mapproxy.layer.map_layer import MapLayer
@@ -121,7 +121,7 @@ class TestTiledSourceGlobalGeodetic(object):
 
 class RecordFileCache(FileCache):
     def __init__(self, *args, **kw):
-        super(RecordFileCache, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self.stored_tiles = set()
         self.loaded_tiles = counting_set([])
         self.is_cached_call_count = 0
@@ -270,7 +270,7 @@ class TestTileManagerDifferentSourceGrid(object):
 
 class MockSource(MapLayer):
     def __init__(self, *args):
-        MapLayer.__init__(self, *args)
+        super().__init__(*args)
         self.requested = []
 
     def _image(self, size):
@@ -536,7 +536,7 @@ class TestTileManagerMultipleSources(object):
 
 class SolidColorMockSource(MockSource):
     def __init__(self, color='#ff0000'):
-        MockSource.__init__(self)
+        super().__init__()
         self.color = color
 
     def _image(self, size):
@@ -666,7 +666,7 @@ class TestTileManagerBulkMetaTilesConcurrent(TestTileManagerBulkMetaTiles):
 
 class ErrorSource(MapLayer):
     def __init__(self, *args):
-        MapLayer.__init__(self, *args)
+        super().__init__(*args)
         self.requested = []
 
     def get_map(self, query):
@@ -732,7 +732,7 @@ class TestCacheMapLayer(object):
                                locker=tile_locker)
         layer = CacheMapLayer(tile_mgr, image_opts=default_image_opts)
 
-        with pytest.raises(BlankImage):
+        with pytest.raises(BlankImageError):
             result = layer.get_map(MapQuery(
                 (-20037508.34, -20037508.34, 20037508.34, 20037508.34), (500, 500),
                 SRS(900913), 'png'))
@@ -763,7 +763,7 @@ class TestCacheMapLayerWithExtent(object):
         return layer
 
     def test_get_outside_extent(self, layer):
-        with pytest.raises(BlankImage):
+        with pytest.raises(BlankImageError):
             layer.get_map(MapQuery((-180, -90, 0, 0), (300, 150), SRS(4326), 'png'))
 
     def test_get_map_small(self, layer, mock_file_cache, mock_wms_client):

--- a/mapproxy/test/unit/test_decorate_img.py
+++ b/mapproxy/test/unit/test_decorate_img.py
@@ -36,7 +36,7 @@ class DummyLayer(MapLayer):
     queryable = False
 
     def __init__(self, name):
-        MapLayer.__init__(self)
+        super().__init__()
         self.name = name
         self.requested = False
         self.queried = False

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -419,7 +419,7 @@ class TestLayerMerge(object):
             image_opts=ImageOptions(opacity=0.5),
         )
 
-        result = merge_images([img1, img2], ImageOptions(transparent=False))
+        result = merge_images([(img1, None), (img2, None)], ImageOptions(transparent=False))
         img = result.as_image()
         assert img.getpixel((0, 0)) == (127, 127, 255)
 
@@ -430,7 +430,7 @@ class TestLayerMerge(object):
             image_opts=ImageOptions(opacity=0.5),
         )
 
-        result = merge_images([img1, img2], ImageOptions(transparent=True))
+        result = merge_images([(img1, None), (img2, None)], ImageOptions(transparent=True))
         img = result.as_image()
         assert_img_colors_eq(img, [(10 * 10, (127, 127, 255, 255))])
 
@@ -439,7 +439,7 @@ class TestLayerMerge(object):
         img2 = ImageSource(Image.new("L", (10, 10), 100))
 
         # img2 overlays img1
-        result = merge_images([img1, img2], ImageOptions(transparent=True))
+        result = merge_images([(img1, None), (img2, None)], ImageOptions(transparent=True))
         img = result.as_image()
         assert_img_colors_eq(img, [(10 * 10, (100, 100, 100, 255))])
 
@@ -464,7 +464,7 @@ class TestLayerMerge(object):
 
         # generate base image and merge the others above
         img3 = ImageSource(Image.new("RGBA", (50, 50), (0, 0, 255, 255)))
-        result = merge_images([img3, img1, img2], ImageOptions(transparent=True))
+        result = merge_images([(img3, None), (img1, None), (img2, None)], ImageOptions(transparent=True))
         img = result.as_image()
 
         assert img.mode == "RGBA"
@@ -475,7 +475,7 @@ class TestLayerMerge(object):
         img1 = ImageSource(Image.new("RGB", (10, 10), (255, 0, 255)))
         img2 = ImageSource(Image.new("RGB", (10, 10), (0, 255, 255)))
 
-        result = merge_images([img1, img2], ImageOptions(transparent=False))
+        result = merge_images([(img1, None), (img2, None)], ImageOptions(transparent=False))
         img = result.as_image()
         assert img.getpixel((0, 0)) == (0, 255, 255)
 
@@ -485,7 +485,7 @@ class TestLayerMerge(object):
         raw.info = {"transparency": (0, 255, 255)}  # make full transparent
         img2 = ImageSource(raw)
 
-        result = merge_images([img1, img2], ImageOptions(transparent=False))
+        result = merge_images([(img1, None), (img2, None)], ImageOptions(transparent=False))
         img = result.as_image()
         assert img.getpixel((0, 0)) == (255, 0, 255)
 
@@ -509,7 +509,7 @@ class TestLayerCompositeMerge(object):
         draw.rectangle((0, 67, 100, 100), fill=(0, 255, 0, 0))
         img2 = ImageSource(img2)
 
-        result = merge_images([img2, img1], ImageOptions(transparent=True))
+        result = merge_images([(img2, None), (img1, None)], ImageOptions(transparent=True))
         img = result.as_image()
         assert img.mode == "RGBA"
         assert_img_colors_eq(
@@ -533,7 +533,7 @@ class TestLayerCompositeMerge(object):
         draw.rectangle((10, 10, 89, 89), fill=(0, 255, 255, 255))
         fg = ImageSource(fg, image_opts=ImageOptions(opacity=0.5))
 
-        result = merge_images([bg, fg], ImageOptions(transparent=True))
+        result = merge_images([(bg, None), (fg, None)], ImageOptions(transparent=True))
         img = result.as_image()
         assert img.mode == "RGBA"
         assert_img_colors_eq(

--- a/mapproxy/test/unit/test_utils.py
+++ b/mapproxy/test/unit/test_utils.py
@@ -58,7 +58,7 @@ class TestFileLock(Mocker):
         class Lock(threading.Thread):
 
             def __init__(self, lock_file):
-                threading.Thread.__init__(self)
+                super().__init__()
                 self.lock_file = lock_file
                 self.lock = FileLock(self.lock_file)
 
@@ -162,7 +162,7 @@ class TestFileLock(Mocker):
         class Lock(threading.Thread):
 
             def __init__(self, lock_file):
-                threading.Thread.__init__(self)
+                super().__init__()
                 self.lock_file = lock_file
                 self.lock = FileLock(self.lock_file, file_permissions=file_permissions)
 

--- a/mapproxy/util/async_.py
+++ b/mapproxy/util/async_.py
@@ -56,7 +56,7 @@ def _result_iter(results, use_result_objects=False):
 
 class ThreadWorker(threading.Thread):
     def __init__(self, task_queue, result_queue):
-        threading.Thread.__init__(self)
+        super().__init__()
         self.task_queue = task_queue
         self.result_queue = result_queue
         self.base_config = base_config()

--- a/mapproxy/util/ext/dictspec/validator.py
+++ b/mapproxy/util/ext/dictspec/validator.py
@@ -56,7 +56,7 @@ def validate(spec, data):
 
 class ValidationError(TypeError):
     def __init__(self, msg, errors=None, informal_only=False):
-        TypeError.__init__(self, msg)
+        super().__init__(msg)
         self.informal_only = informal_only
         self.errors = errors or []
 

--- a/mapproxy/util/ext/serving.py
+++ b/mapproxy/util/ext/serving.py
@@ -272,7 +272,7 @@ def select_ip_version(host, port):
     return socket.AF_INET
 
 
-class BaseWSGIServer(HTTPServer, object):
+class BaseWSGIServer(HTTPServer):
     """Simple single-threaded, single-process WSGI server."""
     multithread = False
     multiprocess = False
@@ -283,7 +283,7 @@ class BaseWSGIServer(HTTPServer, object):
         if handler is None:
             handler = WSGIRequestHandler
         self.address_family = select_ip_version(host, port)
-        HTTPServer.__init__(self, (host, int(port)), handler)
+        super().__init__((host, int(port)), handler)
         self.app = app
         self.passthrough_errors = passthrough_errors
         self.shutdown_signal = False

--- a/mapproxy/util/ext/tempita/__init__.py
+++ b/mapproxy/util/ext/tempita/__init__.py
@@ -55,7 +55,7 @@ class TemplateError(Exception):
     """
 
     def __init__(self, message, position, name=None):
-        Exception.__init__(self, message)
+        super().__init__(message)
         self.position = position
         self.name = name
 

--- a/mapproxy/util/lock.py
+++ b/mapproxy/util/lock.py
@@ -138,8 +138,8 @@ class SemLock(FileLock):
     """
 
     def __init__(self, lock_file, n, timeout=60.0, step=0.01, directory_permissions=None, file_permissions=None):
-        FileLock.__init__(self, lock_file, timeout=timeout, step=step, directory_permissions=directory_permissions,
-                          file_permissions=file_permissions)
+        super().__init__(lock_file, timeout=timeout, step=step, directory_permissions=directory_permissions,
+                         file_permissions=file_permissions)
         self.n = n
 
     def _try_lock(self):


### PR DESCRIPTION
This PR improves the typing for the get_map method.

Also replaces parent super calls with new syntax.

The only functional changes are:
* `merge_images` does not accept inputs without explicit tuples anymore. This only affects calls from the tests where `merge_images` has to be called with coverage explicitly set to `None`.
* it removes a line where image.opacity was set to the layer opacity. This property does not exist on the ImageSource and is not used anywhere in the software as far as I can see.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
