### PR TITLE
feat: improve typing of RequestParams

### DIFF
--- a/mapproxy/config/config.py
+++ b/mapproxy/config/config.py
@@ -51,9 +51,7 @@ class Options(dict):
 
     def update(self, other=None, **kw):
         if other is not None:
-            if hasattr(other, 'iteritems'):
-                it = other.iteritems()
-            elif hasattr(other, 'items'):
+            if hasattr(other, 'items'):
                 it = other.items()
             else:
                 it = iter(other)

--- a/mapproxy/config/configuration/global_conf.py
+++ b/mapproxy/config/configuration/global_conf.py
@@ -40,7 +40,7 @@ class GlobalConfiguration(ConfigurationBase):
         for k, v in d.items():
             if v is None:
                 continue
-            if (hasattr(v, 'iteritems') or hasattr(v, 'items')) and k in target:
+            if hasattr(v, 'items') and k in target:
                 self._copy_conf_values(v, target[k])
             else:
                 target[k] = v

--- a/mapproxy/request/wms/__init__.py
+++ b/mapproxy/request/wms/__init__.py
@@ -206,7 +206,7 @@ class WMSMapRequest(WMSRequest):
                                   "^(%s)$" % "|".join(self.dimension_params))
             keys = []
             if isinstance(param, RequestParams):
-                keys = list(map(lambda k: k[0], param.iteritems()))
+                keys = list(map(lambda k: k[0], param.items()))
             else:
                 keys = list(param.keys())
             if len(keys) > 0:

--- a/mapproxy/request/wmts.py
+++ b/mapproxy/request/wmts.py
@@ -99,7 +99,7 @@ class WMTSTileRequestParams(RequestParams):
         expected_param = set(['version', 'request', 'layer', 'style', 'tilematrixset',
                               'tilematrix', 'tilerow', 'tilecol', 'format', 'service'])
         dimensions = {}
-        for key, value in self.iteritems():
+        for key, value in self.items():
             if key not in expected_param:
                 dimensions[key.lower()] = value
         return dimensions

--- a/mapproxy/util/ext/local.py
+++ b/mapproxy/util/ext/local.py
@@ -72,7 +72,7 @@ class Local(object):
         object.__setattr__(self, '__ident_func__', get_ident)
 
     def __iter__(self):
-        return self.__storage__.iteritems()
+        return self.__storage__.items()
 
     def __call__(self, proxy):
         """Create a proxy for a name."""

--- a/mapproxy/util/ext/tempita/__init__.py
+++ b/mapproxy/util/ext/tempita/__init__.py
@@ -450,7 +450,7 @@ def url(v):
 
 
 def attr(**kw):
-    kw = list(kw.iteritems())
+    kw = list(kw.items())
     kw.sort()
     parts = []
     for name, value in kw:


### PR DESCRIPTION
This makes the `RequestParams` a `Generic[V]` using a `NoCaseMultiDict[V]`.

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
