### PR TITLE
fix: improve error handling for Redis operations

### DIFF
--- a/mapproxy/cache/redis.py
+++ b/mapproxy/cache/redis.py
@@ -30,9 +30,9 @@ from mapproxy.cache.base import (
 from mapproxy.util.coverage import Coverage
 
 try:
-    import redis  # type: ignore
+    import redis
 except ImportError:
-    redis = None  # type: ignore
+    redis = None
 
 
 import logging
@@ -75,6 +75,7 @@ class RedisCache(TileCacheBase):
             ssl=ssl_enabled
         )
 
+
     def _key(self, tile):
         x, y, z = tile.coord
         return self.prefix + '-%d-%d-%d' % (z, x, y)
@@ -88,9 +89,12 @@ class RedisCache(TileCacheBase):
             log.debug('exists_key, key: %s' % key)
             # TODO: according to documentation exists returns an Awaitable
             return cast(bool, self.r.exists(key))
+        except redis.exceptions.TimeoutError as e:
+            log.error('REDIS:exists_key timeout error, returning false. %s' % e)
+            return False
         except redis.exceptions.ConnectionError as e:
             log.error('Error during connection %s' % e)
-            return False
+            return False  
         except Exception as e:
             log.error('REDIS:exists_key error  %s' % e)
             return False
@@ -107,27 +111,21 @@ class RedisCache(TileCacheBase):
             log.debug('store_key, key: %s' % key)
             # TODO: according to documentation set returns an Awaitable
             r = cast(bool, self.r.set(key, data))
+        except redis.exceptions.TimeoutError as e:
+            log.error('REDIS:store_key timeout error, returning false. %s' % e)
+            return False
         except redis.exceptions.ConnectionError as e:
             log.error('Error during connection %s' % e)
-            return False
+            return False  
         except Exception as e:
             log.error('REDIS:store_key error  %s' % e)
             return False
 
+        
         if self.ttl:
             # use ms expire times for unit-tests
             self.r.pexpire(key, int(self.ttl * 1000))
         return r
-
-    def load_tile_metadata(self, tile: Tile, dimensions=None):
-        if tile.timestamp:
-            return
-        pipe = self.r.pipeline()
-        pipe.ttl(self._key(tile))
-        pipe.memory_usage(self._key(tile))
-        pipe_res = pipe.execute()
-        tile.timestamp = time.mktime(datetime.datetime.now().timetuple()) - self.ttl - int(pipe_res[0])
-        tile.size = pipe_res[1]
 
     def load_tile(self, tile: Tile, with_metadata=False, dimensions=None) -> bool:
         if tile.image_result or tile.coord is None:
@@ -142,17 +140,40 @@ class RedisCache(TileCacheBase):
                 tile.image_result = ImageResult(BytesIO(cast(bytes, tile_data)))
                 return True
             return False
+        except redis.exceptions.TimeoutError as e:
+            log.error('REDIS:get_key timeout error, returning false. %s' % e)
+            return False
         except redis.exceptions.ConnectionError as e:
             log.error('Error during connection %s' % e)
-            return False
+            return False  
         except Exception as e:
             log.error('REDIS:get_key error  %s' % e)
             return False
 
+    def load_tile_metadata(self, tile: Tile, dimensions=None):
+        if tile.timestamp:
+            return
+        try:
+            pipe = self.r.pipeline()
+            pipe.ttl(self._key(tile))
+            pipe.memory_usage(self._key(tile))
+            pipe_res = pipe.execute()
+            tile.timestamp = time.mktime(datetime.datetime.now().timetuple()) - self.ttl - int(pipe_res[0])
+            tile.size = pipe_res[1]
+        except (redis.exceptions.TimeoutError, redis.exceptions.ConnectionError, Exception) as e:
+            log.error('REDIS:load_tile_metadata error %s' % e)
+            # Fail silently so the worker doesn't crash.
+            pass
+        
     def remove_tile(self, tile: Tile, dimensions=None):
         if tile.coord is None:
             return True
 
         key = self._key(tile)
-        self.r.delete(key)
-        return True
+        try:
+            self.r.delete(key)
+            return True
+        except (redis.exceptions.TimeoutError, redis.exceptions.ConnectionError, Exception) as e:
+            log.error('REDIS:remove_tile error %s' % e)
+            return False
+

