### PR TITLE
Improve robustness of FeatureInfoDoc parsing and serialization for HTML / XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ nosetests*.xml
 .cursor/
 .claude/
 .vscode/
+
+# Virtual environments
+venv/

--- a/mapproxy/featureinfo.py
+++ b/mapproxy/featureinfo.py
@@ -15,13 +15,16 @@
 
 from codecs import decode
 import copy
+import logging
 import json
 
 from functools import reduce
-from io import StringIO, BytesIO
+from io import BytesIO
 from typing import Optional, Union
 
 from lxml import etree, html
+
+log = logging.getLogger('mapproxy.featureinfo')
 
 
 class FeatureInfoDoc(object):
@@ -49,7 +52,8 @@ class TextFeatureInfoDoc(FeatureInfoDoc):
 
     @classmethod
     def combine(cls, docs: list[FeatureInfoDoc]):
-        result_content = [doc.as_string() for doc in docs]
+        result_content = [s for doc in docs if (s := doc.as_string())]
+
         return cls("\n".join(result_content))
 
 
@@ -77,26 +81,40 @@ class XMLFeatureInfoDoc(FeatureInfoDoc):
 
     def as_etree(self):
         if self._etree is None:
-            self._etree = self._parse_content()
+            try:
+                self._etree = self._parse_content()
+            except (ValueError, etree.XMLSyntaxError):
+                log.warning("Failed to parse content as XML / HTML, returning empty element tree")
+
         return self._etree
 
     def _serialize_etree(self) -> Union[str, bytes]:
         _etree = self.as_etree()
+        if _etree is None:
+            log.warning("Failed to serialize content as XML / HTML, returning empty string")
+            return ""
         encoding = _etree.docinfo.encoding if \
             _etree.docinfo.encoding else self.defaultEncoding
         as_string = etree.tostring(_etree, encoding=encoding, xml_declaration=False)
         return decode(as_string, encoding)  # type: ignore[arg-type]
 
-    def _parse_content(self):
-        if isinstance(self.content, str) and self.content.lstrip().startswith('<?xml'):
-            # Convert back to bytes if it has XML declaration
-            return etree.parse(BytesIO(self.content.encode('utf-8')))
-        elif isinstance(self.content, str):
-            return etree.parse(StringIO(self.content))
-        elif self.content is not None:
-            return etree.parse(BytesIO(self.content))
-        else:
+    def _get_checked_content(self, encoding: str = defaultEncoding) -> Union[str, bytes]:
+        if self.content is None or not self.content:
             raise ValueError('content is None')
+
+        content: Union[str, bytes] = self.content
+        if isinstance(content, str) and not content:
+            log.debug('content is empty string')
+            raise ValueError('content is empty')
+        if isinstance(content, str):
+            return content.encode(encoding)
+        return content
+
+    def _parse_content(self):
+        content = self._get_checked_content()
+        if isinstance(content, str):
+            return etree.ElementTree(etree.fromstring(content))
+        return etree.parse(BytesIO(content))
 
     @classmethod
     def combine(cls, docs):
@@ -106,7 +124,10 @@ class XMLFeatureInfoDoc(FeatureInfoDoc):
         result_tree = copy.deepcopy(doc.as_etree())
         for doc in docs:
             tree = doc.as_etree()
-            result_tree.getroot().extend(tree.getroot().iterchildren())
+            if tree is not None and tree.getroot() is not None:
+                result_tree.getroot().extend(tree.getroot().iterchildren())
+            else:
+                log.debug("Document has no root element, skipping: %s", doc)
 
         return cls(result_tree)
 
@@ -115,17 +136,18 @@ class HTMLFeatureInfoDoc(XMLFeatureInfoDoc):
     info_type = "html"
 
     def _parse_content(self):
-        if self.content is None:
-            raise ValueError('content is None')
-        root = html.document_fromstring(self.content)
-        return root
+        content = self._get_checked_content()
+
+        root = html.document_fromstring(content)
+        return etree.ElementTree(root)
 
     def _serialize_etree(self):
         if self._etree is None:
-            raise ValueError('etree is None')
+            log.warning("Failed to serialize content as XML / HTML, returning empty string")
+            return ""
         encoding = self._etree.docinfo.encoding if \
             self._etree.docinfo.encoding else self.defaultEncoding
-        return decode(html.tostring(self._etree, encoding=encoding), encoding)
+        return html.tostring(self._etree.getroot(), encoding=encoding)
 
     @classmethod
     def combine(cls, docs):
@@ -133,16 +155,29 @@ class HTMLFeatureInfoDoc(XMLFeatureInfoDoc):
             return TextFeatureInfoDoc.combine(docs)
 
         doc = docs.pop(0)
-        result_tree = copy.deepcopy(doc.as_etree())
+        initial_etree = doc.as_etree()
+        if initial_etree is not None:
+            result_tree = copy.deepcopy(initial_etree)
+        else:
+            result_tree = etree.ElementTree(html.fromstring('<html><body/></html>'))
 
         for doc in docs:
-            tree = doc.as_etree()
+            tree = None
+            try:
+                tree = doc.as_etree()
+            except (ValueError, etree.XMLSyntaxError):
+                log.warning("Failed to parse document as XML / HTML, skipping: %s", doc.content)
+
+            if tree is None:
+                log.warning("Document has no body element, skipping: %s", doc.content)
+                continue
 
             try:
-                body = tree.body.getchildren()
+                body = tree.getroot().body.getchildren()
             except IndexError:
-                body = tree.getchildren()
-            result_tree.body.extend(body)
+                body = tree.getroot().getchildren()
+
+            result_tree.getroot().body.extend(body)
 
         return cls(result_tree)
 

--- a/mapproxy/test/unit/test_featureinfo.py
+++ b/mapproxy/test/unit/test_featureinfo.py
@@ -97,6 +97,14 @@ class TestXMLFeatureInfoDocs(object):
         doc = XMLFeatureInfoDoc("<root>hello</root>")
         assert doc.as_etree().getroot().text == "hello"
 
+    def test_bytes(self):
+        doc = XMLFeatureInfoDoc(b"<p>hello</p>")
+        assert doc.as_etree().getroot().text == "hello"
+
+    def test_empty_response(self):
+        doc = XMLFeatureInfoDoc("")
+        assert doc.as_etree() is None
+
     def test_umlauts(self):
         doc = XMLFeatureInfoDoc('<root>öäüß</root>')
         assert doc.as_etree().getroot().text == 'öäüß'
@@ -110,6 +118,7 @@ class TestXMLFeatureInfoDocs(object):
             XMLFeatureInfoDoc("<root><a>foo</a></root>"),
             XMLFeatureInfoDoc("<root><b>bar</b></root>"),
             XMLFeatureInfoDoc("<other_root><a>baz</a></other_root>"),
+            XMLFeatureInfoDoc("")
         ]
         result = XMLFeatureInfoDoc.combine(docs)
 
@@ -137,6 +146,7 @@ class TestXMLFeatureInfoDocsNoLXML(object):
             XMLFeatureInfoDoc(b"<root><a>foo</a></root>"),
             XMLFeatureInfoDoc(b"<root><b>bar</b></root>"),
             XMLFeatureInfoDoc(b"<other_root><a>baz</a></other_root>"),
+            XMLFeatureInfoDoc(b""),
         ]
         result = XMLFeatureInfoDoc.combine(docs)
 
@@ -158,11 +168,26 @@ class TestHTMLFeatureInfoDocs(object):
         doc = HTMLFeatureInfoDoc("<p>hello</p>")
         assert doc.as_etree().find("body/p").text == "hello"
 
