### PR TITLE
fix: ImageResult.as_buffer will always return image mode rgba if requested

### DIFF
--- a/mapproxy/image/__init__.py
+++ b/mapproxy/image/__init__.py
@@ -242,7 +242,8 @@ class ImageResult(BaseImageResult):
                 # need actual image_opts.format for next check
                 self.image_opts = self.image_opts.copy()
                 self.image_opts.format = peek_image_format(buf)
-            if self.image_opts and image_opts and self.image_opts.format != image_opts.format:
+            if self.image_opts and image_opts and (
+                    self.image_opts.format != image_opts.format or self.image_opts.mode != image_opts.mode):
                 log.debug('converting image from %s -> %s' % (self.image_opts, image_opts))
                 self.image = self.as_image()
                 self._buf = None
@@ -418,6 +419,9 @@ def img_to_buf(img: Image.Image, image_opts, georef=None) -> BytesIO:
     if (format == 'png' and img.mode != 'RGB'
             and 'transparency' in img.info and isinstance(img.info['transparency'], tuple)):
         del img.info['transparency']
+
+    if image_opts.mode is not None and img.mode != image_opts.mode:
+        img = img.convert(image_opts.mode)
 
     img.save(buf, format, **defaults)
     buf.seek(0)

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -191,6 +191,34 @@ class TestImageResult(object):
         img = Image.open(ir.as_buffer())
         assert img.mode == "P"
 
+    def test_rgb_image_as_buffer_with_rgba_mode(self):
+        # Regression test for https://github.com/mapproxy/mapproxy/issues/1354
+        # When mode=RGBA is requested, an RGB source image must be returned as
+        # RGBA PNG, not RGB PNG, regardless of whether it contains transparency.
+        img = Image.new("RGB", (10, 10), (255, 0, 0))
+        ir = ImageResult(img, image_opts=PNG_FORMAT)
+        rgba_opts = ImageOptions(mode="RGBA", transparent=True, format="image/png")
+        result = Image.open(ir.as_buffer(rgba_opts))
+        assert result.mode == "RGBA", (
+            "Expected RGBA PNG when mode=RGBA requested, got %s" % result.mode
+        )
+
+    def test_rgb_buf_as_buffer_with_rgba_mode(self):
+        # Regression test for https://github.com/mapproxy/mapproxy/issues/1354
+        # When an upstream source returns an opaque RGB PNG buffer and mode=RGBA
+        # is explicitly configured, as_buffer must re-encode to RGBA, not pass
+        # through the RGB bytes unchanged.
+        src = BytesIO()
+        Image.new("RGB", (10, 10), (255, 0, 0)).save(src, "png")
+        src.seek(0)
+        src_opts = ImageOptions(format="image/png", transparent=False)
+        ir = ImageResult(src, image_opts=src_opts)
+        rgba_opts = ImageOptions(mode="RGBA", transparent=True, format="image/png")
+        result = Image.open(ir.as_buffer(rgba_opts))
+        assert result.mode == "RGBA", (
+            "Expected RGBA PNG when mode=RGBA requested, got %s" % result.mode
+        )
+
 
 class TestSubImageResult(object):
 
@@ -488,6 +516,22 @@ class TestLayerMerge(object):
         result = merge_images([(img1, None), (img2, None)], ImageOptions(transparent=False))
         img = result.as_image()
         assert img.getpixel((0, 0)) == (255, 0, 255)
+
+    def test_single_opaque_rgb_layer_with_rgba_output(self):
+        # Regression test for https://github.com/mapproxy/mapproxy/issues/1354
+        # A single fully-opaque RGB source layer must produce an RGBA PNG when
+        # the requested ImageOptions specify mode=RGBA / transparent=True.
+        # Previously the single-layer shortcut in LayerMerger.merge() returned
+        # the source layer unchanged, so the RGB bytes were passed through
+        # without being converted.
+        source = ImageResult(Image.new("RGB", (10, 10), (255, 0, 0)))
+        rgba_opts = ImageOptions(mode="RGBA", transparent=True, format="image/png")
+        result = merge_images([(source, None)], rgba_opts)
+        output = Image.open(result.as_buffer(rgba_opts))
+        assert output.mode == "RGBA", (
+            "Expected RGBA PNG for opaque source when mode=RGBA requested, got %s"
+            % output.mode
+        )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #1354

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
