### PR TITLE
fix: WMTS demo page throws "resolutions must be sorted in descending order" in OpenLayers

### DIFF
--- a/mapproxy/service/demo.py
+++ b/mapproxy/service/demo.py
@@ -356,7 +356,7 @@ class DemoServer(Server):
                                    matrix_set=wmts_layer.grid.name,
                                    format=escape_html(req.args['format']),
                                    srs=escape_html(req.args['srs']),
-                                   resolutions=wmts_layer.grid.resolutions,
+                                   resolutions=list(wmts_layer.grid.resolutions.values()),
                                    units=units,
                                    all_tile_layers=self.tile_layers,
                                    rest_enabled=rest_enabled,


### PR DESCRIPTION
Opening any layer in the WMTS demo page raises a JavaScript error in the browser console and the map never renders:

```
Uncaught (in promise) Error: `resolutions` must be sorted in descending order
    at Mt (ol.js:1:12171)
    at new fd (ol.js:1:236178)
    at new pd (ol.js:1:241085)
    at init (demo/?wmts_layer=imagery&format=webp&srs=EPSG%3A3857:82:23)
```

Every layer and every SRS is affected. The bug was introduced in 6.1.0 and is also present on current `master`.

**Root Cause**

`_render_wmts_template` passes `wmts_layer.grid.resolutions` (a `NamedGridList`) directly to the Mako template:

```python
resolutions=wmts_layer.grid.resolutions,
```

The template iterates it to build the JavaScript resolutions array:

```html
const resolutions = [{{ ', '.join(str(r) for r in resolutions) }}];
```

In 6.1.0, `ImmutableDictList` was refactored to extend `Mapping[Hashable, V]`. The `Mapping` contract requires `__iter__` to yield **keys**. `NamedGridList` stores resolutions with zero-padded string keys (`'00'`, `'01'`, ...), so iterating now yields those key strings instead of the resolution floats. The generated JavaScript becomes:

```javascript
// broken: ascending key integers, not resolution floats
const resolutions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
```

OpenLayers validates that `resolutions` is strictly descending and throws the error. Note that `_render_tms_template` in the same file was unaffected because it already explicitly extracts values via `for level, resolution in resolutions`.

**Fix**

Call `.values()` before passing to the template, making `_render_wmts_template` consistent with `_render_tms_template`:

```python
resolutions=list(wmts_layer.grid.resolutions.values()),
```

**Testing**

Verified against a MapProxy instance serving MBTiles layers via WMTS. After the fix, the demo page renders correctly for all layers and all SRS options.
