### PR TITLE
fix: return None from _query_sources when all sources are blank (#1439)

### DIFF
--- a/mapproxy/cache/tile_creator.py
+++ b/mapproxy/cache/tile_creator.py
@@ -150,6 +150,13 @@ class TileCreator:
             if layer[0] is not None:
                 layers.append(layer)
 
+        if not layers:
+            # all sources returned BlankImageError -- mirror the single-source
+            # path above and signal "nothing produced" with None rather than
+            # merge_images()'s truthy BlankImageResult, so callers relying on
+            # falsiness (e.g. rescale_tiles) see this case the same way.
+            return None
+
         return merge_images(layers, size=query.size, bbox=query.bbox, bbox_srs=query.srs,
                             image_opts=self.tile_mgr.image_opts, merger=self.image_merger)
 

--- a/mapproxy/test/unit/test_cache.py
+++ b/mapproxy/test/unit/test_cache.py
@@ -747,6 +747,37 @@ class TestCacheMapLayer(object):
                {(512, 257, 10), (513, 256, 10), (512, 256, 10), (513, 257, 10)}
         assert result.size == (50, 50)
 
+    def test_query_sources_multiple_sources_all_blank(self, mock_file_cache, tile_locker):
+        # Regression test: TileCreator._query_sources() must return None --
+        # same as the single-source fast path a few lines above it -- when
+        # a cache has >=2 sources and every one of them raises
+        # BlankImageError. Before the fix, the multi-source branch passed an
+        # empty layer list to merge_images(), whose LayerMerger.merge()
+        # returns a *truthy* BlankImageResult for an empty list rather than
+        # None, so callers that check falsiness (both call sites in this
+        # file, and rescale_tiles in TileManager) treated "no source
+        # produced anything" as if real image data had come back.
+        #
+        # Query is the exact out-of-range query from
+        # test_get_map_with_res_range above, which that sibling test proves
+        # is blank for this res_range/grid.
+        grid = TileGrid(SRS(4326), bbox=[-180, -90, 180, 90])
+        res_range = resolution_range(1000, 10)
+        sources = [
+            WMSSource(MockWMSClient(), res_range=res_range),
+            WMSSource(MockWMSClient(), res_range=res_range),
+        ]
+        image_opts = ImageOptions(resampling='nearest')
+        tile_mgr = TileManager(grid, mock_file_cache, sources, 'png',
+                               meta_size=[2, 2], meta_buffer=0, image_opts=image_opts,
+                               locker=tile_locker)
+
+        query = MapQuery(
+            (-20037508.34, -20037508.34, 20037508.34, 20037508.34), (500, 500),
+            SRS(900913), 'png')
+        result = tile_mgr.creator()._query_sources(query)
+        assert result is None
+
 
 class TestCacheMapLayerWithExtent(object):
     @pytest.fixture


### PR DESCRIPTION
## Problem
Fixes #1439. A cache with `upscale_tiles` set upscales correctly with a single source, but silently returns a blank tile instead of upscaling as soon as the cache has two or more sources and all of them are out of resolution range. Confirmed on master HEAD 49de7e7.

## Root cause
`TileCreator._query_sources()` (`mapproxy/cache/tile_creator.py`) has a fast path for a single source that returns `None` on `BlankImageError`. The multi-source path collects per-source results into `layers`, drops the blank ones, then always calls `merge_images(layers, ...)`. When `layers` is empty, `LayerMerger.merge()` returns a *truthy* `BlankImageResult` rather than `None`. Every caller of `_query_sources()` checks falsiness to decide "no source produced anything" (`create_tiles`'s early return, and `TileManager.load_tile_coords`'s `if not created_tiles and self.rescale_tiles:` fallback), so the multi-source blank case is invisible to them: a blank tile gets stored and the upscale path never fires.

## Fix
Added the missing empty-layers guard so the multi-source path returns `None` too, matching the single-source contract. 6 lines added, no API changes.

## How to test
```
$ git stash -- mapproxy/cache/tile_creator.py   # unpatched source, keep the new test
$ pytest mapproxy/test/unit/test_cache.py -k test_query_sources_multiple_sources_all_blank -v
...
E       assert <mapproxy.image.BlankImageResult object at 0x...> is None
1 failed in 0.35s

$ git stash pop   # restore the fix
$ pytest mapproxy/test/unit/test_cache.py -k test_query_sources_multiple_sources_all_blank -v
...
1 passed in 0.42s
```
Full suite: 1820 passed (was 1819 on unpatched master + this new test), same pre-existing 3 failed / 33 errors on both patched and unpatched (missing GDAL/S3-mock deps in my environment, unrelated to this diff). `flake8` and `mypy mapproxy` both clean.

## Backward compatibility
No breaking changes.

---
Assisted-by: Claude (code generation, reviewed and tested locally)