### PR TITLE
Fix GeoPackage SQLite connection leak (crash after serving 1024 requests)

### DIFF
--- a/mapproxy/cache/geopackage.py
+++ b/mapproxy/cache/geopackage.py
@@ -24,6 +24,7 @@ import time
 from io import BytesIO
 from itertools import groupby
 from typing import Optional
+from contextlib import closing
 
 from mapproxy.cache.tile import TileCollection
 from mapproxy.cache.tile import Tile
@@ -134,7 +135,7 @@ class GeopackageCache(TileCacheBase):
         return True
 
     def _verify_table(self):
-        with self.uncached_db() as db:
+        with closing(self.uncached_db()) as db:
             cur = db.execute("""SELECT name FROM sqlite_master WHERE type='table' AND name=?""",
                              (self.table_name,))
             content = cur.fetchone()
@@ -144,7 +145,7 @@ class GeopackageCache(TileCacheBase):
             return True
 
     def _verify_gpkg_contents(self):
-        with self.uncached_db() as db:
+        with closing(self.uncached_db()) as db:
             cur = db.execute("""SELECT * FROM gpkg_contents WHERE table_name = ?""", (self.table_name,))
 
             results = cur.fetchone()
@@ -168,7 +169,7 @@ class GeopackageCache(TileCacheBase):
             return True
 
     def _verify_tile_size(self):
-        with self.uncached_db() as db:
+        with closing(self.uncached_db()) as db:
             cur = db.execute(
                 """SELECT * FROM gpkg_tile_matrix WHERE table_name = ?""",
                 (self.table_name,))


### PR DESCRIPTION
## Problem

GeoPackage verification opens temporary SQLite connections using:

```python
with self.uncached_db() as db:
```

A `sqlite3.Connection` context manager commits or rolls back the transaction, but does not close the connection. Under sustained tile requests, these connections can accumulate until the process reaches its file-descriptor limit.

Reproduced with Python 3.14, Waitress with 8 threads, and a GeoPackage cache. The process eventually held 1,014 GeoPackage descriptors out of a 1,024-descriptor limit. Requests then failed with:

```text
sqlite3.OperationalError: unable to open database file
```

## Steps to reproduce

1. Configure MapProxy to serve an existing GeoPackage cache.
2. Run MapProxy through a multithreaded WSGI server.
3. Repeatedly request a tile:

```bash
seq 1 200 | xargs -P 12 -I{} \
  curl -sS -o /dev/null \
  'http://127.0.0.1:8181/wmts/layer/grid/6/35/15.png?probe={}'
```

4. Observe the number of open GeoPackage descriptors:

```bash
lsof -p <mapproxy-pid> | grep -c '\.gpkg'
```

The count grows until SQLite can no longer open the database.

## Suggested fix

Wrap temporary verification connections with `contextlib.closing`:

```python
from contextlib import closing

with closing(self.uncached_db()) as db:
    ...
```

This is applied to `_verify_table`, `_verify_gpkg_contents`, and `_verify_tile_size`, ensuring every temporary connection is explicitly closed.

After applying the fix, approximately 1,400 concurrent test requests all returned HTTP 200. The process remained at 9 total file descriptors, with no lingering GeoPackage descriptors.
