### PR TITLE
fix: wrap IOError as LockError in LockFile.__init__ to enable retry on race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ nosetests*.xml
 
 .idea/
 *.iml
+.cursor/
+.claude/
+.vscode/

--- a/mapproxy/test/unit/test_utils.py
+++ b/mapproxy/test/unit/test_utils.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import threading
 import time
+from unittest.mock import patch
 
 from mapproxy.util.lock import FileLock, SemLock, cleanup_lockdir, LockTimeout
 from mapproxy.util.fs import (
@@ -183,6 +184,44 @@ class TestFileLock(Mocker):
         assert_permissions(self.lock_file, file_permissions)
 
         lock_thread.join()
+
+    def test_lock_retries_on_permission_error(self):
+        real_open = open
+        call_count = 0
+
+        def flaky_open(path, *args, **kwargs):
+            nonlocal call_count
+            if path == self.lock_file:
+                call_count += 1
+                if call_count == 1:
+                    raise PermissionError("mock transient failure")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=flaky_open):
+            lock = FileLock(self.lock_file, timeout=1.0, step=0.01)
+            lock.lock()
+            lock.unlock()
+
+        assert call_count >= 2, "expected open to be called at least twice (initial fail + retry)"
+
+    def test_lock_raises_lock_timeout_on_persistent_open_failure(self):
+        real_open = open
+
+        def always_fail(path, *args, **kwargs):
+            if path == self.lock_file:
+                raise PermissionError("mock persistent failure")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=always_fail):
+            lock = FileLock(self.lock_file, timeout=0.05, step=0.01)
+            try:
+                lock.lock()
+            except LockTimeout:
+                pass
+            except PermissionError:
+                assert False, "PermissionError should be wrapped as LockError and retried until LockTimeout"
+            else:
+                assert False, "expected LockTimeout"
 
     def _create_lock(self):
         lock = FileLock(self.lock_file)

--- a/mapproxy/util/ext/lockfile.py
+++ b/mapproxy/util/ext/lockfile.py
@@ -120,12 +120,19 @@ class LockFile:
         set_permissions = file_permissions and not os.path.exists(path)
         try:
             fp = open(path, 'w+')
-        except IOError:
-            raise Exception('Could not create Lock-file, wrong permissions on lock directory?')
+        except IOError as exc:
+            raise LockError('Could not create Lock-file, wrong permissions on lock directory?') from exc
 
         if set_permissions:
-            permission = int(file_permissions, base=8)
-            os.chmod(path, permission)
+            try:
+                permission = int(file_permissions, base=8)
+                os.chmod(path, permission)
+            except OSError as exc:
+                try:
+                    fp.close()
+                except Exception:
+                    pass
+                raise LockError('Could not set permissions on lock file') from exc
 
         try:
             _lock_file(fp)

--- a/mapproxy/util/lock.py
+++ b/mapproxy/util/lock.py
@@ -64,13 +64,13 @@ class FileLock(object):
         while not self._locked:
             try:
                 self._lock = self._try_lock()
-            except LockError:
+            except LockError as last_err:
                 current_time = time.time()
                 if current_time < stop_time:
                     time.sleep(self.step)
                     continue
                 else:
-                    raise LockTimeout('another process is still running with our lock')
+                    raise LockTimeout(last_err.args[0]) from last_err
             else:
                 self._locked = True
 


### PR DESCRIPTION
## Summary

Fixes #1067 — tile cache lock file race condition causes unhandled `Exception` instead of retry.

In `LockFile.__init__`, when `open()` fails (e.g. due to a concurrent process holding the file on Windows), the `IOError` was re-raised as a generic `Exception`. Because the retry loop in `FileLock.lock()` only catches `LockError`, the generic `Exception` escaped entirely, crashing the request with a 500 error.

This PR raises `LockError` instead, which lets the existing retry logic handle transient file-access conflicts gracefully.

## Changes

- **`mapproxy/util/ext/lockfile.py`**
  - `IOError` from `open()` is now re-raised as `LockError` (not `Exception`), using `from exc` to preserve the original traceback.
  - Added `try/except` around `os.chmod()` so that an `OSError` during permission setting properly closes the file handle and raises `LockError` instead of leaking the fd.

- **`mapproxy/util/lock.py`**
  - `LockTimeout` now preserves the original `LockError` message and chains the cause via `from last_err`, instead of a hardcoded string.

- **`mapproxy/test/unit/test_utils.py`**
  - `test_lock_retries_on_permission_error`: verifies that a transient `PermissionError` on `open()` is retried and the lock is eventually acquired.
  - `test_lock_raises_lock_timeout_on_persistent_open_failure`: verifies that a persistent `PermissionError` results in `LockTimeout` (not an unhandled `PermissionError`).

- **`.gitignore`** — added `.cursor/`, `.claude/`, `.vscode/` (IDE config directories). Happy to drop this if preferred.

## Test plan

- [x] Existing `FileLock` / `SemLock` unit tests pass without modification.
- [x] Two new unit tests cover the retry and timeout behavior for permission errors during lock file creation.
