### PR TITLE
fix(s3): normalize S3 tile keys to forward slashes

### DIFF
--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -96,7 +96,11 @@ class S3Cache(TileCacheBase):
         return f"https://{self.bucket_name}.s3.{self.region_name}.amazonaws.com/{self.tile_key(tile)}"
 
     def tile_key(self, tile):
-        return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
+        # tile locations are built with os.path.join, which uses '\' as separator
+        # on Windows; S3 object keys always use '/' and treat '\' as a literal
+        # character, so keys must be normalized independently of the host OS.
+        location = self._tile_location(tile, self.base_path, self.file_ext)
+        return location.replace('\\', '/').lstrip('/')
 
     def conn(self):
         if boto3 is None:

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ntpath
+
 import pytest
 
+import mapproxy.cache.path
 from mapproxy.extent import MapExtent
 from mapproxy.srs import SRS
 
@@ -91,3 +94,12 @@ class TestS3Cache(TileCacheTestBase):
 
         # raises, if key is missing
         boto3.client("s3").head_object(Bucket=self.bucket_name, Key=key)
+
+    def test_tile_key_windows_separator(self, monkeypatch):
+        # on Windows the tile location is built with backslashes, but S3 object
+        # keys must always use forward slashes
+        monkeypatch.setattr(mapproxy.cache.path.os, 'path', ntpath)
+        cache = S3Cache('/mycache/webmercator', 'png', bucket_name=self.bucket_name, directory_layout='tms')
+
+        assert cache.tile_key(self.create_tile((12345, 67890, 12))) == \
+            'mycache/webmercator/12/12345/67890.png'


### PR DESCRIPTION
Closes #1421

`tile_key()` passed the location built by `os.path.join()` straight through as an S3 object key, so on Windows the key contained backslashes — which S3 treats as literal characters, not separators. Tiles seeded on Windows therefore landed under different keys than the ones any other instance reads.

Backslashes are now normalized to `/` in `tile_key()`, which covers read, write, `is_cached` and removal in one place, leaving the generic path building in `mapproxy/cache/path.py` untouched.

Regression test patches `mapproxy.cache.path.os.path` to `ntpath` to produce a Windows-style location; it fails on master and passes with the fix.
