### PR TITLE
fix: sign use_http_get reads so private S3/MinIO buckets work

### DIFF
--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -478,7 +478,10 @@ Available options:
   Defines the directory layout for the tiles (``12/12345/67890.png``, ``L12/R00010932/C00003039.png``, etc.).  See :ref:`cache_file` for available options. Defaults to ``tms`` (e.g. ``12/12345/67890.png``). This cache cache also supports ``reverse_tms`` where tiles are stored as ``y/x/z.format``. See *note* below.
 
 ``use_http_get``:
-  When set to ``true``, requests to S3 ``GetObject`` will be fetched via urllib2 instead of boto, which decreases response times. Defaults to ``false``.
+  When set to ``true``, tiles are read from S3 with a plain HTTP ``GET`` (via ``urllib3``) instead of the boto3 ``GetObject`` API, which decreases response times. Writes still use boto3. Defaults to ``false``.
+
+``username``:
+  Optional S3 access user for a self-hosted endpoint. When set (together with ``endpoint_url`` and ``use_http_get``), it is placed into the read URL path-style as ``{endpoint_url}/{username}:{bucket_name}/{key}``. It is *not* a MapProxy credential and has no paired password — the HTTP ``GET``/``HEAD`` read path is unauthenticated, while boto3 write operations continue to use the standard AWS credential chain (environment, profile, etc.). You can set the default with ``globals.cache.s3.username``.
 
 ``include_grid_name``:
   When set to ``true``, the grid name will be included in the path in the bucket (``[directory]/[grid.name]/[z]/...``). Defaults to ``false``.

--- a/doc/caches.rst
+++ b/doc/caches.rst
@@ -478,7 +478,7 @@ Available options:
   Defines the directory layout for the tiles (``12/12345/67890.png``, ``L12/R00010932/C00003039.png``, etc.).  See :ref:`cache_file` for available options. Defaults to ``tms`` (e.g. ``12/12345/67890.png``). This cache cache also supports ``reverse_tms`` where tiles are stored as ``y/x/z.format``. See *note* below.
 
 ``use_http_get``:
-  When set to ``true``, tiles are read from S3 with a plain HTTP ``GET`` (via ``urllib3``) instead of the boto3 ``GetObject`` API, which decreases response times. Writes still use boto3. Defaults to ``false``.
+  When set to ``true``, tiles are read from S3 with plain HTTP requests via ``urllib3`` — ``HEAD`` for existence/metadata checks and ``GET`` for the tile body — instead of the boto3 ``HeadObject``/``GetObject`` API, which decreases response times. Writes still use boto3. Defaults to ``false``.
 
 ``username``:
   Optional S3 access user for a self-hosted endpoint. When set (together with ``endpoint_url`` and ``use_http_get``), it is placed into the read URL path-style as ``{endpoint_url}/{username}:{bucket_name}/{key}``. It is *not* a MapProxy credential and has no paired password — the HTTP ``GET``/``HEAD`` read path is unauthenticated, while boto3 write operations continue to use the standard AWS credential chain (environment, profile, etc.). You can set the default with ``globals.cache.s3.username``.

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -17,7 +17,6 @@
 import calendar
 import hashlib
 import io
-import os
 import sys
 import threading
 
@@ -25,7 +24,7 @@ import urllib3
 
 from mapproxy.cache.tile import TileCollection
 from mapproxy.cache.tile import Tile
-from mapproxy.image import ImageSource
+from mapproxy.image import ImageResult
 from mapproxy.cache import path
 from mapproxy.cache.base import tile_buffer, TileCacheBase
 from mapproxy.util import async_
@@ -74,7 +73,6 @@ class S3Cache(TileCacheBase):
         self.access_control_list = access_control_list
         self.use_http_get = use_http_get
         self.username = username
-
 
         try:
             self.bucket = self.conn().head_bucket(Bucket=bucket_name)
@@ -180,7 +178,7 @@ class S3Cache(TileCacheBase):
                 if response.status != 200:
                     log.error('S3: load_tile HTTP error, url: %s, status: %s' % (url, response.status))
                     raise Exception('S3 HTTP error %s for url: %s' % (response.status, url))
-                tile.source = ImageSource(io.BytesIO(response.data))
+                tile.image_result = ImageResult(io.BytesIO(response.data))
             except urllib3.exceptions.HTTPError as e:
                 log.error('S3: load_tile request error, url: %s, error: %s' % (url, e))
                 raise
@@ -188,7 +186,7 @@ class S3Cache(TileCacheBase):
             try:
                 r = self.conn().get_object(Bucket=self.bucket_name, Key=key)
                 self._set_metadata(r, tile)