--- a/mapproxy/cache/redis.py
+++ b/mapproxy/cache/redis.py
@@ -30,9 +30,9 @@ from mapproxy.cache.base import (
 from mapproxy.util.coverage import Coverage
 
 try:
-    import redis
+    import redis  # type: ignore
 except ImportError:
-    redis = None
+    redis = None  # type: ignore
 
 
 import logging

--- a/mapproxy/cache/redis.py
+++ b/mapproxy/cache/redis.py
@@ -36,13 +36,25 @@ except ImportError:
 
 
 import logging
+
 log = logging.getLogger(__name__)
 
 
 class RedisCache(TileCacheBase):
     def __init__(
-            self, host, port, prefix, ttl=0, db=0, username=None, password=None, coverage: Optional[Coverage] = None,
-            ssl_certfile=None, ssl_keyfile=None, ssl_ca_certs=None):
+        self,
+        host,
+        port,
+        prefix,
+        ttl=0,
+        db=0,
+        username=None,
+        password=None,
+        coverage: Optional[Coverage] = None,
+        ssl_certfile=None,
+        ssl_keyfile=None,
+        ssl_ca_certs=None,
+    ):
         super().__init__(coverage)
 
         if redis is None:
@@ -54,8 +66,12 @@ class RedisCache(TileCacheBase):
 
         self.prefix = prefix
         # str(username) => if not set defaults to None
-        md5 = hashlib.new('md5', (host + str(port) + prefix + str(db)).encode('utf-8'), usedforsecurity=False)
-        self.lock_cache_id = 'redis-' + md5.hexdigest()
+        md5 = hashlib.new(
+            "md5",
+            (host + str(port) + prefix + str(db)).encode("utf-8"),
+            usedforsecurity=False,
+        )
+        self.lock_cache_id = "redis-" + md5.hexdigest()
         self.ttl = ttl
         # Enable SSL only if certificate and key are provided (CA certificates are not mandatory, but if provided use
         # them)
@@ -72,13 +88,12 @@ class RedisCache(TileCacheBase):
             ssl_certfile=ssl_certfile,
             ssl_keyfile=ssl_keyfile,
             ssl_ca_certs=ssl_ca_certs,
-            ssl=ssl_enabled
+            ssl=ssl_enabled,
         )
-
 
     def _key(self, tile):
         x, y, z = tile.coord
-        return self.prefix + '-%d-%d-%d' % (z, x, y)
+        return self.prefix + "-%d-%d-%d" % (z, x, y)
 
     def is_cached(self, tile: Tile, dimensions=None) -> bool:
         if tile.coord is None or tile.image_result:
@@ -86,17 +101,17 @@ class RedisCache(TileCacheBase):
         key = self._key(tile)
 
         try:
-            log.debug('exists_key, key: %s' % key)
+            log.debug("exists_key, key: %s" % key)
             # TODO: according to documentation exists returns an Awaitable
             return cast(bool, self.r.exists(key))
         except redis.exceptions.TimeoutError as e:
-            log.error('REDIS:exists_key timeout error, returning false. %s' % e)
+            log.error("REDIS:exists_key timeout error, returning false. %s" % e)
             return False
         except redis.exceptions.ConnectionError as e:
-            log.error('Error during connection %s' % e)
-            return False  
+            log.error("Error during connection %s" % e)
+            return False
         except Exception as e:
-            log.error('REDIS:exists_key error  %s' % e)
+            log.error("REDIS:exists_key error  %s" % e)
             return False
 
     def store_tile(self, tile: Tile, dimensions=None) -> bool:
@@ -108,20 +123,19 @@ class RedisCache(TileCacheBase):
             data = buf.read()
 
         try:
-            log.debug('store_key, key: %s' % key)
+            log.debug("store_key, key: %s" % key)
             # TODO: according to documentation set returns an Awaitable
             r = cast(bool, self.r.set(key, data))
         except redis.exceptions.TimeoutError as e:
-            log.error('REDIS:store_key timeout error, returning false. %s' % e)
+            log.error("REDIS:store_key timeout error, returning false. %s" % e)
             return False
         except redis.exceptions.ConnectionError as e:
-            log.error('Error during connection %s' % e)
-            return False  
+            log.error("Error during connection %s" % e)
+            return False
         except Exception as e:
-            log.error('REDIS:store_key error  %s' % e)
+            log.error("REDIS:store_key error  %s" % e)
             return False
 
-        
         if self.ttl:
             # use ms expire times for unit-tests
             self.r.pexpire(key, int(self.ttl * 1000))
@@ -133,7 +147,7 @@ class RedisCache(TileCacheBase):
         key = self._key(tile)
 
         try:
-            log.debug('get_key, key: %s' % key)
+            log.debug("get_key, key: %s" % key)
             tile_data = self.r.get(key)
             if tile_data:
                 # TODO: according to documentation get returns an Awaitable
@@ -141,13 +155,13 @@ class RedisCache(TileCacheBase):
                 return True
             return False
         except redis.exceptions.TimeoutError as e:
-            log.error('REDIS:get_key timeout error, returning false. %s' % e)
+            log.error("REDIS:get_key timeout error, returning false. %s" % e)
             return False
         except redis.exceptions.ConnectionError as e:
-            log.error('Error during connection %s' % e)
-            return False  
+            log.error("Error during connection %s" % e)
+            return False
         except Exception as e:
-            log.error('REDIS:get_key error  %s' % e)
+            log.error("REDIS:get_key error  %s" % e)
             return False
 
     def load_tile_metadata(self, tile: Tile, dimensions=None):
@@ -158,13 +172,21 @@ class RedisCache(TileCacheBase):
             pipe.ttl(self._key(tile))
             pipe.memory_usage(self._key(tile))
             pipe_res = pipe.execute()
-            tile.timestamp = time.mktime(datetime.datetime.now().timetuple()) - self.ttl - int(pipe_res[0])
+            tile.timestamp = (
+                time.mktime(datetime.datetime.now().timetuple())
+                - self.ttl
+                - int(pipe_res[0])
+            )
             tile.size = pipe_res[1]
-        except (redis.exceptions.TimeoutError, redis.exceptions.ConnectionError, Exception) as e:
-            log.error('REDIS:load_tile_metadata error %s' % e)
+        except (
+            redis.exceptions.TimeoutError,
+            redis.exceptions.ConnectionError,
+            Exception,
+        ) as e:
+            log.error("REDIS:load_tile_metadata error %s" % e)
             # Fail silently so the worker doesn't crash.
             pass
-        
+
     def remove_tile(self, tile: Tile, dimensions=None):
         if tile.coord is None:
             return True
@@ -173,7 +195,10 @@ class RedisCache(TileCacheBase):
         try:
             self.r.delete(key)
             return True
-        except (redis.exceptions.TimeoutError, redis.exceptions.ConnectionError, Exception) as e:
-            log.error('REDIS:remove_tile error %s' % e)
+        except (
+            redis.exceptions.TimeoutError,
+            redis.exceptions.ConnectionError,
+            Exception,
+        ) as e:
+            log.error("REDIS:remove_tile error %s" % e)
             return False
-

--- a/mapproxy/cache/redis.py
+++ b/mapproxy/cache/redis.py
@@ -110,9 +110,6 @@ class RedisCache(TileCacheBase):
         except redis.exceptions.ConnectionError as e:
             log.error("Error during connection %s" % e)
             return False
-        except Exception as e:
-            log.error("REDIS:exists_key error  %s" % e)
-            return False
 
     def store_tile(self, tile: Tile, dimensions=None) -> bool:
         if tile.stored:
@@ -131,9 +128,6 @@ class RedisCache(TileCacheBase):
             return False
         except redis.exceptions.ConnectionError as e:
             log.error("Error during connection %s" % e)
-            return False
-        except Exception as e:
-            log.error("REDIS:store_key error  %s" % e)
             return False
 
         if self.ttl:
@@ -160,9 +154,6 @@ class RedisCache(TileCacheBase):
         except redis.exceptions.ConnectionError as e:
             log.error("Error during connection %s" % e)
             return False
-        except Exception as e:
-            log.error("REDIS:get_key error  %s" % e)
-            return False
 
     def load_tile_metadata(self, tile: Tile, dimensions=None):
         if tile.timestamp:
@@ -181,7 +172,6 @@ class RedisCache(TileCacheBase):
         except (
             redis.exceptions.TimeoutError,
             redis.exceptions.ConnectionError,
-            Exception,
         ) as e:
             log.error("REDIS:load_tile_metadata error %s" % e)
             # Fail silently so the worker doesn't crash.
@@ -198,7 +188,6 @@ class RedisCache(TileCacheBase):
         except (
             redis.exceptions.TimeoutError,
             redis.exceptions.ConnectionError,
-            Exception,
         ) as e:
             log.error("REDIS:remove_tile error %s" % e)
             return False

--- a/mapproxy/cache/redis.py
+++ b/mapproxy/cache/redis.py
@@ -102,8 +102,9 @@ class RedisCache(TileCacheBase):
 
         try:
             log.debug("exists_key, key: %s" % key)
-            # TODO: according to documentation exists returns an Awaitable
-            return cast(bool, self.r.exists(key))
+            # exists() returns an int (0/1); convert to a real bool so the
+            # declared -> bool return type holds and `is False` checks work.
+            return bool(self.r.exists(key))
         except redis.exceptions.TimeoutError as e:
             log.error("REDIS:exists_key timeout error, returning false. %s" % e)
             return False
@@ -123,16 +124,20 @@ class RedisCache(TileCacheBase):
             log.debug("store_key, key: %s" % key)
             # TODO: according to documentation set returns an Awaitable
             r = cast(bool, self.r.set(key, data))
+            if self.ttl:
+                # use ms expire times for unit-tests
+                self.r.pexpire(key, int(self.ttl * 1000))
         except redis.exceptions.TimeoutError as e:
             log.error("REDIS:store_key timeout error, returning false. %s" % e)
+            # tile_buffer() set tile.stored=True; undo it so a fallback cache
+            # in a cascade still attempts to store the tile.
+            tile.stored = False
             return False
         except redis.exceptions.ConnectionError as e:
             log.error("Error during connection %s" % e)
+            tile.stored = False
             return False
 
-        if self.ttl:
-            # use ms expire times for unit-tests
-            self.r.pexpire(key, int(self.ttl * 1000))
         return r
 
     def load_tile(self, tile: Tile, with_metadata=False, dimensions=None) -> bool:

--- a/mapproxy/test/unit/test_cache_redis.py
+++ b/mapproxy/test/unit/test_cache_redis.py
@@ -15,6 +15,7 @@
 
 import os
 import time
+from unittest import mock
 
 import pytest
 
@@ -25,7 +26,9 @@ except ImportError:
 
 from mapproxy.cache.redis import RedisCache
 from mapproxy.cache.tile import Tile
