### PR TITLE
use environment variables in yaml-files for storing sensitve data

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -160,6 +160,58 @@ There are other optional sections:
   .. versionchanged:: 1.16.0
     Improved support of splat configuration files
 
+.. index:: environment variables
+   single: environment variables
+
+Environment Variables
+"""""""""""""""""""""
+
+You can use environment variables in all MapProxy YAML configuration files (e.g ``mapproxy.yaml``, ``seed.yaml``, etc.).
+MapProxy supports two syntaxes for referencing environment variables:
+
+- ``$VARIABLE_NAME``
+- ``${VARIABLE_NAME}``
+
+Environment variables are expanded in all string values throughout the entire configuration, including nested structures such as lists and dictionaries. Non-string values (numbers, booleans, etc.) are not affected.
+
+If a referenced environment variable is **not set**, the original placeholder (e.g. ``$VARIABLE_NAME`` or ``${VARIABLE_NAME}``) is kept unchanged. This acts as a safe fallback.
+
+For example, given the following environment variables:
+
+.. code-block:: bash
+
+  export DB_HOST=mydbserver.example.com
+  export CACHE_DIR=/var/cache/mapproxy
+  export WMS_URL=http://wms.example.com/service
+
+You can reference them in your ``mapproxy.yaml``:
+
+.. code-block:: yaml
+
+  globals:
+    cache:
+      base_dir: ${CACHE_DIR}
+
+  sources:
+    my_wms:
+      type: wms
+      req:
+        url: $WMS_URL
+        layers: my_layer
+
+  caches:
+    my_cache:
+      grids: [GLOBAL_MERCATOR]
+      sources: [my_wms]
+      cache:
+        type: sqlite
+        directory: ${CACHE_DIR}/tiles
+
+Both ``$WMS_URL`` and ``${WMS_URL}`` are equivalent. The braced syntax ``${...}`` is useful when the variable is directly followed by other characters, e.g. ``${CACHE_DIR}/tiles``.
+
+.. note::
+  Environment variables are resolved at configuration load time. Changes to environment variables after MapProxy has started require a restart to take effect.
+
 .. #################################################################################
 
 .. index:: services

--- a/mapproxy/config_template/base_config/mapproxy.yaml
+++ b/mapproxy/config_template/base_config/mapproxy.yaml
@@ -50,8 +50,8 @@ sources:
   osm_wms:
     type: wms
     req:
-      url: http://example.org/service?
-      layers: osm
+      url: http://${server}/service?
+      layers: $layer
 
 grids:
     webmercator:

--- a/mapproxy/test/unit/test_yaml.py
+++ b/mapproxy/test/unit/test_yaml.py
@@ -16,7 +16,7 @@
 import os
 import tempfile
 
-from mapproxy.util.yaml import load_yaml, load_yaml_file, YAMLError
+from mapproxy.util.yaml import load_yaml, load_yaml_file, YAMLError, replace_env_vars, expand_env
 
 
 class TestLoadYAMLFile(object):
@@ -66,3 +66,126 @@ class TestLoadYAMLFile(object):
             assert "not a YAML dict" in str(ex)
         else:
             assert False, "expected YAMLError"
+
+
+class TestReplaceEnvVars:
+    """Tests for replace_env_vars: substitutes $VAR and ${VAR} with environment variables."""
+
+    def test_simple_var(self, monkeypatch):
+        monkeypatch.setenv("MY_VAR", "hello")
+        assert replace_env_vars("$MY_VAR") == "hello"
+
+    def test_braced_var(self, monkeypatch):
+        monkeypatch.setenv("MY_VAR", "hello")
+        assert replace_env_vars("${MY_VAR}") == "hello"
+
+    def test_var_embedded_in_string(self, monkeypatch):
+        monkeypatch.setenv("HOST", "localhost")
+        monkeypatch.setenv("PORT", "5432")
+        assert replace_env_vars("http://$HOST:${PORT}/path") == "http://localhost:5432/path"
+
+    def test_unknown_var_stays_unchanged(self, monkeypatch):
+        monkeypatch.delenv("UNKNOWN_VAR_XYZ", raising=False)
+        assert replace_env_vars("$UNKNOWN_VAR_XYZ") == "$UNKNOWN_VAR_XYZ"
+        assert replace_env_vars("${UNKNOWN_VAR_XYZ}") == "${UNKNOWN_VAR_XYZ}"
+
+    def test_mixed_known_and_unknown(self, monkeypatch):
+        monkeypatch.setenv("KNOWN", "value")
+        monkeypatch.delenv("UNKNOWN_VAR_XYZ", raising=False)
+        assert replace_env_vars("$KNOWN and $UNKNOWN_VAR_XYZ") == "value and $UNKNOWN_VAR_XYZ"
+
+    def test_multiple_vars(self, monkeypatch):
+        monkeypatch.setenv("A", "1")
+        monkeypatch.setenv("B", "2")
+        monkeypatch.setenv("C", "3")
+        assert replace_env_vars("$A-${B}-$C") == "1-2-3"
+
+    def test_empty_string(self):
+        assert replace_env_vars("") == ""
+
+    def test_no_vars(self):
+        assert replace_env_vars("just a plain string") == "just a plain string"
+
+    def test_var_with_empty_value(self, monkeypatch):
+        monkeypatch.setenv("EMPTY_VAR", "")
+        assert replace_env_vars("prefix${EMPTY_VAR}suffix") == "prefixsuffix"
+
+    def test_var_with_special_characters_in_value(self, monkeypatch):
+        monkeypatch.setenv("SPECIAL", "hello world/foo@bar")
+        assert replace_env_vars("${SPECIAL}") == "hello world/foo@bar"
+
+
+class TestExpandEnv:
+    """Tests for expand_env: recursively expands env vars in nested structures."""
+
+    def test_string(self, monkeypatch):
+        monkeypatch.setenv("X", "expanded")
+        assert expand_env("$X") == "expanded"
+
+    def test_dict(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "myhost")
+        monkeypatch.setenv("DB_PORT", "3306")
+        data = {"host": "$DB_HOST", "port": "${DB_PORT}"}
+        assert expand_env(data) == {"host": "myhost", "port": "3306"}
+
+    def test_list(self, monkeypatch):
+        monkeypatch.setenv("ITEM", "val")
+        assert expand_env(["$ITEM", "static"]) == ["val", "static"]
+
+    def test_nested_dict_and_list(self, monkeypatch):
+        monkeypatch.setenv("URL", "http://example.com")
+        data = {
+            "sources": [
+                {"url": "$URL", "name": "test"},
+            ],
+            "meta": {"ref": "${URL}/api"},
+        }
+        expected = {
+            "sources": [
+                {"url": "http://example.com", "name": "test"},
+            ],
+            "meta": {"ref": "http://example.com/api"},
+        }
+        assert expand_env(data) == expected
+
+    def test_tuple(self, monkeypatch):
+        monkeypatch.setenv("T", "tval")
+        result = expand_env(("$T", "fixed"))
+        assert result == ("tval", "fixed")
+        assert isinstance(result, tuple)
+
+    def test_non_string_values_unchanged(self):
+        assert expand_env(42) == 42
+        assert expand_env(3.14) == 3.14
+        assert expand_env(True) is True
+        assert expand_env(None) is None
+
+    def test_dict_with_non_string_values(self, monkeypatch):
+        monkeypatch.setenv("NAME", "test")
+        data = {"name": "$NAME", "count": 5, "active": True, "ratio": 0.5}
+        expected = {"name": "test", "count": 5, "active": True, "ratio": 0.5}
+        assert expand_env(data) == expected
+
+    def test_deeply_nested(self, monkeypatch):
+        monkeypatch.setenv("DEEP", "found")
+        data = {"a": {"b": {"c": {"d": "$DEEP"}}}}
+        assert expand_env(data) == {"a": {"b": {"c": {"d": "found"}}}}
+
+    def test_unknown_env_in_nested_structure(self, monkeypatch):
+        monkeypatch.delenv("MISSING_XYZ", raising=False)
+        data = {"key": "${MISSING_XYZ}"}
+        assert expand_env(data) == {"key": "${MISSING_XYZ}"}
+
+
+class TestLoadYamlWithEnvVars:
+    """Integration tests: load_yaml with environment variable expansion."""
+
+    def test_load_yaml_expands_env(self, monkeypatch):
+        monkeypatch.setenv("CACHE_DIR", "/tmp/cache")
+        doc = load_yaml("cache:\n  directory: ${CACHE_DIR}")
+        assert doc == {"cache": {"directory": "/tmp/cache"}}
+
+    def test_load_yaml_expands_env_in_list(self, monkeypatch):
+        monkeypatch.setenv("SRC", "http://wms.example.com")
+        doc = load_yaml("sources:\n  - $SRC\n  - http://static.example.com")
+        assert doc == {"sources": ["http://wms.example.com", "http://static.example.com"]}

--- a/mapproxy/test/unit/test_yaml.py
+++ b/mapproxy/test/unit/test_yaml.py
@@ -15,8 +15,26 @@
 
 import os
 import tempfile
+import warnings
 
-from mapproxy.util.yaml import load_yaml, load_yaml_file, YAMLError, replace_env_vars, expand_env
+import pytest
+
+from mapproxy.util.yaml import (
+    load_yaml,
+    load_yaml_file,
+    YAMLError,
+    replace_env_vars,
+    expand_env,
+    _warned_env_vars,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_warned_env_vars():
+    """Reset the per-name warning tracker before every test."""
+    _warned_env_vars.clear()
+    yield
+    _warned_env_vars.clear()
 
 
 class TestLoadYAMLFile(object):
@@ -86,13 +104,32 @@ class TestReplaceEnvVars:
 
     def test_unknown_var_stays_unchanged(self, monkeypatch):
         monkeypatch.delenv("UNKNOWN_VAR_XYZ", raising=False)
-        assert replace_env_vars("$UNKNOWN_VAR_XYZ") == "$UNKNOWN_VAR_XYZ"
-        assert replace_env_vars("${UNKNOWN_VAR_XYZ}") == "${UNKNOWN_VAR_XYZ}"
+        with pytest.warns(UserWarning, match="UNKNOWN_VAR_XYZ") as w:
+            result = replace_env_vars("$UNKNOWN_VAR_XYZ")
+        assert result == "$UNKNOWN_VAR_XYZ"
+        assert "Using fallback value: '$UNKNOWN_VAR_XYZ'" in str(w[0].message)
+
+        # braced form – same var name: no second warning (already warned)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result2 = replace_env_vars("${UNKNOWN_VAR_XYZ}")
+        assert result2 == "${UNKNOWN_VAR_XYZ}"
+
+    def test_unknown_var_warns_once_per_name(self, monkeypatch):
+        monkeypatch.delenv("ONCE_VAR", raising=False)
+        with pytest.warns(UserWarning):
+            replace_env_vars("$ONCE_VAR")
+        # second call must NOT trigger another warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            replace_env_vars("$ONCE_VAR")
 
     def test_mixed_known_and_unknown(self, monkeypatch):
         monkeypatch.setenv("KNOWN", "value")
         monkeypatch.delenv("UNKNOWN_VAR_XYZ", raising=False)
-        assert replace_env_vars("$KNOWN and $UNKNOWN_VAR_XYZ") == "value and $UNKNOWN_VAR_XYZ"
+        with pytest.warns(UserWarning, match="UNKNOWN_VAR_XYZ"):
+            result = replace_env_vars("$KNOWN and $UNKNOWN_VAR_XYZ")
+        assert result == "value and $UNKNOWN_VAR_XYZ"
 
     def test_multiple_vars(self, monkeypatch):
         monkeypatch.setenv("A", "1")
@@ -174,7 +211,9 @@ class TestExpandEnv:
     def test_unknown_env_in_nested_structure(self, monkeypatch):
         monkeypatch.delenv("MISSING_XYZ", raising=False)
         data = {"key": "${MISSING_XYZ}"}
-        assert expand_env(data) == {"key": "${MISSING_XYZ}"}
+        with pytest.warns(UserWarning, match="MISSING_XYZ"):
+            result = expand_env(data)
+        assert result == {"key": "${MISSING_XYZ}"}
 
 
 class TestLoadYamlWithEnvVars:

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -60,6 +60,7 @@ def load_yaml(doc):
         raise YAMLError("configuration not a YAML dictionary")
     return data
 
+
 # functions for using env-names in variables
 def replace_env_vars(value):
     """Ersetzt $VAR und ${VAR} in einem String."""
@@ -82,5 +83,3 @@ def expand_env(obj):
         return replace_env_vars(obj)
     else:
         return obj
-
-

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+import os
+import re
 
 import yaml
+ENV_PATTERN = re.compile(r"\$(\w+)|\$\{([^}]+)\}")
 
 
 class YAMLError(Exception):
@@ -51,8 +54,33 @@ def load_yaml(doc):
     """
     Load yaml from file object or string.
     """
-    data = _load_yaml(doc)
+    data = expand_env(_load_yaml(doc))
     if type(data) is not dict:
         # all configs are dicts, raise YAMLError to prevent later AttributeErrors (#352)
         raise YAMLError("configuration not a YAML dictionary")
     return data
+
+# functions for using env-names in variables
+def replace_env_vars(value):
+    """Ersetzt $VAR und ${VAR} in einem String."""
+    def repl(match):
+        var_name = match.group(1) or match.group(2)
+        return os.environ.get(var_name, match.group(0))
+
+    return ENV_PATTERN.sub(repl, value)
+
+
+def expand_env(obj):
+    """Rekursiv durch ein nested Pythonobjekt gehen."""
+    if isinstance(obj, dict):
+        return {k: expand_env(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [expand_env(v) for v in obj]
+    elif isinstance(obj, tuple):
+        return tuple(expand_env(v) for v in obj)
+    elif isinstance(obj, str):
+        return replace_env_vars(obj)
+    else:
+        return obj
+
+

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -56,25 +56,28 @@ def load_yaml(doc):
     """
     data = expand_env(_load_yaml(doc))
     if type(data) is not dict:
-        # all configs are dicts, raise YAMLError to prevent later AttributeErrors (#352)
         raise YAMLError("configuration not a YAML dictionary")
     return data
 
 
 # functions for using env-names in variables
-"""Replaces $VAR and ${VAR} in a string. in case the environment variable isn't set it resets to the 'variablename'"""
 def replace_env_vars(value):
+    """Replaces $VAR and ${VAR} in a string.
+    in case the environment variable isn't set
+    it resets to the 'variablename'"""
     def repl(match):
         var_name = match.group(1) or match.group(2)
-        """sec paraemter: 
-        if ${UNKNOWN} doesn't exists (as env-variable) this sets the property-value to ${UNKNOW}.
+        """sec paraemter:
+        if ${UNKNOWN} doesn't exists (as env-variable)
+        this sets the property-value to ${UNKNOW}.
         see it as a fallback strategy"""
         return os.environ.get(var_name, match.group(0))
 
     return ENV_PATTERN.sub(repl, value)
 
-"""Recursively traverse a nested Python object."""
+
 def expand_env(obj):
+    """Recursively traverse a nested Python object."""
     if isinstance(obj, dict):
         return {k: expand_env(v) for k, v in obj.items()}
     elif isinstance(obj, list):

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -63,7 +63,7 @@ def load_yaml(doc):
 
 # functions for using env-names in variables
 def replace_env_vars(value):
-    """Ersetzt $VAR und ${VAR} in einem String."""
+    """Replaces $VAR and ${VAR} in a string."""
     def repl(match):
         var_name = match.group(1) or match.group(2)
         return os.environ.get(var_name, match.group(0))
@@ -72,7 +72,7 @@ def replace_env_vars(value):
 
 
 def expand_env(obj):
-    """Rekursiv durch ein nested Pythonobjekt gehen."""
+    """Recursively traverse a nested Python object."""
     if isinstance(obj, dict):
         return {k: expand_env(v) for k, v in obj.items()}
     elif isinstance(obj, list):

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -62,16 +62,18 @@ def load_yaml(doc):
 
 
 # functions for using env-names in variables
-    """Replaces $VAR and ${VAR} in a string. in case the environment variable isn't set it resets to the 'variablename'"""
+"""Replaces $VAR and ${VAR} in a string. in case the environment variable isn't set it resets to the 'variablename'"""
 def replace_env_vars(value):
     def repl(match):
         var_name = match.group(1) or match.group(2)
