### PR TITLE
Prepare 6.1.1 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,18 @@
+6.1.1 2026-06-17
+~~~~~~~~~~~~~~~~
+
+Maintenance:
+
+  - Update dependencies
+
+Fixes:
+
+  - ImageResult.as_buffer will always return image mode rgba if requested
+  - Restore context manager protocol on ProxyConfiguration
+  - Fix base path for rendering OGC API HTML pages in multi mapproxy setups
+  - Fix determination of resolutions in WMTS demo
+
+
 6.1.0 2026-06-03
 ~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def long_description(changelog_releases=10):
 
 setup(
     name='MapProxy',
-    version="6.1.0",
+    version="6.1.1",
     description='An accelerating proxy for tile and web map services',
     long_description=long_description(7),
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Maintenance:

  - Update dependencies

Fixes:

  - ImageResult.as_buffer will always return image mode rgba if requested
  - Restore context manager protocol on ProxyConfiguration
  - Fix base path for rendering OGC API HTML pages in multi mapproxy setups
  - Fix determination of resolutions in WMTS demo
