### PR TITLE
Restore context manager protocol on ProxyConfiguration (fix #1442)

### DIFF
--- a/mapproxy/config/configuration/proxy.py
+++ b/mapproxy/config/configuration/proxy.py
@@ -186,11 +186,18 @@ class ProxyConfiguration(object):
         self.services = ServiceConfiguration(self.configuration.get('services', {}), context=self)
 
     def configured_services(self):
+        with self:
+            return self.services.services()
+
+    def __enter__(self):
+        # push local base_config onto config stack
         import mapproxy.config.config
         mapproxy.config.config._config.push(self.base_config)
-        services = self.services.services()
+
+    def __exit__(self, type, value, traceback):
+        # pop local base_config from config stack
+        import mapproxy.config.config
         mapproxy.config.config._config.pop()
-        return services
 
     @property
     def base_config(self):

--- a/mapproxy/test/unit/test_conf_loader.py
+++ b/mapproxy/test/unit/test_conf_loader.py
@@ -267,6 +267,30 @@ class TestLayerConfiguration(object):
             assert False, 'expected ConfigurationError'
 
 
+class TestProxyConfigurationContextManager(object):
+    # mapproxy-seed enters the configuration with ``with mapproxy_conf:``;
+    # ProxyConfiguration must therefore support the context manager protocol
+    # (regression: it was lost when the loader was split, see #1442).
+    def test_context_manager_pushes_and_pops_base_config(self):
+        import mapproxy.config.config as mpconfig
+
+        conf = ProxyConfiguration({})
+        before = mpconfig._config.top
+        with conf:
+            assert mpconfig._config.top is conf.base_config
+        assert mpconfig._config.top is before
+
+    def test_context_manager_pops_on_exception(self):
+        import mapproxy.config.config as mpconfig
+
+        conf = ProxyConfiguration({})
+        before = mpconfig._config.top
+        with pytest.raises(ValueError):
+            with conf:
+                raise ValueError
+        assert mpconfig._config.top is before
+
+
 class TestGridConfiguration(object):
     def test_default_grids(self):
         conf = {}


### PR DESCRIPTION
Fixes #1442.

## Problem

`mapproxy-seed` fails with:

```
File "mapproxy/seed/script.py", line 221, in __call__
    with mapproxy_conf:
TypeError: 'ProxyConfiguration' object does not support the context manager protocol
```

## Cause

Before 6.1.0, `ProxyConfiguration` defined `__enter__`/`__exit__`, which push and pop the configuration's local `base_config` onto the global config stack. Splitting `loader.py` into the `configuration` package (6.1.0) moved the class to `configuration/proxy.py` but dropped those two methods, while `seed/script.py` still enters the configuration with `with mapproxy_conf:`.

## Why restore the context manager rather than drop the `with` (cf. #1431)

The `with mapproxy_conf:` block isn't decorative: the seeding workers read the active configuration off the stack. `TileWorkerPool.__init__` calls `conf = base_config()` (`mapproxy/seed/seeder.py:71`) and hands it to every worker. That call only returns the loaded configuration while `base_config` is pushed — i.e. inside the `with` block. Removing the `with` (as in #1431) makes the crash go away but runs seeding against an *un-configured* `base_config`, which is a silent behavior change rather than a fix.

## Change

- Restore `ProxyConfiguration.__enter__`/`__exit__` (identical to the pre-6.1.0 behavior).
- Route `configured_services()` back through `with self:` so the pushed `base_config` is also popped if `services()` raises (the inlined push/pop introduced in the split would leak it on error).

## Tests

Added `TestProxyConfigurationContextManager` (`test_conf_loader.py`): one test asserts the context manager pushes/pops `base_config`, one asserts the stack is restored when the body raises. Both fail on `master` (the original `TypeError`) and pass with the fix.