-        #sec paraemter: ${UNKNOWN} doesn't exists this sets the property-value to ${UNKNOW} see it as a fallback strategy
+        """sec paraemter: 
+        if ${UNKNOWN} doesn't exists (as env-variable) this sets the property-value to ${UNKNOW}.
+        see it as a fallback strategy"""
         return os.environ.get(var_name, match.group(0))
 
     return ENV_PATTERN.sub(repl, value)
 
-    """Recursively traverse a nested Python object."""
+"""Recursively traverse a nested Python object."""
 def expand_env(obj):
     if isinstance(obj, dict):
         return {k: expand_env(v) for k, v in obj.items()}

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -62,17 +62,17 @@ def load_yaml(doc):
 
 
 # functions for using env-names in variables
+    """Replaces $VAR and ${VAR} in a string. in case the environment variable isn't set it resets to the 'variablename'"""
 def replace_env_vars(value):
-    """Replaces $VAR and ${VAR} in a string."""
     def repl(match):
         var_name = match.group(1) or match.group(2)
+        #sec paraemter: ${UNKNOWN} doesn't exists this sets the property-value to ${UNKNOW} see it as a fallback strategy
         return os.environ.get(var_name, match.group(0))
 
     return ENV_PATTERN.sub(repl, value)
 
-
-def expand_env(obj):
     """Recursively traverse a nested Python object."""