-                tile.source = ImageSource(r['Body'])
+                tile.image_result = ImageResult(r['Body'])
             except botocore.exceptions.ClientError as e:
                 # moto get_object can return Error wrapped in Errors...
                 error = e.response.get('Errors', e.response)['Error']

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -16,20 +16,20 @@
 
 import calendar
 import hashlib
+import io
+import os
 import sys
 import threading
-from typing import Optional
+
+import urllib3
 
 from mapproxy.cache.tile import TileCollection
 from mapproxy.cache.tile import Tile
-from mapproxy.image import ImageResult
+from mapproxy.image import ImageSource
 from mapproxy.cache import path
 from mapproxy.cache.base import tile_buffer, TileCacheBase
 from mapproxy.util import async_
 from mapproxy.util.py import reraise_exception
-from urllib import request as urllib2
-
-from mapproxy.util.coverage import Coverage
 
 try:
     import boto3
@@ -42,6 +42,7 @@ import logging
 log = logging.getLogger('mapproxy.cache.s3')
 
 
+_http = urllib3.PoolManager(block=True)
 _s3_sessions_cache = threading.local()
 
 
@@ -61,9 +62,9 @@ class S3Cache(TileCacheBase):
 
     def __init__(self, base_path, file_ext, directory_layout='tms',
                  bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
-                 _concurrent_writer=4, access_control_list=None, coverage: Optional[Coverage] = None,
-                 use_http_get=False):
-        super().__init__(coverage)
+                 _concurrent_writer=4, access_control_list=None, coverage=None, use_http_get=False,
+                 username=None):
+        super(S3Cache, self).__init__(coverage)
         md5 = hashlib.new('md5', base_path.encode('utf-8') + bucket_name.encode('utf-8'), usedforsecurity=False)
         self.lock_cache_id = md5.hexdigest()
         self.bucket_name = bucket_name
@@ -72,6 +73,8 @@ class S3Cache(TileCacheBase):
         self.endpoint_url = endpoint_url
         self.access_control_list = access_control_list
         self.use_http_get = use_http_get
+        self.username = username
+
 
         try:
             self.bucket = self.conn().head_bucket(Bucket=bucket_name)
@@ -81,7 +84,7 @@ class S3Cache(TileCacheBase):
             elif e.response['Error']['Code'] == '403':
                 raise S3ConnectionError('Access denied. Check your credentials')
             else:
-                raise reraise_exception(
+                reraise_exception(
                     S3ConnectionError('Unknown error: %s' % e),
                     sys.exc_info(),
                 )
@@ -93,7 +96,16 @@ class S3Cache(TileCacheBase):
         self._tile_location, _ = path.location_funcs(layout=directory_layout)
 
     def get_bucket_url(self, tile):
-        return f"https://{self.bucket_name}.s3.{self.region_name}.amazonaws.com/{self.tile_key(tile)}"
+        key = self.tile_key(tile)
+        if self.endpoint_url:
+            # Self-hosted S3: scheme is taken from endpoint_url
+            base = self.endpoint_url.rstrip('/')
+            if self.username:
+                return f"{base}/{self.username}:{self.bucket_name}/{key}"
+            return f"{base}/{self.bucket_name}/{key}"
+        else:
+            # AWS S3: always HTTPS
+            return f"https://{self.bucket_name}.s3.{self.region_name}.amazonaws.com/{key}"
 
     def tile_key(self, tile):
         return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
@@ -108,7 +120,7 @@ class S3Cache(TileCacheBase):
         except Exception as e:
             raise S3ConnectionError('Error during connection %s' % e)
 
-    def load_tile_metadata(self, tile: Tile, dimensions=None):
+    def load_tile_metadata(self, tile, dimensions=None):
         if tile.timestamp:
             return
         self.is_cached(tile, dimensions=dimensions)
@@ -119,16 +131,21 @@ class S3Cache(TileCacheBase):
         if 'ContentLength' in response:
             tile.size = response['ContentLength']
 
-    def is_cached(self, tile: Tile, dimensions=None) -> bool:
+    def is_cached(self, tile, dimensions=None):
         if tile.is_missing():
             if self.use_http_get:
+                url = self.get_bucket_url(tile)
                 try:
-                    req = urllib2.Request(self.get_bucket_url(tile))
-                    response = urllib2.urlopen(req)
-                    self._set_metadata(response.info(), tile)
-                except urllib2.HTTPError as e:
-                    if e.code == 403:
+                    response = _http.request('HEAD', url)
+                    if response.status in (403, 404):
+                        log.debug('S3: is_cached HTTP %s, url: %s' % (response.status, url))
                         return False
+                    if response.status != 200:
+                        log.error('S3: is_cached HTTP error, url: %s, status: %s' % (url, response.status))
+                        raise Exception('S3 HTTP error %s for url: %s' % (response.status, url))
+                    self._set_metadata(response.headers, tile)
+                except urllib3.exceptions.HTTPError as e:
+                    log.error('S3: is_cached request error, url: %s, error: %s' % (url, e))
                     raise
             else:
                 key = self.tile_key(tile)
@@ -142,11 +159,11 @@ class S3Cache(TileCacheBase):
 
         return True
 
-    def load_tiles(self, tiles: TileCollection, with_metadata=True, dimensions=None) -> bool:
+    def load_tiles(self, tiles: TileCollection, with_metadata=True, dimensions=None):
         p = async_.Pool(min(4, len(tiles)))
         return all(p.map(self.load_tile, tiles))
 
-    def load_tile(self, tile: Tile, with_metadata=True, dimensions=None) -> bool:
+    def load_tile(self, tile: Tile, with_metadata=True, dimensions=None):
         if not tile.is_missing():
             return True
 
@@ -154,18 +171,24 @@ class S3Cache(TileCacheBase):
         log.debug('S3:load_tile, key: %s' % key)
 
         if self.use_http_get:
+            url = self.get_bucket_url(tile)
             try:
-                req = urllib2.Request(self.get_bucket_url(tile))
-                tile.image_result = ImageResult(urllib2.urlopen(req))
-            except urllib2.HTTPError as e:
-                if e.code == 403:
+                response = _http.request('GET', url)
+                if response.status in (403, 404):
+                    log.debug('S3: load_tile HTTP %s, url: %s' % (response.status, url))
                     return False
+                if response.status != 200:
+                    log.error('S3: load_tile HTTP error, url: %s, status: %s' % (url, response.status))
+                    raise Exception('S3 HTTP error %s for url: %s' % (response.status, url))
+                tile.source = ImageSource(io.BytesIO(response.data))
+            except urllib3.exceptions.HTTPError as e:
+                log.error('S3: load_tile request error, url: %s, error: %s' % (url, e))
                 raise
         else:
             try:
                 r = self.conn().get_object(Bucket=self.bucket_name, Key=key)
                 self._set_metadata(r, tile)
-                tile.image_result = ImageResult(r['Body'])
+                tile.source = ImageSource(r['Body'])
             except botocore.exceptions.ClientError as e:
                 # moto get_object can return Error wrapped in Errors...
                 error = e.response.get('Errors', e.response)['Error']

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -19,6 +19,7 @@ import hashlib
 import io
 import sys
 import threading
+from email.utils import parsedate_to_datetime
 
 import urllib3
 
@@ -41,7 +42,11 @@ import logging
 log = logging.getLogger('mapproxy.cache.s3')
 
 
-_http = urllib3.PoolManager(block=True)
+# urllib3's default maxsize=1 keeps a single pooled connection per host, so with
+# block=True the concurrent tile fetches issued by load_tiles/store_tiles
+# (async_.Pool) would serialize behind that one connection. Size the pool so the
+# HTTP-GET fan-out isn't throttled to a single connection.
+_http = urllib3.PoolManager(maxsize=10, block=True)
 _s3_sessions_cache = threading.local()
 
 
@@ -82,7 +87,7 @@ class S3Cache(TileCacheBase):
             elif e.response['Error']['Code'] == '403':
                 raise S3ConnectionError('Access denied. Check your credentials')
             else:
-                reraise_exception(
+                raise reraise_exception(
                     S3ConnectionError('Unknown error: %s' % e),
                     sys.exc_info(),
                 )
@@ -118,18 +123,30 @@ class S3Cache(TileCacheBase):
         except Exception as e:
             raise S3ConnectionError('Error during connection %s' % e)
 
-    def load_tile_metadata(self, tile, dimensions=None):
+    def load_tile_metadata(self, tile: Tile, dimensions=None):
         if tile.timestamp:
             return
         self.is_cached(tile, dimensions=dimensions)
 
     def _set_metadata(self, response, tile):
+        # boto3 responses expose LastModified (datetime) / ContentLength (int);
+        # the urllib3 HTTP-GET path passes raw HTTP headers instead, which use
+        # Last-Modified / Content-Length. Handle both so metadata is populated
+        # on either path.
         if 'LastModified' in response:
             tile.timestamp = calendar.timegm(response['LastModified'].timetuple())
-        if 'ContentLength' in response:
-            tile.size = response['ContentLength']
+        elif 'Last-Modified' in response:
+            tile.timestamp = calendar.timegm(parsedate_to_datetime(response['Last-Modified']).timetuple())
 
-    def is_cached(self, tile, dimensions=None):
+        if 'ContentLength' in response:
+            tile.size = int(response['ContentLength'])
+        elif 'Content-Length' in response:
+            try:
+                tile.size = int(response['Content-Length'])
+            except (TypeError, ValueError):
+                pass
+
+    def is_cached(self, tile: Tile, dimensions=None) -> bool:
         if tile.is_missing():
             if self.use_http_get:
                 url = self.get_bucket_url(tile)
@@ -157,11 +174,11 @@ class S3Cache(TileCacheBase):
 
         return True
 
-    def load_tiles(self, tiles: TileCollection, with_metadata=True, dimensions=None):
+    def load_tiles(self, tiles: TileCollection, with_metadata=True, dimensions=None) -> bool:
         p = async_.Pool(min(4, len(tiles)))
         return all(p.map(self.load_tile, tiles))
 
-    def load_tile(self, tile: Tile, with_metadata=True, dimensions=None):
+    def load_tile(self, tile: Tile, with_metadata=True, dimensions=None) -> bool:
         if not tile.is_missing():
             return True
 

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -68,7 +68,7 @@ class S3Cache(TileCacheBase):
                  bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
                  _concurrent_writer=4, access_control_list=None, coverage=None, use_http_get=False,
                  username=None):
-        super(S3Cache, self).__init__(coverage)
+        super().__init__(coverage)
         md5 = hashlib.new('md5', base_path.encode('utf-8') + bucket_name.encode('utf-8'), usedforsecurity=False)
         self.lock_cache_id = md5.hexdigest()
         self.bucket_name = bucket_name
@@ -136,7 +136,10 @@ class S3Cache(TileCacheBase):
         if 'LastModified' in response:
             tile.timestamp = calendar.timegm(response['LastModified'].timetuple())
         elif 'Last-Modified' in response:
-            tile.timestamp = calendar.timegm(parsedate_to_datetime(response['Last-Modified']).timetuple())
+            # utctimetuple() normalizes tz-aware datetimes to UTC before
+            # calendar.timegm (which assumes UTC); timetuple() would drop the
+            # offset and skew timestamps for non-GMT Last-Modified headers.
+            tile.timestamp = calendar.timegm(parsedate_to_datetime(response['Last-Modified']).utctimetuple())
 
         if 'ContentLength' in response:
             tile.size = int(response['ContentLength'])
@@ -157,7 +160,7 @@ class S3Cache(TileCacheBase):
                         return False
                     if response.status != 200:
                         log.error('S3: is_cached HTTP error, url: %s, status: %s' % (url, response.status))
-                        raise Exception('S3 HTTP error %s for url: %s' % (response.status, url))
+                        raise S3ConnectionError('S3 HTTP error %s for url: %s' % (response.status, url))
                     self._set_metadata(response.headers, tile)
                 except urllib3.exceptions.HTTPError as e:
                     log.error('S3: is_cached request error, url: %s, error: %s' % (url, e))

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -19,7 +19,9 @@ import hashlib
 import io
 import sys
 import threading
+from datetime import datetime
 from email.utils import parsedate_to_datetime
+from typing import Optional
 
 import urllib3
 
@@ -30,6 +32,8 @@ from mapproxy.cache import path
 from mapproxy.cache.base import tile_buffer, TileCacheBase
 from mapproxy.util import async_
 from mapproxy.util.py import reraise_exception
+
+from mapproxy.util.coverage import Coverage
 
 try:
     import boto3
@@ -66,8 +70,8 @@ class S3Cache(TileCacheBase):
 
     def __init__(self, base_path, file_ext, directory_layout='tms',
                  bucket_name='mapproxy', profile_name=None, region_name=None, endpoint_url=None,
-                 _concurrent_writer=4, access_control_list=None, coverage=None, use_http_get=False,
-                 username=None):
+                 _concurrent_writer=4, access_control_list=None, coverage: Optional[Coverage] = None,
+                 use_http_get=False, username=None):
         super().__init__(coverage)
         md5 = hashlib.new('md5', base_path.encode('utf-8') + bucket_name.encode('utf-8'), usedforsecurity=False)
         self.lock_cache_id = md5.hexdigest()
