### PR TITLE
Collections no case multi dict

### DIFF
--- a/mapproxy/request/no_case_multi_dict.py
+++ b/mapproxy/request/no_case_multi_dict.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Iterable, Optional, Callable, Iterator, MutableMapping
+from typing import TypeVar, Generic, Iterable, Iterator, MutableMapping
 
 V = TypeVar("V")
 T = TypeVar("T")
@@ -25,10 +25,11 @@ class NoCaseMultiDict(MutableMapping[str, V], Generic[V]):
     def _key(self, key: str) -> str:
         return key.lower()
 
-    def update_multi(self, mapping: Iterable[tuple[str, V]] | dict[str, V] | "NoCaseMultiDict[V]", append: bool = False) -> None:
+    def update_multi(self, mapping: Iterable[tuple[str, V]] | dict[str, V] | "NoCaseMultiDict[V]",
+                     append: bool = False) -> None:
         if isinstance(mapping, NoCaseMultiDict):
-            for key, value in mapping.items_multi():
-                self.set(key, value, append=append)
+            for key, values in mapping.items_multi():
+                self.set(key, values, append=append, unpack=True)
         elif isinstance(mapping, dict):
             for key2, value2 in mapping.items():
                 self.set(key2, value2, append=append)
@@ -61,16 +62,6 @@ class NoCaseMultiDict(MutableMapping[str, V], Generic[V]):
     def __setstate__(self, state: Iterable[tuple[str, V]]) -> None:
         self._data = {}
         self.update_multi(state)
-
-    def get_typed(self, key: str, default: Optional[T] = None, type_func: Optional[Callable[[V], T]] = None) -> Optional[V | T]:
-        try:
-            value = self[key]
-            if type_func:
-                return type_func(value)
-            else:
-                return value
-        except (KeyError, ValueError):
-            return default
 
     def get_all(self, key: str) -> list[V]:
         return self._data.get(self._key(key), ("", []))[1]

--- a/mapproxy/test/unit/test_request.py
+++ b/mapproxy/test/unit/test_request.py
@@ -70,7 +70,7 @@ class TestNoCaseMultiDict(object):
         data = [("LAYERS", "foo,bar"), ("laYERs", "baz"), ("crs", "EPSG:4326")]
         nc_dict = NoCaseMultiDict(data)
 
-        for key, values in nc_dict.items():
+        for key, values in nc_dict.items_multi():
             if key in ("LAYERS", "laYERs"):
                 assert values == ["foo,bar", "baz"]
             elif key == "crs":
@@ -98,7 +98,7 @@ class TestNoCaseMultiDict(object):
         assert nc_dict.get("bar") is None
         assert nc_dict.get("bar", "default_bar") == "default_bar"
         assert nc_dict.get("num") == "42"
-        assert nc_dict.get_typed("num", type_func=int) == 42
+        assert int(nc_dict.get("num")) == 42
         assert nc_dict.get("foo") == "bar"
 
     def test_get_all(self):
@@ -543,7 +543,7 @@ class TestWMSMapRequestParams(object):
 
     def test_get(self):
         assert self.m.get("LAYERS") == "bar"
-        assert self.m.get("width", type_func=int) == 100
+        assert int(self.m.get("width")) == 100
 
     def test_set(self):
         self.m.set("Layers", "baz", append=True)


### PR DESCRIPTION
NoCaseMultiDict:

Dictionary with case-insensitive keys and support for multiple values per key. The first inserted key spelling is preserved.

inherit from `MutableMapping[str, V], Generic[V]` to make it more typesafe - but why not `MutableMapping[str, list[V]]?

Because `__getitem__` (`[]` access) returns just the first value!

The special method `get_all` is used to get all values for one key.

Inheriting from `MutableMapping[str, V], Generic[V]` breaks the signature of the custom `update` method so a new `update_multi` method is introduced.

It als breaks the signature of `iteritems` (becoming `items`), in the old version it yielded `(str, list[V])`, but with `Mapping[str, V]` it is only allowed to yield `(str, V)`. So a new `items_multi` method is introduced.

Overall this changes make the standard API behave more consistent (signatures of `__getitem__`, `update` and `items` fit together).

Also the `type_func` for the `get` method is also breaking the api. As it is very easy to replace `ncmd.get('x', type_func=int)` with `int(ncmd.get('x'))`, I just did that.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