-from mapproxy.test.unit.test_cache_tile import TileCacheTestBase
+from mapproxy.image import ImageResult
+from mapproxy.image.opts import ImageOptions
+from mapproxy.test.unit.test_cache_tile import TileCacheTestBase, tile_image
 
 
 @pytest.mark.skipif(not redis or not os.environ.get('MAPPROXY_TEST_REDIS'),
@@ -121,3 +124,60 @@ class TestRedisCache(TileCacheTestBase):
         assert cache.store_tile(t1)
         t2 = Tile(t1.coord)
         assert cache.is_cached(t2)
+
+
+@pytest.mark.skipif(not redis, reason="redis package required")
+class TestRedisErrorHandling:
+    """An unavailable Redis (timeout/connection error) must fall back gracefully
+    — return False / not crash the worker — so MapProxy can use the next cache.
+    Any other exception indicates a real defect and must propagate.
+
+    StrictRedis connects lazily, so these run without a live server: we build a
+    RedisCache and swap in a fake client that raises on every operation.
+    """
+
+    def _cache_with_client(self, client):
+        cache = RedisCache('localhost', 6379, prefix='mapproxy-test', db=1)
+        cache.r = client
+        return cache
+
+    def _stored_tile(self):
+        return Tile((0, 0, 1),
+                    ImageResult(tile_image, image_opts=ImageOptions(format='image/png')))
+
+    def _client_raising(self, exc):
+        client = mock.Mock()
+        client.exists.side_effect = exc
+        client.get.side_effect = exc
+        client.set.side_effect = exc
+        client.delete.side_effect = exc
+        pipe = mock.Mock()
+        pipe.execute.side_effect = exc
+        client.pipeline.return_value = pipe
+        return client
+
+    @pytest.mark.parametrize('exc', [
+        redis.exceptions.TimeoutError if redis else None,
+        redis.exceptions.ConnectionError if redis else None,
+    ])
+    def test_unavailable_redis_falls_back(self, exc):
+        cache = self._cache_with_client(self._client_raising(exc()))
+        assert cache.is_cached(Tile((0, 0, 1))) is False
+        assert cache.load_tile(Tile((0, 0, 1))) is False
+        assert cache.store_tile(self._stored_tile()) is False
+        assert cache.remove_tile(Tile((0, 0, 1))) is False
+        # metadata loading must not raise
+        cache.load_tile_metadata(Tile((0, 0, 1)))
+
+    def test_other_exception_propagates(self):
+        cache = self._cache_with_client(self._client_raising(ValueError("boom")))
+        with pytest.raises(ValueError):
+            cache.is_cached(Tile((0, 0, 1)))
+        with pytest.raises(ValueError):
+            cache.load_tile(Tile((0, 0, 1)))
+        with pytest.raises(ValueError):
+            cache.store_tile(self._stored_tile())
+        with pytest.raises(ValueError):
+            cache.remove_tile(Tile((0, 0, 1)))
+        with pytest.raises(ValueError):
+            cache.load_tile_metadata(Tile((0, 0, 1)))

--- a/mapproxy/test/unit/test_cache_redis.py
+++ b/mapproxy/test/unit/test_cache_redis.py
@@ -164,7 +164,11 @@ class TestRedisErrorHandling:
         cache = self._cache_with_client(self._client_raising(exc()))
         assert cache.is_cached(Tile((0, 0, 1))) is False
         assert cache.load_tile(Tile((0, 0, 1))) is False
-        assert cache.store_tile(self._stored_tile()) is False
+        tile = self._stored_tile()
+        assert cache.store_tile(tile) is False
+        # a failed store must not leave the tile marked stored, otherwise a
+        # fallback cache in a cascade would skip it
+        assert tile.stored is False
         assert cache.remove_tile(Tile((0, 0, 1))) is False
         # metadata loading must not raise
         cache.load_tile_metadata(Tile((0, 0, 1)))


### PR DESCRIPTION
This pull request improves the robustness and error handling of the Redis cache backend in `mapproxy/cache/redis.py`. The main focus is on handling Redis timeout errors more gracefully and ensuring that Redis-related failures do not cause the worker process to crash. Additionally, the `load_tile_metadata` method is refactored for better error handling and code organization.

This feature allows for setting a fallback cache for a Redis-defined cache.
currenly if redis tile fails to serve it returns error, instead of continuing to fallback cache.

**Improved Redis error handling:**

* Added handling for `redis.exceptions.TimeoutError` in the `is_cached`, `store_tile`, and `load_tile` methods, logging errors and returning `False` when a timeout occurs. [[1]](diffhunk://#diff-ce5cf6bbfd6f7c5c9a2f0eff3f250a20a53435a8c3ba66675e9b3aa3d2ec3a01R92-R94) [[2]](diffhunk://#diff-ce5cf6bbfd6f7c5c9a2f0eff3f250a20a53435a8c3ba66675e9b3aa3d2ec3a01R114-L131) [[3]](diffhunk://#diff-ce5cf6bbfd6f7c5c9a2f0eff3f250a20a53435a8c3ba66675e9b3aa3d2ec3a01R143-R179)
* Updated the `remove_tile` method to catch and log `TimeoutError`, `ConnectionError`, and other exceptions, returning `False` instead of letting exceptions propagate.

**Refactoring and code organization:**

* Refactored the `load_tile_metadata` method: moved it to a later position in the file, wrapped Redis calls in a try/except block to handle all relevant exceptions, and ensured the worker does not crash if metadata loading fails. [[1]](diffhunk://#diff-ce5cf6bbfd6f7c5c9a2f0eff3f250a20a53435a8c3ba66675e9b3aa3d2ec3a01R114-L131) [[2]](diffhunk://#diff-ce5cf6bbfd6f7c5c9a2f0eff3f250a20a53435a8c3ba66675e9b3aa3d2ec3a01R143-R179)

**Code cleanup:**

* Removed unnecessary `# type: ignore` comments from the Redis import block.
* Minor whitespace and formatting adjustments for clarity.