### PR TITLE
feat: improve typing of ImmutableDictList

### DIFF
--- a/mapproxy/cache/geopackage.py
+++ b/mapproxy/cache/geopackage.py
@@ -294,8 +294,8 @@ class GeopackageCache(TileCacheBase):
             db.commit()
 
             tile_size = self.tile_grid.tile_size
-            for grid, resolution, level in zip(self.tile_grid.grid_sizes,
-                                               self.tile_grid.resolutions, range(20)):
+            for grid, resolution, level in zip(self.tile_grid.grid_sizes.values(),
+                                               self.tile_grid.resolutions.values(), range(20)):
                 db.execute("""
                     INSERT OR REPLACE INTO gpkg_tile_matrix (table_name, zoom_level, matrix_width,
                         matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size)

--- a/mapproxy/grid/resolutions.py
+++ b/mapproxy/grid/resolutions.py
@@ -1,5 +1,8 @@
 import math
+from typing import Optional, TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from mapproxy.grid.tile_grid import NamedGridList
 from mapproxy.util.bbox import bbox_size
 
 
@@ -35,16 +38,15 @@ def get_resolution(bbox, size):
 
 
 def aligned_resolutions(
-    min_res=None,
-    max_res=None,
-    res_factor=2.0,
-    num_levels=None,
+    with_resolutions: 'NamedGridList',
+    min_res: Optional[float] = None,
+    max_res: Optional[float] = None,
+    res_factor: float = 2.0,
+    num_levels: Optional[int] = None,
     bbox=None,
-    tile_size=(256, 256),
-    align_with=None,
+    tile_size: tuple[int, int] = (256, 256),
 ):
-    alinged_res = align_with.resolutions
-    res = list(alinged_res)
+    res = list(with_resolutions.values())
 
     if not min_res:
         width = bbox[2] - bbox[0]

--- a/mapproxy/grid/tile_grid.py
+++ b/mapproxy/grid/tile_grid.py
@@ -75,8 +75,7 @@ def tile_grid(srs=None, bbox=None, bbox_srs=None, tile_size=(256, 256),
             raise ValueError("res is not a list, use res_factor for float values")
 
     elif align_with is not None:
-        res = aligned_resolutions(min_res, max_res, res_factor, num_levels, bbox, tile_size,
-                                  align_with)
+        res = aligned_resolutions(align_with.resolutions, min_res, max_res, res_factor, num_levels, bbox, tile_size)
     else:
         res = resolutions(min_res, max_res, res_factor, num_levels, bbox, tile_size)
 
@@ -162,10 +161,8 @@ def tile_grid_from_ogc_tile_matrix_set(ogc_tile_matrix_set):
                     name=ogc_tile_matrix_set["id"])
 
     grids = []
-    idx = 0
-    for name, _ in tilegrid.resolutions.iteritems():
+    for idx, name in enumerate(tilegrid.resolutions.keys()):
         grids.append((name, grid_sizes[idx]))
-        idx += 1
     tilegrid.grid_sizes = NamedGridList(grids)
 
     return tilegrid
@@ -252,7 +249,7 @@ class TileGrid(object):
         width = self.bbox[2] - self.bbox[0]
         height = self.bbox[3] - self.bbox[1]
         grids = []
-        for idx, res in self.resolutions.iteritems():
+        for idx, res in self.resolutions.items():
             x = max(math.ceil(width // res / self.tile_size[0]), 1)
             y = max(math.ceil(height // res / self.tile_size[1]), 1)
             grids.append((idx, (int(x), int(y))))
@@ -275,7 +272,7 @@ class TileGrid(object):
         else:
             return pyramid_res_level(initial_res, factor, levels=self.levels)
 
-    def resolution(self, level):
+    def resolution(self, level: str):
         """
         Returns the resolution of the `level` in units/pixel.
 
@@ -316,7 +313,7 @@ class TileGrid(object):
                 threshold = thresholds.pop()
 
         threshold_result = None
-        for level, l_res in enumerate(self.resolutions):
+        for level, l_res in enumerate(self.resolutions.values()):
             if threshold and prev_l_res > threshold >= l_res:
                 if res > threshold:
                     return level-1
@@ -387,7 +384,7 @@ class TileGrid(object):
         # allow for some rounding errors in the _tiles_bbox calculations
         delta = max(abs(self.bbox[1]), abs(self.bbox[3])) / 1e12
 
-        for level, grid_size in enumerate(self.grid_sizes):
+        for level, grid_size in enumerate(self.grid_sizes.values()):
             level_bbox = self._tiles_bbox([(0, 0, level),
                                            (grid_size[0] - 1, grid_size[1] - 1, level)])
 
@@ -567,7 +564,7 @@ class TileGrid(object):
 
         # check if all level tiles from self align with (affected)
         # tiles from other
-        for self_level, self_level_res in self.resolutions.iteritems():
+        for self_level, self_level_res in self.resolutions.items():
             level_size = (
                 self.grid_sizes[self_level][0] * self.tile_size[0],
                 self.grid_sizes[self_level][1] * self.tile_size[1]

--- a/mapproxy/script/grids.py
+++ b/mapproxy/script/grids.py
@@ -82,8 +82,8 @@ def display_grid(grid_conf, coverage=None):
         print('    Levels: Resolutions, # x * y = total tiles (approx. tiles within coverage)')
     else:
         print('    Levels: Resolutions, # x * y = total tiles')
-    max_digits = max([len("%r" % (res,)) for level, res in enumerate(tile_grid.resolutions)])
-    for level, res in enumerate(tile_grid.resolutions):
+    max_digits = max([len("%r" % (res,)) for level, res in enumerate(tile_grid.resolutions.values())])
+    for level, res in enumerate(tile_grid.resolutions.values()):
         tiles_in_x, tiles_in_y = tile_grid.grid_sizes[level]
         total_tiles = tiles_in_x * tiles_in_y
         spaces = max_digits - len("%r" % (res,)) + 1

--- a/mapproxy/service/wmts.py
+++ b/mapproxy/service/wmts.py
@@ -405,7 +405,7 @@ class TileMatrixSet(object):
         return iter(self.tile_matrices)
 
     def _tile_matrices(self):
-        for level, res in self.grid.resolutions.iteritems():
+        for level, res in self.grid.resolutions.items():
             origin = self.grid.origin_tile(level, 'ul')
             bbox = self.grid.tile_bbox(origin)
             topleft = bbox[0], bbox[3]

--- a/mapproxy/test/unit/test_cache_tile.py
+++ b/mapproxy/test/unit/test_cache_tile.py
@@ -39,7 +39,7 @@ tile_image = create_tmp_image_buf((256, 256), color='blue')
 tile_image2 = create_tmp_image_buf((256, 256), color='red')
 
 
-class TileCacheTestBase(object):
+class TileCacheTestBase:
     always_loads_metadata = False
     uses_utc = False
 
@@ -201,7 +201,7 @@ class TileCacheTestBase(object):
 
     def test_store_tile_already_stored(self):
         # tile object is marked as stored,
-        # check that is is not stored 'again'
+        # check that it is not stored 'again'
         # (used for disable_storage)
         tile = Tile((1234, 589, 12), ImageSource(BytesIO(b'foo')))
         tile.stored = True

--- a/mapproxy/test/unit/test_collections.py
+++ b/mapproxy/test/unit/test_collections.py
@@ -103,12 +103,49 @@ class TestImmutableDictList(object):
         assert res['three'] == 3
         assert len(res) == 3
 
-    def test_named_iteritems(self):
+    def test_values(self):
         res = ImmutableDictList([('one', 10), ('two', 5), ('three', 3)])
-        itr = res.iteritems()
+        itr = iter(res.values())
+        assert next(itr) == 10
+        assert next(itr) == 5
+        assert next(itr) == 3
+        try:
+            next(itr)
+        except StopIteration:
+            pass
+        else:
+            assert False, 'StopIteration expected'
+
+    def test_named_items(self):
+        res = ImmutableDictList([('one', 10), ('two', 5), ('three', 3)])
+        itr = iter(res.items())
         assert next(itr) == ('one', 10)
         assert next(itr) == ('two', 5)
         assert next(itr) == ('three', 3)
+        try:
+            next(itr)
+        except StopIteration:
+            pass
+        else:
+            assert False, 'StopIteration expected'
+
+    def test_enumerate(self):
+        res = ImmutableDictList([('one', 10), ('two', 5), ('three', 3)])
+        itr = enumerate(res)
+        assert next(itr) == (0, 'one')
+        assert next(itr) == (1, 'two')
+        assert next(itr) == (2, 'three')
+        try:
+            next(itr)
+        except StopIteration:
+            pass
+        else:
+            assert False, 'StopIteration expected'
+
+        itr = enumerate(res.values())
+        assert next(itr) == (0, 10)
+        assert next(itr) == (1, 5)
+        assert next(itr) == (2, 3)
         try:
             next(itr)
         except StopIteration:


### PR DESCRIPTION
This PR aims at making the ImmutableDictList and NamedGridList more typesafe.

This is done mainly by making ImmutableDictList a generic that inherits from Mapping:

```python
class ImmutableDictList(Mapping[Hashable, V], Generic[V]):
  ...
```

Inheriting from Mapping changed the behavior for iterating the ImmutableDictList. For mappings it is default that the standard iterator yields keys, the ImmutableDictList yielded the values. So every time a standard iterator was used (for example in enumerate), the `.values()` function needs to be used now.

Also `.iteritems` was removed in favor of the standard `.items` method.

`__str__` was replaced by `__repr__`.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
