### PR TITLE
fix(image): don't convert JPEG output back to RGBA mode

### DIFF
--- a/mapproxy/image/__init__.py
+++ b/mapproxy/image/__init__.py
@@ -421,7 +421,10 @@ def img_to_buf(img: Image.Image, image_opts, georef=None) -> BytesIO:
         del img.info['transparency']
 
     if image_opts.mode is not None and img.mode != image_opts.mode:
-        img = img.convert(image_opts.mode)
+        # Don't convert JPEG output back to RGBA — Pillow cannot write
+        # RGBA as JPEG (fixes #1446).
+        if not (format == 'jpeg' and image_opts.mode == 'RGBA'):
+            img = img.convert(image_opts.mode)
 
     img.save(buf, format, **defaults)
     buf.seek(0)


### PR DESCRIPTION
When a WMS source returns RGBA images (e.g., transparent PNG) and the cache uses `format: jpeg` or `format: mixed`, `img_to_buf` converts the image to RGB for JPEG encoding at line 401, but then the generic mode conversion at line 423-424 reverts it back to RGBA because `image_opts.mode` is still `'RGBA'`.

This causes Pillow to raise `OSError: cannot write mode RGBA as JPEG`.

Skip the mode conversion when JPEG format requires RGB.

Fixes #1446