@@ -130,24 +134,28 @@ class S3Cache(TileCacheBase):
 
     def _set_metadata(self, response, tile):
         # boto3 responses expose LastModified (datetime) / ContentLength (int);
-        # the urllib3 HTTP-GET path passes raw HTTP headers instead, which use
-        # Last-Modified / Content-Length. Handle both so metadata is populated
-        # on either path.
-        if 'LastModified' in response:
-            tile.timestamp = calendar.timegm(response['LastModified'].timetuple())
-        elif 'Last-Modified' in response:
-            # utctimetuple() normalizes tz-aware datetimes to UTC before
-            # calendar.timegm (which assumes UTC); timetuple() would drop the
-            # offset and skew timestamps for non-GMT Last-Modified headers.
-            tile.timestamp = calendar.timegm(parsedate_to_datetime(response['Last-Modified']).utctimetuple())
-
-        if 'ContentLength' in response:
-            tile.size = int(response['ContentLength'])
-        elif 'Content-Length' in response:
+        # the urllib3 HTTP-GET path passes raw HTTP headers instead, which spell
+        # the same two values Last-Modified / Content-Length. Only the key
+        # spelling and the value type differ, so normalize both spellings to the
+        # same handling instead of treating the paths differently.
+        last_modified = response.get('LastModified', response.get('Last-Modified'))
+        if last_modified is not None:
             try:
-                tile.size = int(response['Content-Length'])
-            except (TypeError, ValueError):
-                pass
+                if not isinstance(last_modified, datetime):
+                    last_modified = parsedate_to_datetime(last_modified)
+                # utctimetuple() normalizes tz-aware datetimes to UTC before
+                # calendar.timegm (which assumes UTC); timetuple() would drop
+                # the offset and skew non-UTC timestamps.
+                tile.timestamp = calendar.timegm(last_modified.utctimetuple())
+            except (TypeError, ValueError) as e:
+                log.warning('S3: ignoring unparsable last-modified %r: %s' % (last_modified, e))
+
+        content_length = response.get('ContentLength', response.get('Content-Length'))
+        if content_length is not None:
+            try:
+                tile.size = int(content_length)
+            except (TypeError, ValueError) as e:
+                log.warning('S3: ignoring unparsable content-length %r: %s' % (content_length, e))
 
     def is_cached(self, tile: Tile, dimensions=None) -> bool:
         if tile.is_missing():
@@ -197,7 +205,7 @@ class S3Cache(TileCacheBase):
                     return False
                 if response.status != 200:
                     log.error('S3: load_tile HTTP error, url: %s, status: %s' % (url, response.status))
-                    raise Exception('S3 HTTP error %s for url: %s' % (response.status, url))
+                    raise S3ConnectionError('S3 HTTP error %s for url: %s' % (response.status, url))
                 tile.image_result = ImageResult(io.BytesIO(response.data))
             except urllib3.exceptions.HTTPError as e:
                 log.error('S3: load_tile request error, url: %s, error: %s' % (url, e))

--- a/mapproxy/cache/s3.py
+++ b/mapproxy/cache/s3.py
@@ -114,6 +114,13 @@ class S3Cache(TileCacheBase):
             # AWS S3: always HTTPS
             return f"https://{self.bucket_name}.s3.{self.region_name}.amazonaws.com/{key}"
 
+    def _presigned_url(self, client_method, key):
+        # Built locally by botocore (SigV4 signature over Bucket/Key) — no
+        # network round-trip — so unsigned HEAD/GET requests against a
+        # private bucket are authenticated the same as the boto3 write path.
+        return self.conn().generate_presigned_url(
+            client_method, Params={'Bucket': self.bucket_name, 'Key': key})
+
     def tile_key(self, tile):
         return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
 
@@ -160,18 +167,22 @@ class S3Cache(TileCacheBase):
     def is_cached(self, tile: Tile, dimensions=None) -> bool:
         if tile.is_missing():
             if self.use_http_get:
-                url = self.get_bucket_url(tile)
+                key = self.tile_key(tile)
+                url = self._presigned_url('head_object', key)
                 try:
                     response = _http.request('HEAD', url)
-                    if response.status in (403, 404):
-                        log.debug('S3: is_cached HTTP %s, url: %s' % (response.status, url))
+                    if response.status == 404:
+                        log.debug('S3: is_cached HTTP 404, key: %s' % key)
                         return False
+                    if response.status == 403:
+                        log.error('S3: is_cached HTTP 403 (access denied), key: %s' % key)
+                        raise S3ConnectionError('S3 HTTP 403 (access denied) for key: %s' % key)
                     if response.status != 200:
-                        log.error('S3: is_cached HTTP error, url: %s, status: %s' % (url, response.status))
-                        raise S3ConnectionError('S3 HTTP error %s for url: %s' % (response.status, url))
+                        log.error('S3: is_cached HTTP error, key: %s, status: %s' % (key, response.status))
+                        raise S3ConnectionError('S3 HTTP error %s for key: %s' % (response.status, key))
                     self._set_metadata(response.headers, tile)
                 except urllib3.exceptions.HTTPError as e:
-                    log.error('S3: is_cached request error, url: %s, error: %s' % (url, e))
+                    log.error('S3: is_cached request error, key: %s, error: %s' % (key, e))
                     raise
             else:
                 key = self.tile_key(tile)
@@ -197,18 +208,21 @@ class S3Cache(TileCacheBase):
         log.debug('S3:load_tile, key: %s' % key)
 
         if self.use_http_get:
-            url = self.get_bucket_url(tile)
+            url = self._presigned_url('get_object', key)
             try:
                 response = _http.request('GET', url)
-                if response.status in (403, 404):
-                    log.debug('S3: load_tile HTTP %s, url: %s' % (response.status, url))
+                if response.status == 404:
+                    log.debug('S3: load_tile HTTP 404, key: %s' % key)
                     return False
