### PR TITLE
installing uswgi through pip eliminates python-linking errors

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -78,11 +78,11 @@ FROM base AS nginx
 # use current version of nginx
 ARG NGINX_VERSION=1.25.3
 
-ENV MAPPROXY_ALPINE=true
+ENV PATH="/mapproxy/.local/bin:${PATH}"
 
 USER root:root
 
-RUN apk --no-cache add ca-certificates uwsgi uwsgi-python3 supervisor pcre-dev && \
+RUN apk --no-cache add ca-certificates supervisor pcre-dev && \
   rm -rf /var/cache/apk/*
 
 RUN apk --no-cache add build-base linux-headers openssl-dev wget zlib-dev && \


### PR DESCRIPTION
the mapproxy 6.0.1-version works like a charm, I've started to upgrade to mapproxy 6.1.1 and always got this error:
```
Traceback (most recent call last):
File "/mapproxy/app.py", line 23, in <module>
from mapproxy.wsgiapp import make_wsgi_app
ModuleNotFoundError: No module named 'mapproxy'
```
so I think that's a linking problem:
uWSGI is linked against Python 3.14, but mapproxy is only installed under Python 3.12 

try to resolve this by installing uwsgi through pip (to be honest throw ai against the problem and that was there solution)

please handle with care

closes #1454
