### PR TITLE
Fix WMTS demo passing matrix IDs instead of resolutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ nosetests*.xml
 .pydevproject
 .tox/
 /cache_data/
-
+venv/
 .idea/
 *.iml
 .cursor/

--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -352,11 +352,13 @@ class DemoServer(Server):
         background_url = base_config().background.url
         if self.background:
             background_url = self.background["url"]
+
+        res = [wmts_layer.grid.resolutions[k] for k in list(wmts_layer.grid.resolutions)]
         return template.substitute(layer=wmts_layer,
                                    matrix_set=wmts_layer.grid.name,
                                    format=escape_html(req.args['format']),
                                    srs=escape_html(req.args['srs']),
-                                   resolutions=wmts_layer.grid.resolutions,
+                                   resolutions=res,
                                    units=units,
                                    all_tile_layers=self.tile_layers,
                                    rest_enabled=rest_enabled,


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

WMTS tilegrids use `NamedGridList` consisting of an array of mappings for `matrixId` and `resolution`. Due to typing changes and refactorings, the matrix IDs are passed to the WMTS demo instead of the resolutions, leading to a broken map. This PR fixes this.