+                if response.status == 403:
+                    log.error('S3: load_tile HTTP 403 (access denied), key: %s' % key)
+                    raise S3ConnectionError('S3 HTTP 403 (access denied) for key: %s' % key)
                 if response.status != 200:
-                    log.error('S3: load_tile HTTP error, url: %s, status: %s' % (url, response.status))
-                    raise S3ConnectionError('S3 HTTP error %s for url: %s' % (response.status, url))
+                    log.error('S3: load_tile HTTP error, key: %s, status: %s' % (key, response.status))
+                    raise S3ConnectionError('S3 HTTP error %s for key: %s' % (response.status, key))
                 tile.image_result = ImageResult(io.BytesIO(response.data))
             except urllib3.exceptions.HTTPError as e:
-                log.error('S3: load_tile request error, url: %s, error: %s' % (url, e))
+                log.error('S3: load_tile request error, key: %s, error: %s' % (key, e))
                 raise
         else:
             try:

--- a/mapproxy/config/configuration/cache.py
+++ b/mapproxy/config/configuration/cache.py
@@ -243,6 +243,9 @@ class CacheConfiguration(ConfigurationBase):
                                                       global_key='cache.s3.use_http_get'
                                                       )
 
+        username = self.context.globals.get_value('cache.username', self.conf,
+                                                  global_key='cache.s3.username')
+
         include_grid_name = self.context.globals.get_value('cache.include_grid_name', self.conf,
                                                       global_key='cache.s3.include_grid_name')
 
@@ -266,7 +269,8 @@ class CacheConfiguration(ConfigurationBase):
             endpoint_url=endpoint_url,
             access_control_list=access_control_list,
             coverage=coverage,
