### PR TITLE
catch sqlite3.DatabaseErrors for all cursor actions

### DIFF
--- a/mapproxy/cache/mbtiles.py
+++ b/mapproxy/cache/mbtiles.py
@@ -316,12 +316,13 @@ class MBTilesCache(TileCacheBase):
             except sqlite3.DatabaseError as ex:
                 log.warning('unable to remove level tiles before from %s: %s' % (self.mbtile_file, ex))
                 return False
-            
+
         if self.supports_timestamp:
             try:
                 cursor = self.db.cursor()
                 cursor.execute(
-                    "DELETE FROM tiles WHERE (zoom_level = ? AND last_modified < datetime(?, 'unixepoch', 'localtime'))",
+                    '''DELETE FROM tiles WHERE
+                    (zoom_level = ? AND last_modified < datetime(?, 'unixepoch', 'localtime'))''',
                     (level, timestamp))
                 self.db.commit()
                 if cursor.rowcount:


### PR DESCRIPTION
we are facing situations in our environment where we sometimes get temporary sqlite3.DatabaseError like:

File "/usr/local/lib/python3.9/site-packages/mapproxy/cache/mbtiles.py", line 259, in load_tiles
cursor.execute(stmt, cur_coords)
sqlite3.DatabaseError: database disk image is malformed

or even sqlite3.OperationalError in load_tiles

File "/usr/local/lib/python3.9/site-packages/mapproxy/cache/mbtiles.py", line 259, in load_tiles
cursor.execute(stmt, cur_coords)
sqlite3.OperationalError: no such table: tiles

till now the only method where an sqlite3.OperationalError was catched was _store_bulk

these exceptions sometimes killed all our concurrent subprocesses of a nightly seeding and we see this errors too in our service log where wsgi subprocessed than were killed

so we decided to catch the more general sqlite3.DatabaseError in all methods with cursor actions. this prevents our nightly seedings from beeing stopped too early