+def expand_env(obj):
     if isinstance(obj, dict):
         return {k: expand_env(v) for k, v in obj.items()}
     elif isinstance(obj, list):

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -16,13 +16,18 @@
 from __future__ import absolute_import
 import os
 import re
+import warnings
 
 import yaml
 ENV_PATTERN = re.compile(r"\$(\w+)|\$\{([^}]+)\}")
 
+# Tracks variable names for which a warning has already been issued (once per name).
+_warned_env_vars: set = set()
+
 
 class YAMLError(Exception):
     pass
+
 
 
 def load_yaml_file(file_or_filename):
@@ -63,15 +68,24 @@ def load_yaml(doc):
 # functions for using env-names in variables
 def replace_env_vars(value):
     """Replaces $VAR and ${VAR} in a string.
-    in case the environment variable isn't set
-    it resets to the 'variablename'"""
+    If the environment variable is not set, the original placeholder is kept
+    as a fallback value and a :class:`UserWarning` is issued once per
+    unknown variable name.
+    """
     def repl(match):
         var_name = match.group(1) or match.group(2)
-        """sec paraemter:
-        if ${UNKNOWN} doesn't exists (as env-variable)
-        this sets the property-value to ${UNKNOW}.
-        see it as a fallback strategy"""
-        return os.environ.get(var_name, match.group(0))
+        if var_name in os.environ:
+            return os.environ[var_name]
+        fallback = match.group(0)
+        if var_name not in _warned_env_vars:
+            _warned_env_vars.add(var_name)
+            warnings.warn(
+                f"Environment variable '{var_name}' is not set. "
+                f"Using fallback value: '{fallback}'",
+                UserWarning,
+                stacklevel=2,
+            )
+        return fallback
 
     return ENV_PATTERN.sub(repl, value)
 

--- a/mapproxy/util/yaml.py
+++ b/mapproxy/util/yaml.py
@@ -29,7 +29,6 @@ class YAMLError(Exception):
     pass
 
 
-
 def load_yaml_file(file_or_filename):
     """
     Load yaml from file object or filename.


### PR DESCRIPTION
Maybe you dont want to save sensitive data like an api-key in an yaml-config-file.
This PR enables mapproxy to use enviroment variables in their config-yaml-files. 

With this PR you can use:
$yourname : for the whole yaml-value subsitution
${yourname} : for part subsitution e.g "https://${server}:${port}"

PR for this issue: https://github.com/mapproxy/mapproxy/issues/1392
CLOSES: #1392
