### PR TITLE
Count the partial edge tile in TileGrid.grid_sizes()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+Unreleased
+~~~~~~~~~~
+
+Fixes:
+
+  - Count the partial edge tile in TileGrid.grid_sizes() so a bbox that is not
+    an exact multiple of the tile extent is fully covered
+
+
 7.0.0 2026-07-17
 ~~~~~~~~~~~~~~~~
 

--- a/mapproxy/grid/tile_grid.py
+++ b/mapproxy/grid/tile_grid.py
@@ -252,8 +252,12 @@ class TileGrid(object):
         height = self.bbox[3] - self.bbox[1]
         grids = []
         for idx, res in self.resolutions.items():
-            x = max(math.ceil(width // res / self.tile_size[0]), 1)
-            y = max(math.ceil(height // res / self.tile_size[1]), 1)
+            # Round the tile count before ceil()ing so that a bbox which is not
+            # an exact multiple of the tile extent still gets the partial tile
+            # that covers its edge, while floating point noise (e.g. from sqrt2
+            # resolutions) does not spuriously add an extra empty tile.
+            x = max(math.ceil(round(width / res / self.tile_size[0], 6)), 1)
+            y = max(math.ceil(round(height / res / self.tile_size[1], 6)), 1)
             grids.append((idx, (int(x), int(y))))
         return NamedGridList(grids)
 

--- a/mapproxy/test/unit/test_grid.py
+++ b/mapproxy/test/unit/test_grid.py
@@ -1072,6 +1072,56 @@ class TestTileGrid(object):
             assert False, "Expected TransformationError"
 
 
+class TestGridSizePartialTiles(object):
+    def test_partial_edge_tile_is_counted(self):
+        # bbox is 2560.5 units wide with res 1.0 and 256px tiles, i.e. 10.002
+        # tiles. The partial tile at the right/top edge must be counted so the
+        # grid covers the whole bbox (11 tiles, not 10).
+        grid = TileGrid("EPSG:900913", bbox=(0, 0, 2560.5, 2560.5), res=[1.0])
+        assert grid.grid_sizes[0] == (11, 11)
+
+    def test_partial_edge_tile_is_counted_geographic(self):
+        # A geographic grid with a non-power-of-two resolution: 153.75 deg wide
+        # at res 0.3 with 256px tiles is 512.5 px, i.e. just over two tiles, so
+        # the partial third edge tile must be counted (3, not 2). The coarser,
+        # exactly-fitting levels must stay put and not be inflated by float noise.
+        grid = TileGrid("EPSG:4326", bbox=(-76.875, -76.875, 76.875, 76.875), res=[1.0, 0.5, 0.3])
+        assert grid.grid_sizes[0] == (1, 1)
+        assert grid.grid_sizes[1] == (2, 2)
+        assert grid.grid_sizes[2] == (3, 3)
+
+    @pytest.mark.parametrize(
+        "srs,bbox,origin",
+        [
+            ("EPSG:900913", (0, 0, 2560.5, 2560.5), "ll"),
+            ("EPSG:900913", (0, 0, 2560.5, 2560.5), "ul"),
+            # 153.75 units wide at res 0.3 with 256px tiles is 512.5 px = just
+            # over 2 tiles: the grid must cover 3 tiles, but the buggy floor of
+            # the pixel count drops the partial and only counts 2, leaving the
+            # right/top edge (and any point in it) uncovered.
+            ("EPSG:4326", (-76.875, -76.875, 76.875, 76.875), "ll"),
+            ("EPSG:4326", (-76.875, -76.875, 76.875, 76.875), "ul"),
+        ],
+    )
+    def test_point_inside_bbox_maps_to_existing_tile(self, srs, bbox, origin):
+        # Every point strictly inside the bbox must map to a tile that the grid
+        # actually contains, otherwise the edge of the bbox is left uncovered
+        # (regression for grid_sizes undercounting the partial edge tile).
+        grid = TileGrid(srs, bbox=bbox, res=[1.0, 0.5, 0.3], origin=origin)
+        w, h = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        eps = min(w, h) * 1e-9
+        for z in range(grid.levels):
+            tile = grid.tile_coord_for_point(bbox[2] - eps, bbox[3] - eps, z)
+            assert grid.limit_tile(tile) is not None, (srs, origin, z, tile)
+
+    def test_sqrt2_grid_not_over_counted(self):
+        # sqrt2 resolutions carry float noise (sqrt(2)**2 == 2.0000000000000004);
+        # tile counts on exact-boundary levels must not be inflated by it.
+        grid = tile_grid("EPSG:4326", res_factor="sqrt2")
+        assert grid.grid_sizes[2] == (2, 1)
+        assert grid.grid_sizes[4] == (4, 2)
+
+
 class TestTileGridThreshold(object):
     def test_lower_bound(self):
         # thresholds near the next lower res value


### PR DESCRIPTION
`TileGrid.grid_sizes()` computed the number of tiles per resolution with integer floor division of the pixel span:

```python
x = max(math.ceil(width // res / self.tile_size[0]), 1)
y = max(math.ceil(height // res / self.tile_size[1]), 1)
```

`width // res` floors the pixel count before the division and `ceil`, so when the bbox is not an exact multiple of the tile extent the partial tile covering its edge is dropped and the grid is one tile too small in that dimension. A point inside the bbox but within that edge tile then maps to a tile index that the reported grid size says does not exist.

The fix uses true division and rounds to 6 decimals before `ceil`, so a genuine partial tile is counted while floating-point noise (e.g. from sqrt2 resolutions) does not spuriously add an empty tile:

```python
x = max(math.ceil(round(width / res / self.tile_size[0], 6)), 1)
y = max(math.ceil(round(height / res / self.tile_size[1], 6)), 1)
```

Added tests covering a partial edge tile (projected and geographic), a parametrized check that a point inside the bbox maps to an existing tile, and a sqrt2 grid guard that the count is not inflated.