### PR TITLE
Fix: OGC API URL Handling for Multi-Instance Deployments

### DIFF
--- a/mapproxy/service/ogcapi/api.py
+++ b/mapproxy/service/ogcapi/api.py
@@ -113,9 +113,13 @@ def api(server: OGCAPIServer, req: Request):
 
     oas["info"] = info
 
+    server_url = cfg["server"]["url"]
+    if not req.script_url.endswith("/ogcapi"):
+        server_url = server.create_href(req, "/ogcapi")
+
     oas["servers"] = [
         {
-            "url": cfg["server"]["url"],
+            "url": server_url,
         }
     ]
     server_description = _get(cfg, "metadata", "identification", "description")

--- a/mapproxy/service/ogcapi/server.py
+++ b/mapproxy/service/ogcapi/server.py
@@ -278,6 +278,7 @@ class OGCAPIServer(Server):
                 "type": e.type,
                 "status": e.status,
                 "detail": e.detail,
+                "ogc_api_base": self.create_href(req, "/ogcapi")
             }
             return self.create_json_or_html_response(
                 req, json_resp, "exception.html", status=e.status
@@ -305,6 +306,10 @@ class OGCAPIServer(Server):
     ):
         headers = copy.copy(headers)
         headers.update(self.response_headers)
+
+        # Add the ogc_api_base to the response, so it can be used in the templates and in the JSON response
+        # Needed especially in multi-mapproxy setups
+        json_resp["ogc_api_base"] = self.create_href(req, "/ogcapi")
 
         if self.is_html_req(req):
             content = render_j2_template(

--- a/mapproxy/service/ogcapi/server.py
+++ b/mapproxy/service/ogcapi/server.py
@@ -278,7 +278,6 @@ class OGCAPIServer(Server):
                 "type": e.type,
                 "status": e.status,
                 "detail": e.detail,
-                "ogc_api_base": self.create_href(req, "/ogcapi")
             }
             return self.create_json_or_html_response(
                 req, json_resp, "exception.html", status=e.status
@@ -307,11 +306,12 @@ class OGCAPIServer(Server):
         headers = copy.copy(headers)
         headers.update(self.response_headers)
 
-        # Add the ogc_api_base to the response, so it can be used in the templates and in the JSON response
-        # Needed especially in multi-mapproxy setups
-        json_resp["ogc_api_base"] = self.create_href(req, "/ogcapi")
-
         if self.is_html_req(req):
+            # Add the ogc_api_base to render the HTML response.
+            # In this case it is used in the templates to get the correct
+            # resource urls especially in multi-mapproxy setups
+            json_resp["ogc_api_base"] = self.create_href(req, "/ogcapi")
+
             content = render_j2_template(
                 self.get_pygeoapi_config(req),
                 service_package.__package__,

--- a/mapproxy/service/templates/ogcapi/_base.html
+++ b/mapproxy/service/templates/ogcapi/_base.html
@@ -4,13 +4,13 @@
 {% if config['server']['icon'] %}
 {% set icon = config['server']['icon'] %}
 {% else %}
-{% set icon = config['server']['url'] + '/static/img/favicon.ico' %}
+{% set icon = data['ogc_api_base'] + '/static/img/favicon.ico' %}
 {% endif %}
 
 {% if config['server']['logo'] %}
 {% set logo = config['server']['logo'] %}
 {% else %}
-{% set logo = config['server']['url'] + '/static/img/logo.png' %}
+{% set logo = data['ogc_api_base'] + '/static/img/logo.png' %}
 {% endif %}
 
   <head>
@@ -21,8 +21,8 @@
     <meta name="description" content="{{ config['metadata']['identification']['title'] }}">
     <meta name="keywords" content="{{ config['metadata']['identification']['keywords']|join(',') }}">
     <link rel="shortcut icon" href="{{ icon }}" type="image/x-icon">
-    <link rel="stylesheet" href="{{ config['server']['url'] }}/static/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ config['server']['url'] }}/static/css/default.css">
+    <link rel="stylesheet" href="{{ data['ogc_api_base'] }}/static/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ data['ogc_api_base'] }}/static/css/default.css">
     <meta name="twitter:image:src"   content="{% block thumb %}{% endblock %}{% if not self.thumb() %}{{ logo }}{% endif %}" />
     <meta property="og:image"        content="{{ self.thumb() }}{% if not self.thumb() %}{{ logo }}{% endif %}" />
     <meta name="twitter:site"        content="{{ config['metadata']['identification']['title'] }}" />
@@ -48,7 +48,7 @@
   <div class="bg-light sticky-top border-bottom">
     <div class="container">
       <header class="d-flex flex-wrap align-items-center py-3 justify-content-between">
-        <a href="{{ config['server']['url'] }}"
+        <a href="{{ data['ogc_api_base'] }}"
           class="d-flex align-items-center mb-3 mb-md-0 text-dark text-decoration-none">
           <img src="{{ logo }}"
             title="{{ config['metadata']['identification']['title'] }}" style="height:40px;vertical-align: middle;" /></a>
@@ -60,7 +60,7 @@
           {% endif %}
           {% if config['server']['admin'] %}
           <li class="nav-item">
-            <a href="{{ config['server']['url'] }}/admin/config" class="nav-link" aria-current="page">{% trans %}Admin{% endtrans %}</a>
+            <a href="{{ data['ogc_api_base'] }}/admin/config" class="nav-link" aria-current="page">{% trans %}Admin{% endtrans %}</a>
           </li>
          {% endif %}
           <!--
@@ -76,7 +76,7 @@
       <div class="row">
         <div class="col-sm-12">
         {% block crumbs %}
-        <a href="{{ config['server']['url'] }}">{% trans %}Home{% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}">{% trans %}Home{% endtrans %}</a>
         {% endblock %}
         <span style="float: inline-end">
           {% set links_found = namespace(json=0, jsonld=0) %}
@@ -114,10 +114,10 @@
     <footer class="sticky-bottom bg-light d-flex justify-content-center align-items-center py-3 px-3 border-top">
       <div class="text-center w-100">
         {% trans %}Powered by {% endtrans %}
-        <a title="mapproxy" href="https://mapproxy.org/"><img src="{{ config['server']['url'] }}/static/img/logo.png" class="mx-1" title="mapproxy logo" style="height:24px;vertical-align: middle;" /> MapProxy</a>
+        <a title="mapproxy" href="https://mapproxy.org/"><img src="{{ data['ogc_api_base'] }}/static/img/logo.png" class="mx-1" title="mapproxy logo" alt="mapproxy logo" style="height:24px;vertical-align: middle;" /> MapProxy</a>
         {{ version }}
         <br>
-        (HTML theming based on <a title="mapproxy" href="https://pygeoapi.io/"><img src="/ogcapi/static/img/pygeoapi-logo.png" class="mx-1" title="pygeoapi logo" style="height:24px;vertical-align: middle;" /></a>)
+        (HTML theming based on <a title="mapproxy" href="https://pygeoapi.io/"><img src="{{ data['ogc_api_base'] }}/static/img/pygeoapi-logo.png" class="mx-1" title="pygeoapi logo" alt="pygeoapi logo" style="height:24px;vertical-align: middle;" /></a>)
       </div>
     </footer>
     {% block extrafoot %}

--- a/mapproxy/service/templates/ogcapi/collections/collection.html
+++ b/mapproxy/service/templates/ogcapi/collections/collection.html
@@ -9,9 +9,9 @@
 
 {% block extrahead %}
 
-<script src="{{ config['server']['url'] }}/static/ol.js"></script>
-<script src="{{ config['server']['url'] }}/static/proj4.min.js"></script>
-<link rel="stylesheet" href="{{ config['server']['url'] }}/static/ol.css"/>
+<script src="{{ data['ogc_api_base'] }}/static/ol.js"></script>
+<script src="{{ data['ogc_api_base'] }}/static/proj4.min.js"></script>
+<link rel="stylesheet" href="{{ data['ogc_api_base'] }}/static/ol.css"/>
 
 {% endblock %}
 
@@ -93,7 +93,7 @@ let init;
         const extent = {{ data['extent'] }};
 
         if (!ol.proj.get(srs)) {
-            const projDefsUrl = "{{ config['server']['url'] }}/static/proj4defs.js";
+            const projDefsUrl = "{{ data['ogc_api_base'] }}/static/proj4defs.js";
             const allDefs = await import(projDefsUrl);
             const srsNum = srs.indexOf(':') > -1 ? parseInt(srs.split(':')[1]) : parseInt(srs);
             if (!allDefs.defs[srsNum]) {
@@ -155,7 +155,7 @@ let init;
         const storageCrs = "{{ data['storageCrs'] }}";
 
         if (!ol.proj.get(srs)) {
-            const projDefsUrl = "{{ config['server']['url'] }}/static/proj4defs.js";
+            const projDefsUrl = "{{ data['ogc_api_base'] }}/static/proj4defs.js";
             const allDefs = await import(projDefsUrl);
             const srsNum = srs.indexOf(':') > -1 ? parseInt(srs.split(':')[1]) : parseInt(srs);
             if (!allDefs.defs[srsNum]) {

--- a/mapproxy/service/templates/ogcapi/landing_page.html
+++ b/mapproxy/service/templates/ogcapi/landing_page.html
@@ -61,7 +61,7 @@
   <section id="collections">
     <h2>{% trans %}Collections{% endtrans %}</h2>
     <p>
-      <a href="{{ config['server']['url'] }}/collections?f=html">{% trans %}View the collections in this service{% endtrans %}</a>
+      <a href="{{ data['ogc_api_base'] }}/collections?f=html">{% trans %}View the collections in this service{% endtrans %}</a>
     </p>
   </section>
  {% endif %}
@@ -69,7 +69,7 @@
   <section id="collections">
     <h2>{% trans %}SpatioTemporal Assets{% endtrans %}</h2>
     <p>
-      <a href="{{ config['server']['url'] }}/stac?f=html">{% trans %}View the SpatioTemporal Assets in this service{% endtrans %}</a>
+      <a href="{{ data['ogc_api_base'] }}/stac?f=html">{% trans %}View the SpatioTemporal Assets in this service{% endtrans %}</a>
     </p>
   </section>
  {% endif %}
@@ -77,7 +77,7 @@
   <section id="processes">
       <h2>{% trans %}Processes{% endtrans %}</h2>
       <p>
-        <a href="{{ config['server']['url'] }}/processes?f=html">{% trans %}View the processes in this service{% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/processes?f=html">{% trans %}View the processes in this service{% endtrans %}</a>
       </p>
   </section>
   <section id="jobs">
@@ -90,23 +90,23 @@
   <section id="openapi">
       <h2>{% trans %}API Definition{% endtrans %}</h2>
       <p>
-        {% trans %}Documentation{% endtrans %}: <a href="{{ config['server']['url'] }}/api?f=html">{% trans %}Swagger UI{% endtrans %}</a> <a href="{{ config['server']['url'] }}/api?f=html&ui=redoc">{% trans %}ReDoc{% endtrans %}</a>
+        {% trans %}Documentation{% endtrans %}: <a href="{{ data['ogc_api_base'] }}/api?f=html">{% trans %}Swagger UI{% endtrans %}</a> | <a href="{{ data['ogc_api_base'] }}/api?f=html&ui=redoc">{% trans %}ReDoc{% endtrans %}</a>
       </p>
       <p>
-        <a href="{{ config['server']['url'] }}/api?f=json">{% trans %}OpenAPI Document{% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/api?f=json">{% trans %}OpenAPI Document{% endtrans %}</a>
       </p>
   </section>
   <section id="conformance">
       <h2>{% trans %}Conformance{% endtrans %}</h2>
       <p>
-        <a href="{{ config['server']['url'] }}/conformance?f=html">{% trans %}View the conformance classes of this service{% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/conformance?f=html">{% trans %}View the conformance classes of this service{% endtrans %}</a>
       </p>
   </section>
   {% if data['tile'] %}
   <section id="tilematrixsets">
       <h2>{% trans %}Tile Matrix Sets{% endtrans %}</h2>
       <p>
-        <a href="{{ config['server']['url'] }}/tileMatrixSets?f=html">{% trans %}View the Tile Matrix Sets available on this service{% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/tileMatrixSets?f=html">{% trans %}View the Tile Matrix Sets available on this service{% endtrans %}</a>
       </p>
   </section>
   {% endif %}
@@ -114,10 +114,10 @@
   <section id="dataset_map">
       <h2>{% trans %}Dataset maps{% endtrans %}</h2>
       <p>
-        <a href="{{ config['server']['url'] }}/map.png">{% trans %}Default map of the whole dataset (as PNG){% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/map.png">{% trans %}Default map of the whole dataset (as PNG){% endtrans %}</a>
       </p>
       <p>
-        <a href="{{ config['server']['url'] }}/map.jpg">{% trans %}Default map of the whole dataset (as JPEG){% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/map.jpg">{% trans %}Default map of the whole dataset (as JPEG){% endtrans %}</a>
       </p>
   </section>
   {% endif %}
@@ -125,10 +125,10 @@
   <section id="dataset_tiles">
       <h2>{% trans %}Dataset tilesets{% endtrans %}</h2>
       <p>
-        <a href="{{ config['server']['url'] }}/map/tiles?f=html">{% trans %}Default tilesets for the whole dataset (as HTML){% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/map/tiles?f=html">{% trans %}Default tilesets for the whole dataset (as HTML){% endtrans %}</a>
       </p>
       <p>
-        <a href="{{ config['server']['url'] }}/map/tiles?f=json">{% trans %}Default tilesets for the whole dataset (as JSON){% endtrans %}</a>
+        <a href="{{ data['ogc_api_base'] }}/map/tiles?f=json">{% trans %}Default tilesets for the whole dataset (as JSON){% endtrans %}</a>
       </p>
   </section>
   {% endif %}

--- a/mapproxy/service/templates/ogcapi/openapi/redoc.html
+++ b/mapproxy/service/templates/ogcapi/openapi/redoc.html
@@ -4,7 +4,7 @@
     <title>ReDoc - {{ config['metadata']['identification']['title'] }}</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="{{ config['server']['url'] }}/static/fonts_montserra_roboto.css" rel="stylesheet">
+    <link href="{{ data['openapi-document-path'] }}/../static/fonts_montserra_roboto.css" rel="stylesheet">
     <style>
       body {
         margin: 0;
@@ -14,6 +14,6 @@
   </head>
   <body>
     <redoc spec-url='{{ data['openapi-document-path'] }}?f=json'></redoc>
-    <script src="{{ config['server']['url'] }}/static/redoc.standalone.js"> </script>
+    <script src="{{ data['openapi-document-path'] }}/../static/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/mapproxy/service/templates/ogcapi/openapi/swagger.html
+++ b/mapproxy/service/templates/ogcapi/openapi/swagger.html
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI - {{ config['metadata']['identification']['title'] }}</title>
-    <link rel="stylesheet" type="text/css" href="{{ config['server']['url'] }}/static/swagger-ui-dist/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="{{ config['server']['url'] }}/static/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="{{ config['server']['url'] }}/static/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="{{ data['openapi-document-path'] }}/../static/swagger-ui-dist/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="{{ data['openapi-document-path'] }}/../static/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{{ data['openapi-document-path'] }}/../static/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -30,8 +30,8 @@
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="{{ config['server']['url'] }}/static/swagger-ui-dist/swagger-ui-bundle.js"> </script>
-    <script src="{{ config['server']['url'] }}/static/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
+    <script src="{{ data['openapi-document-path'] }}/../static/swagger-ui-dist/swagger-ui-bundle.js"> </script>
+    <script src="{{ data['openapi-document-path'] }}/../static/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region

--- a/mapproxy/service/templates/ogcapi/tilesets/tileset.html
+++ b/mapproxy/service/templates/ogcapi/tilesets/tileset.html
@@ -10,9 +10,9 @@
 {% endblock %}
 
 {% block extrahead %}
-<script src="{{ config['server']['url'] }}/static/ol.js"></script>
-<script src="{{ config['server']['url'] }}/static/proj4.min.js"></script>
-<link rel="stylesheet" href="{{ config['server']['url'] }}/static/ol.css"/>
+<script src="{{ data['ogc_api_base'] }}/static/ol.js"></script>
+<script src="{{ data['ogc_api_base'] }}/static/proj4.min.js"></script>
+<link rel="stylesheet" href="{{ data['ogc_api_base'] }}/static/ol.css"/>
 
 {% endblock %}
 
@@ -54,7 +54,7 @@
         const extent = {{ data['extent'] }};
 
         if (!ol.proj.get(srs)) {
-            const projDefsUrl = "{{ config['server']['url'] }}/static/proj4defs.js";
+            const projDefsUrl = "{{ data['ogc_api_base'] }}/static/proj4defs.js";
             const allDefs = await import(projDefsUrl);
             const srsNum = srs.indexOf(':') > -1 ? parseInt(srs.split(':')[1]) : parseInt(srs);
             if (!allDefs.defs[srsNum]) {


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

This change improves how OGC API base URLs are resolved and propagated throughout the HTML pages, ensuring that generated links, static assets, and OpenAPI definitions correctly reflect the actual request context rather than relying solely on the configured server URL.

Related to https://github.com/mapproxy/mapproxy/issues/1305