+    def test_bytes(self):
+        doc = HTMLFeatureInfoDoc(b"<p>hello</p>")
+        assert doc.as_etree().find("body/p").text == "hello"
+
+    def test_broken_html(self):
+        # see documentation of lxml (https://lxml.de/parsing.html#parsing-html)
+        broken_html = "<html><head><title>test</title><body><h1>page title</h3>"
+        doc = HTMLFeatureInfoDoc(broken_html)
+        assert doc.as_etree().find(".//h1").text == "page title"
+
+    def test_empty_response(self):
+        doc = HTMLFeatureInfoDoc("")
+        assert doc.as_etree() is None
+
     def test_combine(self):
         docs = [
             HTMLFeatureInfoDoc(b"<html><head><title>Hello</title></head><body><p>baz</p><p>baz2</body></html>"),
             HTMLFeatureInfoDoc(b"<p>foo</p>"),
             HTMLFeatureInfoDoc(b"<body><p>bar</p></body>"),
+            HTMLFeatureInfoDoc(b""),
         ]
         result = HTMLFeatureInfoDoc.combine(docs)
         assert "<title>Hello</title>" in result.as_string()
@@ -172,11 +197,42 @@ class TestHTMLFeatureInfoDocs(object):
         )
         assert result.info_type == "html"
 
-    def test_combine_parts(self):
+    def test_combine_parts_empty_last(self):
         docs = [
             HTMLFeatureInfoDoc("<p>foo</p>"),
             HTMLFeatureInfoDoc("<body><p>bar</p></body>"),
             HTMLFeatureInfoDoc("<html><head><title>Hello</title></head><body><p>baz</p><p>baz2</body></html>"),
+            HTMLFeatureInfoDoc(""),
+        ]
+        result = HTMLFeatureInfoDoc.combine(docs)
+
+        assert (
+            "<body><p>foo</p><p>bar</p><p>baz</p><p>baz2</p></body>"
+            in result.as_string()
+        )
+        assert result.info_type == "html"
+
+    def test_combine_parts_empty_first(self):
+        docs = [
+            HTMLFeatureInfoDoc(""),
+            HTMLFeatureInfoDoc("<p>foo</p>"),
+            HTMLFeatureInfoDoc("<body><p>bar</p></body>"),
+            HTMLFeatureInfoDoc("<html><head><title>Hello</title></head><body><p>baz</p><p>baz2</body></html>"),
+        ]
+        result = HTMLFeatureInfoDoc.combine(docs)
+
+        assert (
+            "<body><p>foo</p><p>bar</p><p>baz</p><p>baz2</p></body>"
+            in result.as_string()
+        )
+        assert result.info_type == "html"
+
+    def test_combine_parts_empty_inbetween(self):
+        docs = [
+            HTMLFeatureInfoDoc("<p>foo</p>"),
+            HTMLFeatureInfoDoc("<body><p>bar</p></body>"),
+            HTMLFeatureInfoDoc(""),
+            HTMLFeatureInfoDoc("<html><head><title>Hello</title></head><body><p>baz</p><p>baz2</body></html>")
         ]
         result = HTMLFeatureInfoDoc.combine(docs)
 
@@ -204,6 +260,7 @@ class TestHTMLFeatureInfoDocsNoLXML(object):
         docs = [
             HTMLFeatureInfoDoc(b"<html><head><title>Hello<body><p>baz</p><p>baz2"),
             HTMLFeatureInfoDoc(b"<p>foo</p>"),
+            HTMLFeatureInfoDoc(b""),
             HTMLFeatureInfoDoc(b"<body><p>bar</p></body>"),
         ]
         result = HTMLFeatureInfoDoc.combine(docs)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -27,7 +27,7 @@ jsonpickle==4.1.1
 jsonpointer==2.4
 jsonschema==4.20
 junit-xml==1.9
-lxml==6.0.2
+lxml==6.1.1
 lxml-stubs==0.5.1
 MarkupSafe==1.1.1
 mock==5.1.0


### PR DESCRIPTION
In this PR, the robustness of FeatureInfoDoc parsing and serialization for HTML / XML is improved. Instead of raising exceptions on bad input, the code now logs warnings and returns safe empty defaults, allowing combine operations to skip invalid documents gracefully.

**Changes**

* Consolidated content validation and unified ElementTree return types across `XMLFeatureInfoDoc` and `HTMLFeatureInfoDoc`
* Fixed double UTF-8 encoding of special characters during HTML serialization
* Extended test coverage for edge cases: empty input, bytes input, broken HTML, and empty documents within combine() calls
* Upgraded lxml `6.0.2` → `6.1.1`

Please review

<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