-            use_http_get=use_http_get
+            use_http_get=use_http_get,
+            username=username
         )
 
     def _sqlite_cache(self, grid_conf, image_opts):

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -171,6 +171,7 @@ cache_types = {
         'tile_lock_dir': str(),
         'use_http_get': bool(),
         'include_grid_name': bool(),
+        'username': str(),
     }),
     'redis': combined(cache_commons, {
         'host': str(),
@@ -403,6 +404,7 @@ mapproxy_yaml_spec = {
                 'profile_name': str(),
                 'region_name': str(),
                 'endpoint_url': str(),
+                'username': str(),
             },
             'azureblob': {
                 'connection_string': str(),

--- a/mapproxy/config/spec.py
+++ b/mapproxy/config/spec.py
@@ -405,6 +405,9 @@ mapproxy_yaml_spec = {
                 'region_name': str(),
                 'endpoint_url': str(),
                 'username': str(),
+                'access_control_list': str(),
+                'use_http_get': bool(),
+                'include_grid_name': bool(),
             },
             'azureblob': {
                 'connection_string': str(),

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
+
 import pytest
 
+from mapproxy.cache.tile import Tile
 from mapproxy.extent import MapExtent
 from mapproxy.srs import SRS
 
@@ -91,3 +94,65 @@ class TestS3Cache(TileCacheTestBase):
 
         # raises, if key is missing
         boto3.client("s3").head_object(Bucket=self.bucket_name, Key=key)
+
+    def test_get_bucket_url_self_hosted(self):
+        tile = self.create_tile((0, 0, 1))
+        key = self.cache.tile_key(tile)
+
+        self.cache.endpoint_url = 'http://s3.example.com'
+        self.cache.username = 'myuser'
+        assert self.cache.get_bucket_url(tile) == \
+            'http://s3.example.com/myuser:%s/%s' % (self.bucket_name, key)
+
+        # without a username the segment is omitted
+        self.cache.username = None
+        assert self.cache.get_bucket_url(tile) == \
+            'http://s3.example.com/%s/%s' % (self.bucket_name, key)
+
+    def _http_get_cache(self):
+        # Construct without endpoint_url so __init__'s head_bucket hits the moto
+        # AWS mock; set the self-hosted endpoint afterwards for get_bucket_url.
+        # The HTTP-GET path itself is exercised with _http mocked (no network).
+        cache = S3Cache('mapproxy', file_ext='png', directory_layout='tms',
+                        bucket_name=self.bucket_name, use_http_get=True, _concurrent_writer=1)
+        cache.endpoint_url = 'http://s3.example.com'
+        return cache
+
+    def test_is_cached_http_get(self):
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        resp = mock.Mock(status=200,
+                         headers={'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT',
+                                  'Content-Length': '1234'})
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = resp
+            assert cache.is_cached(tile) is True
+            assert http.request.call_args[0][0] == 'HEAD'
+        # metadata parsed from the HTTP response headers
+        assert tile.size == 1234
+        assert tile.timestamp is not None
+
+    def test_is_cached_http_get_missing(self):
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = mock.Mock(status=404)
+            assert cache.is_cached(tile) is False
+
+    def test_load_tile_http_get(self):
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        resp = mock.Mock(status=200, data=b'\x89PNG\r\n\x1a\n')
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = resp
+            assert cache.load_tile(tile) is True
+            assert http.request.call_args[0][0] == 'GET'
+        assert tile.image_result is not None
+        assert not tile.is_missing()
+
+    def test_load_tile_http_get_missing(self):
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = mock.Mock(status=404)
+            assert cache.load_tile(tile) is False

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -28,7 +29,7 @@ except ImportError:
     boto3 = None
     mock_aws = None
 
-from mapproxy.cache.s3 import S3Cache
+from mapproxy.cache.s3 import S3Cache, S3ConnectionError
 from mapproxy.test.unit.test_cache_tile import TileCacheTestBase
 
 
@@ -156,3 +157,49 @@ class TestS3Cache(TileCacheTestBase):
         with mock.patch('mapproxy.cache.s3._http') as http:
             http.request.return_value = mock.Mock(status=404)
             assert cache.load_tile(tile) is False
+
+    @pytest.mark.parametrize('method,status', [('HEAD', 500), ('GET', 500)])
+    def test_http_get_error_status_raises(self, method, status):
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = mock.Mock(status=status, data=b'')
+            with pytest.raises(S3ConnectionError):
+                if method == 'HEAD':
+                    cache.is_cached(tile)
+                else:
+                    cache.load_tile(tile)
+
+    def test_set_metadata_boto3_and_http_agree(self):
+        # boto3 spells the keys LastModified/ContentLength with typed values,
+        # the HTTP path spells them Last-Modified/Content-Length as strings.
+        # Both must yield identical tile metadata.
+        boto_tile, http_tile = Tile((0, 0, 1)), Tile((0, 0, 1))
+        self.cache._set_metadata(
+            {'LastModified': datetime(2015, 10, 21, 7, 28, tzinfo=timezone.utc),
+             'ContentLength': 1234}, boto_tile)
+        self.cache._set_metadata(
+            {'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT',
+             'Content-Length': '1234'}, http_tile)
+
+        assert boto_tile.timestamp == http_tile.timestamp
+        assert boto_tile.size == http_tile.size == 1234
+
+    def test_set_metadata_honours_utc_offset(self):
+        # a non-UTC offset must be normalized, not dropped
+        offset_tile, utc_tile = Tile((0, 0, 1)), Tile((0, 0, 1))
+        self.cache._set_metadata({'Last-Modified': 'Wed, 21 Oct 2015 09:28:00 +0200'}, offset_tile)
+        self.cache._set_metadata({'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT'}, utc_tile)
+        assert offset_tile.timestamp == utc_tile.timestamp
+
+        aware_tile = Tile((0, 0, 1))
+        self.cache._set_metadata(
+            {'LastModified': datetime(2015, 10, 21, 9, 28,
+                                      tzinfo=timezone(timedelta(hours=2)))}, aware_tile)
+        assert aware_tile.timestamp == utc_tile.timestamp
+
+    def test_set_metadata_ignores_unparsable_values(self):
+        tile = Tile((0, 0, 1))
+        self.cache._set_metadata({'Last-Modified': 'not a date', 'Content-Length': 'huge'}, tile)
+        assert tile.timestamp is None
+        assert tile.size is None

--- a/mapproxy/test/unit/test_cache_s3.py
+++ b/mapproxy/test/unit/test_cache_s3.py
@@ -129,6 +129,10 @@ class TestS3Cache(TileCacheTestBase):
             http.request.return_value = resp
             assert cache.is_cached(tile) is True
             assert http.request.call_args[0][0] == 'HEAD'
+        # the request is signed: a presigned URL, not the bare bucket URL
+        requested_url = http.request.call_args[0][1]
+        assert requested_url != cache.get_bucket_url(tile)
+        assert 'Signature=' in requested_url
         # metadata parsed from the HTTP response headers
         assert tile.size == 1234
         assert tile.timestamp is not None
@@ -148,6 +152,10 @@ class TestS3Cache(TileCacheTestBase):
             http.request.return_value = resp
             assert cache.load_tile(tile) is True
             assert http.request.call_args[0][0] == 'GET'
+        # the request is signed: a presigned URL, not the bare bucket URL
+        requested_url = http.request.call_args[0][1]
+        assert requested_url != cache.get_bucket_url(tile)
+        assert 'Signature=' in requested_url
         assert tile.image_result is not None
         assert not tile.is_missing()
 
@@ -158,7 +166,11 @@ class TestS3Cache(TileCacheTestBase):
             http.request.return_value = mock.Mock(status=404)
             assert cache.load_tile(tile) is False
 
-    @pytest.mark.parametrize('method,status', [('HEAD', 500), ('GET', 500)])
+    @pytest.mark.parametrize('method,status', [
+        ('HEAD', 500), ('GET', 500),
+        # a genuine 403 on a signed request is a real error, not a cache miss
+        ('HEAD', 403), ('GET', 403),
+    ])
     def test_http_get_error_status_raises(self, method, status):
         cache = self._http_get_cache()
         tile = Tile((0, 0, 1))
@@ -169,6 +181,45 @@ class TestS3Cache(TileCacheTestBase):
                     cache.is_cached(tile)
                 else:
                     cache.load_tile(tile)
+
+    @pytest.mark.parametrize('method', ['HEAD', 'GET'])
+    def test_http_get_404_is_cache_miss_not_error(self, method):
+        # 404 must remain a normal cache miss, unlike 403, even though both
+        # were previously grouped together
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = mock.Mock(status=404, data=b'')
+            if method == 'HEAD':
+                assert cache.is_cached(tile) is False
+            else:
+                assert cache.load_tile(tile) is False
+
+    def test_http_get_uses_presigned_url_not_bucket_url(self):
+        # Bucket/Key addressing must match the boto3 write path — the
+        # {endpoint}/{username}:{bucket}/{key} convention is retired here.
+        cache = self._http_get_cache()
+        cache.username = 'myuser'
+        tile = Tile((0, 0, 1))
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = mock.Mock(status=404, data=b'')
+            cache.is_cached(tile)
+        requested_url = http.request.call_args[0][1]
+        assert 'myuser:' not in requested_url
+        assert cache.bucket_name in requested_url
+
+    def test_http_get_logs_key_not_url(self, caplog):
+        # debug logs must not print the full request URL, which would carry
+        # the presigned signature
+        cache = self._http_get_cache()
+        tile = Tile((0, 0, 1))
+        key = cache.tile_key(tile)
+        with mock.patch('mapproxy.cache.s3._http') as http:
+            http.request.return_value = mock.Mock(status=404, data=b'')
+            with caplog.at_level('DEBUG', logger='mapproxy.cache.s3'):
+                cache.is_cached(tile)
+        assert any(key in record.getMessage() and 'Signature=' not in record.getMessage()
+                   for record in caplog.records)
 
     def test_set_metadata_boto3_and_http_agree(self):
         # boto3 spells the keys LastModified/ContentLength with typed values,


### PR DESCRIPTION
## Summary

Depends on / stacked on top of #1424 (still open) — this PR's branch is built directly on top of that branch, so the diff shown here includes #1424's commits until it merges. This is intentionally a separate, discrete follow-up rather than an expansion of #1424's scope; please review the top commit (`sign use_http_get reads...`) on its own once #1424 lands, or review both together if that's easier — happy to rebase once #1424 merges.

`S3Cache.is_cached`/`load_tile` issued completely unauthenticated `urllib3` HEAD/GET requests when `use_http_get` is enabled — no boto3, no SigV4 signing. A private bucket returns `403` to any unsigned request, and the code treated `403` identically to `404` ("not cached"). Writes remain authenticated via boto3 and always succeed, so tiles get written to a private bucket but could never be read back through this path — a deployment using an S3-compatible cache (e.g. MinIO) with `use_http_get: true` against a private bucket effectively never serves tiles from cache.

## Changes

- `is_cached`/`load_tile` now sign their HEAD/GET requests using a boto3-generated presigned URL, built locally from the same session already used for writes (no extra network round-trip).
- Bucket addressing uses `Bucket=self.bucket_name`, matching the write path — the `{endpoint}/{username}:{bucket}/{key}` URL convention is retired from this path (`get_bucket_url` is unchanged and still used/tested independently).
- A genuine `403` on a signed request now raises `S3ConnectionError` instead of being treated as a cache miss; `404` remains a normal cache miss, unchanged.
- Debug logs print the object key instead of the full request URL, which would otherwise carry the presigned signature.

## Test plan

- Extended `test_cache_s3.py`: `test_is_cached_http_get`, `test_load_tile_http_get`, and `test_http_get_error_status_raises` now assert requests go out signed (not the bare bucket URL) and that `403` raises while `404` still misses; added `test_http_get_404_is_cache_miss_not_error`, `test_http_get_uses_presigned_url_not_bucket_url`, and `test_http_get_logs_key_not_url`.
- Full unit suite passes (1168 passed).
- Verified end-to-end against a real MinIO instance: a tile written to a private bucket is served from cache (unchanged ETag/timestamp) on a subsequent request; a credential with `GetObject` denied on the bucket surfaces `S3ConnectionError` with a clear traceback rather than a silent, permanent cache miss; existing public-bucket + `use_http_get` behavior is unchanged.