### PR TITLE
Fix `OSError: cannot write mode RGBA as JPEG` in `img_to_buf`

### DIFF
--- a/mapproxy/image/__init__.py
+++ b/mapproxy/image/__init__.py
@@ -423,6 +423,10 @@ def img_to_buf(img: Image.Image, image_opts, georef=None) -> BytesIO:
     if image_opts.mode is not None and img.mode != image_opts.mode:
         img = img.convert(image_opts.mode)
 
+    # JPEG must always be RGB
+    if format == 'jpeg' and img.mode != 'RGB':
+        img = img.convert('RGB')
+
     img.save(buf, format, **defaults)
     buf.seek(0)
     return buf

--- a/mapproxy/image/__init__.py
+++ b/mapproxy/image/__init__.py
@@ -349,12 +349,12 @@ class ReadBufWrapper(object):
 
 def img_has_transparency(img: Image.Image) -> bool:
     if img.mode == 'P':
-        if img.info.get('transparency', False):
-            return True
-        # convert to RGBA and check alpha channel
+        # Convert to RGBA and check the actual alpha channel instead of
+        # relying on img.info['transparency'], which may reference a color
+        # that does not actually appear in the image.
         img = img.convert('RGBA')
     if img.mode == 'RGBA':
-        # any alpha except fully opaque
+        # any alpha except fully opaque (alpha < 255)
         return any(img.histogram()[-256:-1])
     return False
 

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -219,6 +219,38 @@ class TestImageResult(object):
             "Expected RGBA PNG when mode=RGBA requested, got %s" % result.mode
         )
 
+    def test_rgba_source_image_stored_as_jpeg(self):
+        """
+        Regression test: RGBA PNG from transparent WMS source (e.g. basemapde)
+        must not raise OSError when stored to a JPEG cache.
+        The mode=RGBA from image_opts must not override the JPEG-required RGB conversion.
+        """
+        # Simulate what a WMS with transparent=True & format=image/png returns
+        rgba_img = Image.new("RGBA", (256, 256), (100, 150, 200, 255))
+        source_opts = ImageOptions(format="image/png", transparent=True, mode="RGBA")
+        ir = ImageResult(rgba_img, image_opts=source_opts)
+
+        # Cache is configured as JPEG – mode=RGBA must not override the JPEG conversion
+        jpeg_opts = ImageOptions(format="image/jpeg", mode="RGBA")
+        buf = ir.as_buffer(jpeg_opts)
+        assert is_jpeg(buf), "Expected JPEG output when saving RGBA image with JPEG cache opts"
+
+    def test_rgba_image_to_jpeg_via_img_to_buf(self):
+        """
+        img_to_buf must not raise 'cannot write mode RGBA as JPEG'
+        when image_opts.mode='RGBA' and format='jpeg'.
+        """
+        from mapproxy.image import img_to_buf
+
+        rgba_img = Image.new("RGBA", (256, 256), (100, 150, 200, 128))
+        # The critical case: mode=RGBA but format=jpeg
+        opts = ImageOptions(format="image/jpeg", mode="RGBA", transparent=True)
+
+        # Must not raise OSError
+        buf = img_to_buf(rgba_img, image_opts=opts)
+        result = Image.open(buf)
+        assert result.mode == "RGB", "JPEG output must be RGB, not RGBA"
+
 
 class TestSubImageResult(object):
 

--- a/mapproxy/test/unit/test_image.py
+++ b/mapproxy/test/unit/test_image.py
@@ -1095,3 +1095,43 @@ class TestBandMerge(object):
         img = result.as_image()
         assert img.mode == "RGBA"
         assert img.getpixel((0, 0)) == (200, 100, 0, 255)
+
+
+class TestImgHasTransparency(object):
+    """Tests for img_has_transparency"""
+
+    def test_rgb_opaque(self):
+        img = Image.new("RGB", (10, 10), (255, 0, 0))
+        assert not img_has_transparency(img)
+
+    def test_rgba_fully_opaque(self):
+        img = Image.new("RGBA", (10, 10), (255, 0, 0, 255))
+        assert not img_has_transparency(img)
+
+    def test_rgba_with_transparency(self):
+        img = Image.new("RGBA", (10, 10), (255, 0, 0, 255))
+        img.paste((255, 0, 0, 0), (3, 3, 7, 7))
+        assert img_has_transparency(img)
+
+    def test_p_with_transparency_info_but_color_not_used(self):
+        """
+        Regression: P-mode image with transparency info entry, but the
+        transparent color does not appear in the image at all.
+        img_has_transparency should return False, not True.
+        """
+        img = Image.new("RGB", (10, 10), (255, 0, 0)).quantize(256)
+        assert img.mode == "P"
+        pixels = list(img.getdata())
+        assert 1 not in pixels, "palette index 1 must not appear in image for this test to be valid"
+        img.info["transparency"] = 1
+        assert not img_has_transparency(img)
+
+    def test_p_with_actual_transparency(self):
+        """
+        P-mode image where the transparent color actually appears in the image.
+        """
+        img = Image.new("RGBA", (10, 10), (255, 0, 0, 255))
+        img.paste((255, 0, 0, 0), (3, 3, 7, 7))
+        img_p = img.quantize(256)
+        assert img.mode != "P" or img_has_transparency(img_p)
+        assert img_has_transparency(img_p)


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->

When a WMS source returns a transparent PNG and the cache is configured with
`format: mixed` or `format: jpeg`, MapProxy raises:

```
OSError: cannot write mode RGBA as JPEG
```

Related issue: #1446 
